### PR TITLE
Add Hot-or-Not Backend Release Monitor and DID File Management Workflow

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -53,21 +53,37 @@ runs:
         ESCAPED_BODY=$(echo "$RELEASE_BODY" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g' | head -c 500)
         echo "release_body=$ESCAPED_BODY" >> $GITHUB_OUTPUT
         
-        # Check if we've seen this release before
-        if [ -f "last_release.txt" ]; then
-          LAST_NOTIFIED=$(cat last_release.txt)
-          echo "Last notified release: $LAST_NOTIFIED"
+        # Check version file in codebase
+        VERSION_FILE="shared/rust/rust-agent-uniffi/did/VERSION"
+        if [ -f "$VERSION_FILE" ]; then
+          VERSION_FILE_TAG=$(cat "$VERSION_FILE")
+          echo "Last notified release from version file: $VERSION_FILE_TAG"
         else
-          LAST_NOTIFIED="v3.5.4"  # Initialize with current latest
-          echo "No previous notifications found, initializing with v3.5.4"
+          echo "No version file found"
+          # Create version file directory
+          mkdir -p "$(dirname "$VERSION_FILE")"
         fi
         
-        if [ "$RELEASE_TAG" != "$LAST_NOTIFIED" ] && [ "$RELEASE_TAG" != "null" ]; then
+        # Check cache for last processed version
+        CACHE_KEY="last-processed-release"
+        CACHE_PATH=".github/cache"
+        mkdir -p "$CACHE_PATH"
+        
+        if [ -f "$CACHE_PATH/$CACHE_KEY" ]; then
+          CACHE_TAG=$(cat "$CACHE_PATH/$CACHE_KEY")
+          echo "Last processed release from cache: $CACHE_TAG"
+        else
+          echo "No cache found"
+        fi
+        
+        # Determine if this is a new release by checking both version file and cache
+        if [ "$RELEASE_TAG" != "$VERSION_FILE_TAG" ] && [ "$RELEASE_TAG" != "$CACHE_TAG" ] && [ "$RELEASE_TAG" != "null" ]; then
           echo "New release detected!"
           echo "new_release=true" >> $GITHUB_OUTPUT
           
-          # Update the last notified release
-          echo "$RELEASE_TAG" > last_release.txt
+          # Update both version file and cache
+          echo "$RELEASE_TAG" > "$VERSION_FILE"
+          echo "$RELEASE_TAG" > "$CACHE_PATH/$CACHE_KEY"
         else
           echo "No new release"
           echo "new_release=false" >> $GITHUB_OUTPUT

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -1,0 +1,74 @@
+name: 'Check Hot-or-Not Backend Release'
+description: 'Checks for new releases of the Hot-or-Not Backend'
+
+outputs:
+  new_release:
+    description: 'Whether a new release was found'
+    value: ${{ steps.check_release.outputs.new_release }}
+  release_tag:
+    description: 'The tag of the latest release'
+    value: ${{ steps.check_release.outputs.release_tag }}
+  release_name:
+    description: 'The name of the latest release'
+    value: ${{ steps.check_release.outputs.release_name }}
+  release_url:
+    description: 'The URL of the latest release'
+    value: ${{ steps.check_release.outputs.release_url }}
+  release_body:
+    description: 'The body/description of the latest release'
+    value: ${{ steps.check_release.outputs.release_body }}
+  published_at:
+    description: 'When the release was published'
+    value: ${{ steps.check_release.outputs.published_at }}
+  author:
+    description: 'The author of the release'
+    value: ${{ steps.check_release.outputs.author }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Check for new releases
+      id: check_release
+      shell: bash
+      run: |
+        # Get the latest release from the target repository
+        LATEST_RELEASE=$(curl -s "https://api.github.com/repos/dolr-ai/hot-or-not-backend-canister/releases/latest")
+        
+        # Extract release information
+        RELEASE_TAG=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
+        RELEASE_NAME=$(echo "$LATEST_RELEASE" | jq -r '.name')
+        RELEASE_URL=$(echo "$LATEST_RELEASE" | jq -r '.html_url')
+        RELEASE_BODY=$(echo "$LATEST_RELEASE" | jq -r '.body')
+        PUBLISHED_AT=$(echo "$LATEST_RELEASE" | jq -r '.published_at')
+        AUTHOR=$(echo "$LATEST_RELEASE" | jq -r '.author.login')
+        
+        echo "Latest release tag: $RELEASE_TAG"
+        echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
+        echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+        echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
+        echo "published_at=$PUBLISHED_AT" >> $GITHUB_OUTPUT
+        echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+        
+        # Escape newlines and quotes in release body for JSON
+        ESCAPED_BODY=$(echo "$RELEASE_BODY" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g' | head -c 500)
+        echo "release_body=$ESCAPED_BODY" >> $GITHUB_OUTPUT
+        
+        # Check if we've seen this release before
+        if [ -f "last_release.txt" ]; then
+          LAST_NOTIFIED=$(cat last_release.txt)
+          echo "Last notified release: $LAST_NOTIFIED"
+        else
+          LAST_NOTIFIED="v3.5.4"  # Initialize with current latest
+          echo "No previous notifications found, initializing with v3.5.4"
+        fi
+        
+        if [ "$RELEASE_TAG" != "$LAST_NOTIFIED" ] && [ "$RELEASE_TAG" != "null" ]; then
+          echo "New release detected!"
+          echo "new_release=true" >> $GITHUB_OUTPUT
+          
+          # Update the last notified release
+          echo "$RELEASE_TAG" > last_release.txt
+        else
+          echo "No new release"
+          echo "new_release=false" >> $GITHUB_OUTPUT
+        fi 

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -71,7 +71,7 @@ runs:
 
           ## Changes Summary
           The following .did files were affected:
-          ${{ inputs.changed_files }}
+          ${{ fromJSON(inputs.changed_files) }}
 
           ## Breaking Changes Status
           ${{ inputs.breaking_changes == 'true' && '⚠️ **Warning:** This update contains breaking changes!' || '✅ No breaking changes detected' }}

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -1,0 +1,80 @@
+name: 'Create Pull Request'
+description: 'Creates a pull request for DID file changes'
+
+inputs:
+  release_tag:
+    description: 'The tag of the release'
+    required: true
+  release_name:
+    description: 'The name of the release'
+    required: true
+  release_url:
+    description: 'The URL of the release'
+    required: true
+  published_at:
+    description: 'When the release was published'
+    required: true
+  author:
+    description: 'The author of the release'
+    required: true
+  release_body:
+    description: 'The body/description of the release'
+    required: true
+  changed_files:
+    description: 'List of changed files'
+    required: true
+  breaking_changes:
+    description: 'Whether there are breaking changes'
+    required: true
+
+outputs:
+  pr_url:
+    description: 'The URL of the created pull request'
+    value: ${{ steps.cpr.outputs.pull-request-url }}
+  pr_status:
+    description: 'The status of the pull request creation'
+    value: ${{ steps.cpr.outcome }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Process Release Notes
+      id: process_notes
+      shell: bash
+      run: |
+        # Convert release notes to proper markdown and clean up formatting
+        NOTES=$(echo '${{ inputs.release_body }}' | sed 's/\\n/\n/g' | sed 's/^## /### /g')
+        echo "PROCESSED_NOTES<<EOF" >> $GITHUB_ENV
+        echo "$NOTES" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7
+      id: cpr
+      continue-on-error: true
+      with:
+        commit-message: "Update .did files from release ${{ inputs.release_tag }}"
+        title: "Update .did files from release ${{ inputs.release_tag }}"
+        add-paths: |
+          *.did
+        body: |
+          This PR updates the .did files from the latest release.
+
+          ## Release Details
+          - **Release:** ${{ inputs.release_name }}
+          - **Tag:** ${{ inputs.release_tag }}
+          - **Published:** ${{ inputs.published_at }}
+          - **Author:** ${{ inputs.author }}
+
+          ## Release Notes
+          ${{ env.PROCESSED_NOTES }}
+
+          ## Changes Summary
+          The following .did files were affected:
+          ${{ inputs.changed_files }}
+
+          ## Breaking Changes Status
+          ${{ inputs.breaking_changes == 'true' && '⚠️ **Warning:** This update contains breaking changes!' || '✅ No breaking changes detected' }}
+
+          ---
+          [View Original Release](${{ inputs.release_url }}) 

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -55,8 +55,7 @@ runs:
       with:
         commit-message: "Update .did files from release ${{ inputs.release_tag }}"
         title: "${{ inputs.breaking_changes == 'true' && '🚨 BREAKING CHANGES: ' || '' }}Update .did files from release ${{ inputs.release_tag }}"
-        add-paths: |
-          *.did
+        path: shared/rust/rust-agent-uniffi/did/
         body: |
           ${{ inputs.breaking_changes == 'true' && '# ⚠️ WARNING: This PR Contains Breaking Changes ⚠️
 

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -55,7 +55,7 @@ runs:
       with:
         commit-message: "Update .did files from release ${{ inputs.release_tag }}"
         title: "${{ inputs.breaking_changes == 'true' && '🚨 BREAKING CHANGES: ' || '' }}Update .did files from release ${{ inputs.release_tag }}"
-        path: shared/rust/rust-agent-uniffi/did/
+        add-paths: shared/rust/rust-agent-uniffi/did/
         body: |
           ${{ inputs.breaking_changes == 'true' && '# ⚠️ WARNING: This PR Contains Breaking Changes ⚠️
 

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -77,4 +77,5 @@ runs:
           ${{ inputs.breaking_changes == 'true' && '⚠️ **Warning:** This update contains breaking changes!' || '✅ No breaking changes detected' }}
 
           ---
-          [View Original Release](${{ inputs.release_url }}) 
+          [View Original Release](${{ inputs.release_url }})
+        branch: create-pull-request/update-did-files-${{ inputs.release_tag }}

--- a/.github/actions/create-pr/action.yml
+++ b/.github/actions/create-pr/action.yml
@@ -54,11 +54,22 @@ runs:
       continue-on-error: true
       with:
         commit-message: "Update .did files from release ${{ inputs.release_tag }}"
-        title: "Update .did files from release ${{ inputs.release_tag }}"
+        title: "${{ inputs.breaking_changes == 'true' && '🚨 BREAKING CHANGES: ' || '' }}Update .did files from release ${{ inputs.release_tag }}"
         add-paths: |
           *.did
         body: |
-          This PR updates the .did files from the latest release.
+          ${{ inputs.breaking_changes == 'true' && '# ⚠️ WARNING: This PR Contains Breaking Changes ⚠️
+
+          > **IMPORTANT**: This PR includes breaking changes to DID interfaces that will affect generated Rust bindings.
+          > Please review carefully as this will impact the mobile app''s interaction with the backend.
+          > 
+          > - The generated Rust bindings will have incompatible changes
+          > - Mobile app code using these bindings will need updates
+          > - Careful testing is required to ensure compatibility
+          
+          ---
+          ' || '' }}
+          This PR updates the .did files from the latest release. These files will be used to generate Rust bindings for mobile app integration.
 
           ## Release Details
           - **Release:** ${{ inputs.release_name }}
@@ -74,8 +85,22 @@ runs:
           ${{ fromJSON(inputs.changed_files) }}
 
           ## Breaking Changes Status
-          ${{ inputs.breaking_changes == 'true' && '⚠️ **Warning:** This update contains breaking changes!' || '✅ No breaking changes detected' }}
+          ${{ inputs.breaking_changes == 'true' && '🚨 **Warning:** This update contains breaking changes that will affect generated Rust bindings!' || '✅ No breaking changes detected' }}
+
+          ## Checklist
+          ${{ inputs.breaking_changes == 'true' && '### Breaking Changes Checklist
+          - [ ] Review all interface changes in detail
+          - [ ] Generate and verify new Rust bindings
+          - [ ] Identify all affected mobile app components
+          - [ ] Update mobile app code to handle interface changes
+          - [ ] Add/update tests for new interfaces
+          - [ ] Test mobile app integration thoroughly
+          - [ ] Consider adding migration notes to documentation
+          ' || '- [ ] Review interface changes
+          - [ ] Generate new Rust bindings
+          - [ ] Test mobile app integration' }}
 
           ---
           [View Original Release](${{ inputs.release_url }})
         branch: create-pull-request/update-did-files-${{ inputs.release_tag }}
+        draft: ${{ inputs.breaking_changes == 'true' }}

--- a/.github/actions/handle-did-files/action.yml
+++ b/.github/actions/handle-did-files/action.yml
@@ -1,0 +1,119 @@
+name: 'Handle DID Files'
+description: 'Downloads and compares DID files from the latest release'
+
+inputs:
+  release_tag:
+    description: 'The tag of the release to check'
+    required: true
+
+outputs:
+  has_changes:
+    description: 'Whether there are changes in DID files'
+    value: ${{ steps.compare_did.outputs.has_changes }}
+  has_breaking_changes:
+    description: 'Whether there are breaking changes'
+    value: ${{ steps.compare_did.outputs.has_breaking_changes }}
+  changed_files:
+    description: 'List of changed files'
+    value: ${{ steps.compare_did.outputs.changed_files }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install didc tool
+      shell: bash
+      run: |
+        # Download didc
+        curl -L -o didc https://github.com/dfinity/candid/releases/download/2024-07-29/didc-linux64
+        
+        # Make it executable
+        chmod +x didc
+        
+        # Move to a directory in PATH and verify installation
+        sudo mv didc /usr/local/bin/
+        export PATH="/usr/local/bin:$PATH"
+        
+        # Verify installation
+        which didc
+        didc --version
+        
+        # Ensure the directory exists and is writable
+        sudo mkdir -p /usr/local/bin
+        sudo chmod 755 /usr/local/bin
+
+    - name: Download and compare .did files
+      id: compare_did
+      shell: bash
+      run: |
+        # Create temporary directory for new release files
+        mkdir -p temp_release
+        
+        # Create did directory if it doesn't exist
+        mkdir -p shared/rust/rust-agent-uniffi/did
+        
+        # Download release assets
+        RELEASE_ASSETS=$(curl -s "https://api.github.com/repos/dolr-ai/hot-or-not-backend-canister/releases/latest" | jq -r '.assets[].browser_download_url')
+        
+        # Download .did files to temp directory
+        for asset_url in $RELEASE_ASSETS; do
+          if [[ $asset_url == *.did ]]; then
+            echo "Downloading $(basename $asset_url)..."
+            curl -L -o "temp_release/$(basename $asset_url)" "$asset_url"
+          fi
+        done
+        
+        # Compare and update files
+        HAS_CHANGES=false
+        HAS_BREAKING_CHANGES=false
+        CHANGED_FILES=""
+        for did_file in temp_release/*.did; do
+          if [ -f "$did_file" ]; then
+            local_file="shared/rust/rust-agent-uniffi/did/$(basename $did_file)"
+            if [ -f "$local_file" ]; then
+              echo "Comparing $(basename $did_file)..."
+              # Run didc check and capture both output and exit code
+              set +e  # Disable exit on error
+              DIFF_OUTPUT=$(didc check "$did_file" "$local_file" 2>&1)
+              DIFF_EXIT_CODE=$?
+              set -e  # Re-enable exit on error
+              
+              if [ $DIFF_EXIT_CODE -ne 0 ]; then
+                echo "❌ Breaking changes detected in $(basename $did_file):"
+                echo "$DIFF_OUTPUT"
+                echo "breaking_changes=true" >> $GITHUB_OUTPUT
+                HAS_BREAKING_CHANGES=true
+                CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (breaking changes)"
+              else
+                echo "✅ No breaking changes in $(basename $did_file)"
+                # Check if files are different despite being compatible
+                if ! cmp -s "$local_file" "$did_file"; then
+                  echo "ℹ️ Non-breaking updates found in $(basename $did_file)"
+                  echo "differences=true" >> $GITHUB_OUTPUT
+                  echo "Updating $(basename $did_file)..."
+                  cp "$did_file" "$local_file"
+                  HAS_CHANGES=true
+                  CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (updated)"
+                else
+                  echo "✅ Files are identical"
+                fi
+              fi
+            else
+              echo "⚠️ New .did file found: $(basename $did_file)"
+              echo "new_files=true" >> $GITHUB_OUTPUT
+              echo "Adding new file $(basename $did_file)..."
+              cp "$did_file" "$local_file"
+              HAS_CHANGES=true
+              CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (new)"
+            fi
+          fi
+        done
+        
+        # Cleanup
+        rm -rf temp_release
+        
+        # Set outputs
+        echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
+        echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
+        # Format changed files for JSON
+        CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | sed '1d' | jq -Rs .)
+        echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT 

--- a/.github/actions/handle-did-files/action.yml
+++ b/.github/actions/handle-did-files/action.yml
@@ -16,6 +16,12 @@ outputs:
   changed_files:
     description: 'List of changed files'
     value: ${{ steps.compare_did.outputs.changed_files }}
+  differences:
+    description: 'Whether there are non-breaking changes'
+    value: ${{ steps.compare_did.outputs.differences }}
+  new_files:
+    description: 'Whether there are new files'
+    value: ${{ steps.compare_did.outputs.new_files }}
 
 runs:
   using: "composite"
@@ -83,6 +89,10 @@ runs:
                 echo "breaking_changes=true" >> $GITHUB_OUTPUT
                 HAS_BREAKING_CHANGES=true
                 CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (breaking changes)"
+                # Copy the file even though it has breaking changes
+                echo "Updating $(basename $did_file) despite breaking changes..."
+                cp "$did_file" "$local_file"
+                HAS_CHANGES=true
               else
                 echo "✅ No breaking changes in $(basename $did_file)"
                 # Check if files are different despite being compatible

--- a/.github/actions/notify-did-changes/action.yml
+++ b/.github/actions/notify-did-changes/action.yml
@@ -14,6 +14,12 @@ inputs:
   breaking_changes:
     description: 'Whether there are breaking changes'
     required: true
+  differences:
+    description: 'Whether there are non-breaking changes'
+    required: true
+  new_files:
+    description: 'Whether there are new files'
+    required: true
   pr_url:
     description: 'Pull request URL'
     required: true
@@ -30,8 +36,12 @@ runs:
     - name: Send DID changes notification
       shell: bash
       run: |
-        # Prepare PR status widgets based on inputs
-        if [ "${{ inputs.pr_status }}" = "success" ]; then
+        # Check if PR was created successfully
+        PR_STATUS="${{ inputs.pr_status }}"
+        PR_URL="${{ inputs.pr_url }}"
+        
+        # Prepare PR status widgets
+        if [ "$PR_STATUS" = "success" ]; then
           PR_WIDGETS='[
             {
               "decoratedText": {
@@ -45,7 +55,7 @@ runs:
                     "text": "View Pull Request",
                     "onClick": {
                       "openLink": {
-                        "url": "${{ inputs.pr_url }}"
+                        "url": "'"$PR_URL"'"
                       }
                     }
                   }
@@ -82,6 +92,16 @@ runs:
                         "decoratedText": {
                           "text": "${{ inputs.breaking_changes == 'true' && '🚨 Breaking changes detected in .did files' || '✅ No breaking changes detected' }}"
                         }
+                      },
+                      {
+                        "decoratedText": {
+                          "text": "${{ inputs.differences == 'true' && 'ℹ️ Non-breaking updates found in .did files' || '✅ No non breaking changes detected' }}"
+                        }
+                      },
+                      {
+                        "decoratedText": {
+                          "text": "${{ inputs.new_files == 'true' && 'ℹ️ New .did files found in release' || '✅ No new files' }}"
+                        }
                       }
                     ]
                   },
@@ -90,7 +110,7 @@ runs:
                     "widgets": [
                       {
                         "textParagraph": {
-                          "text": "${{ inputs.changed_files }}"
+                          "text": "${{ fromJSON(inputs.changed_files) }}"
                         }
                       }
                     ]

--- a/.github/actions/notify-did-changes/action.yml
+++ b/.github/actions/notify-did-changes/action.yml
@@ -1,0 +1,115 @@
+name: 'Send DID Changes Notification'
+description: 'Sends a notification to Google Chat about DID file changes'
+
+inputs:
+  webhook_url:
+    description: 'Google Chat webhook URL'
+    required: true
+  release_tag:
+    description: 'Release tag'
+    required: true
+  changed_files:
+    description: 'List of changed files'
+    required: true
+  breaking_changes:
+    description: 'Whether there are breaking changes'
+    required: true
+  pr_url:
+    description: 'Pull request URL'
+    required: true
+  pr_status:
+    description: 'Pull request creation status'
+    required: true
+  workflow_url:
+    description: 'Workflow run URL'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Send DID changes notification
+      shell: bash
+      run: |
+        # Prepare PR status widgets based on inputs
+        if [ "${{ inputs.pr_status }}" = "success" ]; then
+          PR_WIDGETS='[
+            {
+              "decoratedText": {
+                "text": "✅ Pull Request created successfully"
+              }
+            },
+            {
+              "buttonList": {
+                "buttons": [
+                  {
+                    "text": "View Pull Request",
+                    "onClick": {
+                      "openLink": {
+                        "url": "${{ inputs.pr_url }}"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]'
+        else
+          PR_WIDGETS='[
+            {
+              "decoratedText": {
+                "text": "❌ Failed to create Pull Request"
+              }
+            }
+          ]'
+        fi
+        
+        curl -X POST "${{ inputs.webhook_url }}" \
+        -H "Content-Type: application/json" \
+        -d '{
+          "cardsV2": [
+            {
+              "cardId": "did-changes",
+              "card": {
+                "header": {
+                  "title": "DID File Changes Detected",
+                  "subtitle": "Changes from release ${{ inputs.release_tag }}"
+                },
+                "sections": [
+                  {
+                    "header": "Findings",
+                    "widgets": [
+                      {
+                        "decoratedText": {
+                          "text": "${{ inputs.breaking_changes == 'true' && '🚨 Breaking changes detected in .did files' || '✅ No breaking changes detected' }}"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "header": "Changed Files",
+                    "widgets": [
+                      {
+                        "textParagraph": {
+                          "text": "${{ inputs.changed_files }}"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "header": "Pull Request Status",
+                    "widgets": '"$PR_WIDGETS"'
+                  },
+                  {
+                    "widgets": [
+                      {
+                        "textParagraph": {
+                          "text": "<i><a href=\"${{ inputs.workflow_url }}\">View workflow run</a></i>"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }' 

--- a/.github/actions/notify-release/action.yml
+++ b/.github/actions/notify-release/action.yml
@@ -1,0 +1,114 @@
+name: 'Send Release Notification'
+description: 'Sends a notification to Google Chat about new releases'
+
+inputs:
+  webhook_url:
+    description: 'Google Chat webhook URL'
+    required: true
+  release_tag:
+    description: 'Release tag'
+    required: true
+  release_name:
+    description: 'Release name'
+    required: true
+  release_url:
+    description: 'Release URL'
+    required: true
+  release_body:
+    description: 'Release body'
+    required: true
+  published_at:
+    description: 'Published at'
+    required: true
+  author:
+    description: 'Author'
+    required: true
+  workflow_url:
+    description: 'Workflow run URL'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Send release notification
+      shell: bash
+      run: |
+        # Process and escape release notes for JSON
+        RELEASE_NOTES=$(echo "${{ inputs.release_body }}" | .github/helperscripts/cleanup_release_notes_for_google_chat.sh | jq -Rs .)
+        
+        curl -X POST "${{ inputs.webhook_url }}" \
+        -H "Content-Type: application/json" \
+        -d '{
+          "cardsV2": [
+            {
+              "cardId": "release-alert",
+              "card": {
+                "header": {
+                  "title": "New Release Alert!",
+                  "subtitle": "Hot-or-Not Backend Canister",
+                  "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4"
+                },
+                "sections": [
+                  {
+                    "widgets": [
+                      {
+                        "decoratedText": {
+                          "startIcon": { "knownIcon": "DESCRIPTION" },
+                          "topLabel": "Release",
+                          "text": "${{ inputs.release_name }} ( ${{ inputs.release_tag }} )"
+                        }
+                      },
+                      {
+                        "decoratedText": {
+                          "startIcon": { "knownIcon": "PERSON" },
+                          "topLabel": "Author",
+                          "text": "${{ inputs.author }}"
+                        }
+                      },
+                      {
+                        "decoratedText": {
+                          "startIcon": { "knownIcon": "INVITE" },
+                          "topLabel": "Published",
+                          "text": "${{ inputs.published_at }}"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "header": "Release Notes",
+                    "widgets": [
+                      { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
+                    ]
+                  },
+                  {
+                    "widgets": [
+                      {
+                        "buttonList": {
+                          "buttons": [
+                            {
+                              "text": "View Release",
+                              "onClick": {
+                                "openLink": {
+                                  "url": "${{ inputs.release_url }}"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "widgets": [
+                      {
+                        "textParagraph": {
+                          "text": "<i><a href=\"${{ inputs.workflow_url }}\">View workflow run</a></i>"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }' 

--- a/.github/helperscripts/cleanup_release_notes_for_google_chat.sh
+++ b/.github/helperscripts/cleanup_release_notes_for_google_chat.sh
@@ -3,23 +3,19 @@
 # Function to process release notes
 process_release_notes() {
     local input="$1"
-    
+
     # Process the input text
-    # First convert literal \n to actual newlines, then process
+    # First convert literal \n to actual newlines for processing
     echo -e "$input" | sed -E '
-        # Convert ## Headers to *Bold*
-        s/^## (.*)$/\*\1\*/g
+        # Convert ## Headers to <b>Bold</b>
+        s/^## (.*)$/<b>\1<\/b>/g
 
-        # Remove complete URLs from markdown links: [text](url) -> [text]
-        s/\]\([^)]*\)/]/g
+        # Convert markdown links [text](url) to <a href="url">text</a>
+        s/\[([^]]*)\]\(([^)]*)\)/<a href="\2">\1<\/a>/g
 
-        # Handle truncated cases at the end of input
-        # Case 1: ends with incomplete URL like ](https://github.com/dolr-ai/h
-        s/\]\([^)]*$/]/g
-
-        # Case 2: ends with ([Name](incomplete_url -> ([Name]
-        s/\(\[([^]]*)\]\([^)]*$/(\[\1]/g
-    '
+        # Handle truncated links at the end - remove incomplete ones
+        s/\[([^]]*)\]\([^)]*$/<a href="">\1<\/a>/g
+    ' | sed ':a;N;$!ba;s/\n/<br>/g'
 }
 
 # Main script logic

--- a/.github/helperscripts/cleanup_release_notes_for_google_chat.sh
+++ b/.github/helperscripts/cleanup_release_notes_for_google_chat.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Function to process release notes
+process_release_notes() {
+    local input="$1"
+    
+    # Process the input text
+    # First convert literal \n to actual newlines, then process
+    echo -e "$input" | sed -E '
+        # Convert ## Headers to *Bold*
+        s/^## (.*)$/\*\1\*/g
+
+        # Remove complete URLs from markdown links: [text](url) -> [text]
+        s/\]\([^)]*\)/]/g
+
+        # Handle truncated cases at the end of input
+        # Case 1: ends with incomplete URL like ](https://github.com/dolr-ai/h
+        s/\]\([^)]*$/]/g
+
+        # Case 2: ends with ([Name](incomplete_url -> ([Name]
+        s/\(\[([^]]*)\]\([^)]*$/(\[\1]/g
+    '
+}
+
+# Main script logic
+if [ $# -eq 0 ]; then
+    # Read from stdin if no arguments
+    input=$(cat)
+    process_release_notes "$input"
+elif [ $# -eq 1 ]; then
+    # Process single argument as input string
+    process_release_notes "$1"
+else
+    echo "Usage: $0 [input_string]"
+    echo "       echo 'input' | $0"
+    echo ""
+    echo "If no input_string is provided, reads from stdin"
+    exit 1
+fi

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -3,7 +3,7 @@ name: Hot-or-Not Backend Release Monitor
 on:
   push:
   schedule:
-    # Check for new releases every 30 minutes (more frequent)
+    # Check for new releases every 30 minutes
     - cron: '*/30 * * * *'
   workflow_dispatch: # Allow manual triggering
 
@@ -11,7 +11,7 @@ jobs:
   check-releases:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'write'  # Changed to write to allow committing changes
+      contents: 'write'
       id-token: 'write'
       pull-requests: 'write'
 
@@ -19,410 +19,55 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-#      - name: Restore last notified release from cache
-#        id: cache-release
-#        uses: actions/cache/restore@v4
-#        with:
-#          path: last_release.txt
-#          key: last-notified-release
-
       - name: Check for new releases
         id: check_release
-        run: |
-          # Get the latest release from the target repository
-          LATEST_RELEASE=$(curl -s "https://api.github.com/repos/dolr-ai/hot-or-not-backend-canister/releases/latest")
-          
-          # Extract release information
-          RELEASE_TAG=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
-          RELEASE_NAME=$(echo "$LATEST_RELEASE" | jq -r '.name')
-          RELEASE_URL=$(echo "$LATEST_RELEASE" | jq -r '.html_url')
-          RELEASE_BODY=$(echo "$LATEST_RELEASE" | jq -r '.body')
-          PUBLISHED_AT=$(echo "$LATEST_RELEASE" | jq -r '.published_at')
-          AUTHOR=$(echo "$LATEST_RELEASE" | jq -r '.author.login')
-          
-          echo "Latest release tag: $RELEASE_TAG"
-          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
-          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
-          echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
-          echo "published_at=$PUBLISHED_AT" >> $GITHUB_OUTPUT
-          echo "author=$AUTHOR" >> $GITHUB_OUTPUT
-          
-          # Escape newlines and quotes in release body for JSON
-          ESCAPED_BODY=$(echo "$RELEASE_BODY" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g' | head -c 500)
-          echo "release_body=$ESCAPED_BODY" >> $GITHUB_OUTPUT
-          
-          # Check if we've seen this release before
-          if [ -f "last_release.txt" ]; then
-            LAST_NOTIFIED=$(cat last_release.txt)
-            echo "Last notified release: $LAST_NOTIFIED"
-          else
-            LAST_NOTIFIED="v3.5.4"  # Initialize with current latest
-            echo "No previous notifications found, initializing with v3.5.4"
-          fi
-          
-          if [ "$RELEASE_TAG" != "$LAST_NOTIFIED" ] && [ "$RELEASE_TAG" != "null" ]; then
-            echo "New release detected!"
-            echo "new_release=true" >> $GITHUB_OUTPUT
-            
-            # Update the last notified release
-            echo "$RELEASE_TAG" > last_release.txt
-          else
-            echo "No new release"
-            echo "new_release=false" >> $GITHUB_OUTPUT
-          fi
+        uses: ./.github/actions/check-release
 
-      - name: Send release notification to Google Chat
+      - name: Send release notification
         if: steps.check_release.outputs.new_release == 'true'
-        run: |
-          # Process and escape release notes for JSON
-          RELEASE_NOTES=$(echo "${{ steps.check_release.outputs.release_body }}" | .github/helperscripts/cleanup_release_notes_for_google_chat.sh | jq -Rs .)
-          
-          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
-          -H "Content-Type: application/json" \
-          -d '{
-            "cardsV2": [
-              {
-                "cardId": "release-alert",
-                "card": {
-                  "header": {
-                    "title": "New Release Alert!",
-                    "subtitle": "Hot-or-Not Backend Canister",
-                    "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4"
-                  },
-                  "sections": [
-                    {
-                      "widgets": [
-                        {
-                          "decoratedText": {
-                            "startIcon": { "knownIcon": "DESCRIPTION" },
-                            "topLabel": "Release",
-                            "text": "${{ steps.check_release.outputs.release_name }} ( ${{ steps.check_release.outputs.release_tag }} )"
-                          }
-                        },
-                        {
-                          "decoratedText": {
-                            "startIcon": { "knownIcon": "PERSON" },
-                            "topLabel": "Author",
-                            "text": "${{ steps.check_release.outputs.author }}"
-                          }
-                        },
-                        {
-                          "decoratedText": {
-                            "startIcon": { "knownIcon": "INVITE" },
-                            "topLabel": "Published",
-                            "text": "${{ steps.check_release.outputs.published_at }}"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "header": "Release Notes",
-                      "widgets": [
-                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
-                      ]
-                    },
-                    {
-                      "widgets": [
-                        {
-                          "buttonList": {
-                            "buttons": [
-                              {
-                                "text": "View Release",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "${{ steps.check_release.outputs.release_url }}"
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "widgets": [
-                        {
-                          "textParagraph": {
-                            "text": "<i><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View workflow run</a></i>"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }'
+        uses: ./.github/actions/notify-release
+        with:
+          webhook_url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          release_tag: ${{ steps.check_release.outputs.release_tag }}
+          release_name: ${{ steps.check_release.outputs.release_name }}
+          release_url: ${{ steps.check_release.outputs.release_url }}
+          release_body: ${{ steps.check_release.outputs.release_body }}
+          published_at: ${{ steps.check_release.outputs.published_at }}
+          author: ${{ steps.check_release.outputs.author }}
+          workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-#      - name: Save last notified release to cache
-#        if: steps.check_release.outputs.new_release == 'true'
-#        uses: actions/cache/save@v4
-#        with:
-#          path: last_release.txt
-#          key: last-notified-release
-
-      - name: Install didc tool
+      - name: Handle DID files
         if: steps.check_release.outputs.new_release == 'true'
-        run: |
-          # Download didc
-          curl -L -o didc https://github.com/dfinity/candid/releases/download/2024-07-29/didc-linux64
-          
-          # Make it executable
-          chmod +x didc
-          
-          # Move to a directory in PATH and verify installation
-          sudo mv didc /usr/local/bin/
-          export PATH="/usr/local/bin:$PATH"
-          
-          # Verify installation
-          which didc
-          didc --version
-          
-          # Ensure the directory exists and is writable
-          sudo mkdir -p /usr/local/bin
-          sudo chmod 755 /usr/local/bin
-
-      - name: Download and compare .did files
-        if: steps.check_release.outputs.new_release == 'true'
-        id: compare_did
-        run: |
-          # Verify didc is available
-          which didc || { echo "didc not found in PATH"; exit 1; }
-          
-          # Create temporary directory for new release files
-          mkdir -p temp_release
-          
-          # Create did directory if it doesn't exist
-          mkdir -p shared/rust/rust-agent-uniffi/did
-          
-          # Download release assets
-          RELEASE_ASSETS=$(curl -s "https://api.github.com/repos/dolr-ai/hot-or-not-backend-canister/releases/latest" | jq -r '.assets[].browser_download_url')
-          
-          # Download .did files to temp directory
-          for asset_url in $RELEASE_ASSETS; do
-            if [[ $asset_url == *.did ]]; then
-              echo "Downloading $(basename $asset_url)..."
-              curl -L -o "temp_release/$(basename $asset_url)" "$asset_url"
-            fi
-          done
-          
-          # Compare and update files
-          HAS_CHANGES=false
-          HAS_BREAKING_CHANGES=false
-          CHANGED_FILES=""
-          for did_file in temp_release/*.did; do
-            if [ -f "$did_file" ]; then
-              local_file="shared/rust/rust-agent-uniffi/did/$(basename $did_file)"
-              if [ -f "$local_file" ]; then
-                echo "Comparing $(basename $did_file)..."
-                # Run didc check and capture both output and exit code
-                set +e  # Disable exit on error
-                DIFF_OUTPUT=$(didc check "$did_file" "$local_file" 2>&1)
-                DIFF_EXIT_CODE=$?
-                set -e  # Re-enable exit on error
-                
-                if [ $DIFF_EXIT_CODE -ne 0 ]; then
-                  echo "❌ Breaking changes detected in $(basename $did_file):"
-                  echo "$DIFF_OUTPUT"
-                  echo "breaking_changes=true" >> $GITHUB_OUTPUT
-                  HAS_BREAKING_CHANGES=true
-                  CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (breaking changes)"
-                else
-                  echo "✅ No breaking changes in $(basename $did_file)"
-                  # Check if files are different despite being compatible
-                  if ! cmp -s "$local_file" "$did_file"; then
-                    echo "ℹ️ Non-breaking updates found in $(basename $did_file)"
-                    echo "differences=true" >> $GITHUB_OUTPUT
-                    echo "Updating $(basename $did_file)..."
-                    cp "$did_file" "$local_file"
-                    HAS_CHANGES=true
-                    CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (updated)"
-                  else
-                    echo "✅ Files are identical"
-                  fi
-                fi
-              else
-                echo "⚠️ New .did file found: $(basename $did_file)"
-                echo "new_files=true" >> $GITHUB_OUTPUT
-                echo "Adding new file $(basename $did_file)..."
-                cp "$did_file" "$local_file"
-                HAS_CHANGES=true
-                CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (new)"
-              fi
-            fi
-          done
-          
-          # Cleanup
-          rm -rf temp_release
-          
-          # Set outputs for next steps
-          echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
-          echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
-          # Format changed files for JSON
-          CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | sed '1d' | jq -Rs .)
-          echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT
-
-      - name: Process Release Notes
-        id: process_notes
-        run: |
-          # Convert release notes to proper markdown and clean up formatting
-          NOTES=$(echo '${{ steps.check_release.outputs.release_body }}' | sed 's/\\n/\n/g' | sed 's/^## /### /g')
-          echo "PROCESSED_NOTES<<EOF" >> $GITHUB_ENV
-          echo "$NOTES" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+        id: handle_did
+        uses: ./.github/actions/handle-did-files
+        with:
+          release_tag: ${{ steps.check_release.outputs.release_tag }}
 
       - name: Create Pull Request
-        if: steps.compare_did.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v7
-        id: cpr
-        continue-on-error: true
+        if: steps.check_release.outputs.new_release == 'true' && steps.handle_did.outputs.has_changes == 'true'
+        id: create_pr
+        uses: ./.github/actions/create-pr
         with:
-          commit-message: "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
-          title: "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
-          add-paths: |
-            *.did
-          body: |
-            This PR updates the .did files from the latest release.
+          release_tag: ${{ steps.check_release.outputs.release_tag }}
+          release_name: ${{ steps.check_release.outputs.release_name }}
+          release_url: ${{ steps.check_release.outputs.release_url }}
+          published_at: ${{ steps.check_release.outputs.published_at }}
+          author: ${{ steps.check_release.outputs.author }}
+          release_body: ${{ steps.check_release.outputs.release_body }}
+          changed_files: ${{ steps.handle_did.outputs.changed_files }}
+          breaking_changes: ${{ steps.handle_did.outputs.has_breaking_changes }}
 
-            ## Release Details
-            - **Release:** ${{ steps.check_release.outputs.release_name }}
-            - **Tag:** ${{ steps.check_release.outputs.release_tag }}
-            - **Published:** ${{ steps.check_release.outputs.published_at }}
-            - **Author:** ${{ steps.check_release.outputs.author }}
-
-            ## Release Notes
-            ${{ env.PROCESSED_NOTES }}
-
-            ## Changes Summary
-            The following .did files were affected:
-            ${{ fromJSON(steps.compare_did.outputs.changed_files) }}
-
-            ## Breaking Changes Status
-            ${{ steps.compare_did.outputs.breaking_changes == 'true' && '⚠️ **Warning:** This update contains breaking changes!' || '✅ No breaking changes detected' }}
-
-            ---
-            [View Original Release](${{ steps.check_release.outputs.release_url }})
-          branch: create-pull-request/update-did-files-${{ steps.check_release.outputs.release_tag }}
-
-      - name: Send DID changes notification to Google Chat
-        if: steps.check_release.outputs.new_release == 'true' && steps.compare_did.outputs.has_changes == 'true'
-        run: |
-          # Check if PR was created successfully
-          PR_STATUS="${{ steps.cpr.outcome }}"
-          PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
-          
-          # Prepare PR status widgets
-          if [ "$PR_STATUS" = "success" ]; then
-            PR_WIDGETS='[
-              {
-                "decoratedText": {
-                  "text": "✅ Pull Request created successfully"
-                }
-              },
-              {
-                "buttonList": {
-                  "buttons": [
-                    {
-                      "text": "View Pull Request",
-                      "onClick": {
-                        "openLink": {
-                          "url": "'"$PR_URL"'"
-                        }
-                      }
-                    }
-                  ]
-                }
-              }
-            ]'
-          else
-            PR_WIDGETS='[
-              {
-                "decoratedText": {
-                  "text": "❌ Failed to create Pull Request"
-                }
-              }
-            ]'
-          fi
-          
-          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
-          -H "Content-Type: application/json" \
-          -d '{
-            "cardsV2": [
-              {
-                "cardId": "did-changes",
-                "card": {
-                  "header": {
-                    "title": "DID File Changes Detected",
-                    "subtitle": "Changes from release ${{ steps.check_release.outputs.release_tag }}"
-                  },
-                  "sections": [
-                    {
-                      "header": "Findings",
-                      "widgets": [
-                        {
-                          "decoratedText": {
-                            "text": "${{ steps.compare_did.outputs.breaking_changes == 'true' && '🚨 Breaking changes detected in .did files' || '✅ No breaking changes detected' }}"
-                          }
-                        },
-                        {
-                          "decoratedText": {
-                            "text": "${{ steps.compare_did.outputs.differences == 'true' && 'ℹ️ Non-breaking updates found in .did files' || '✅ No non breaking changes detected' }}"
-                          }
-                        },
-                        {
-                          "decoratedText": {
-                            "text": "${{ steps.compare_did.outputs.new_files == 'true' && 'ℹ️ New .did files found in release' || '✅ No new files' }}"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "header": "Changed Files",
-                      "widgets": [
-                        {
-                          "textParagraph": {
-                            "text": "${{ fromJSON(steps.compare_did.outputs.changed_files) }}"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "header": "Pull Request Status",
-                      "widgets": '"$PR_WIDGETS"'
-                    },
-                    {
-                      "widgets": [
-                        {
-                          "textParagraph": {
-                            "text": "<i><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View workflow run</a></i>"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }'
-
-      - name: Log notification status
-        if: steps.check_release.outputs.new_release == 'true'
-        run: |
-          echo "✅ Processed release ${{ steps.check_release.outputs.release_tag }}"
-          if [ "${{ steps.compare_did.outputs.differences }}" == "true" ]; then
-            echo "⚠️ Non-breaking updates found in .did files"
-          fi
-          if [ "${{ steps.compare_did.outputs.breaking_changes }}" == "true" ]; then
-            echo "🚨 Breaking changes detected in .did files"
-          fi
-          if [ "${{ steps.compare_did.outputs.new_files }}" == "true" ]; then
-            echo "ℹ️ New .did files found in release"
-          fi
-          if [ "${{ steps.compare_did.outputs.has_changes }}" == "true" ]; then
-            echo "✅ Changes committed and PR created"
-          else
-            echo "ℹ️ No changes needed"
-          fi
+      - name: Send DID changes notification
+        if: steps.check_release.outputs.new_release == 'true' && steps.handle_did.outputs.has_changes == 'true'
+        uses: ./.github/actions/notify-did-changes
+        with:
+          webhook_url: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+          release_tag: ${{ steps.check_release.outputs.release_tag }}
+          changed_files: ${{ steps.handle_did.outputs.changed_files }}
+          breaking_changes: ${{ steps.handle_did.outputs.has_breaking_changes }}
+          pr_url: ${{ steps.create_pr.outputs.pr_url }}
+          pr_status: ${{ steps.create_pr.outputs.pr_status }}
+          workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Create GitHub Summary
         if: steps.check_release.outputs.new_release == 'true'
@@ -438,34 +83,34 @@ jobs:
           echo "- **Release URL:** [${{ steps.check_release.outputs.release_url }}](${{ steps.check_release.outputs.release_url }})" >> $GITHUB_STEP_SUMMARY
           
           echo "## Release Notes" >> $GITHUB_STEP_SUMMARY
-          echo "${{ env.PROCESSED_NOTES }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.check_release.outputs.release_body }}" >> $GITHUB_STEP_SUMMARY
           
           echo "## DID Changes Analysis" >> $GITHUB_STEP_SUMMARY
           
           # Add status indicators
-          if [ "${{ steps.compare_did.outputs.has_changes }}" == "true" ]; then
+          if [ "${{ steps.handle_did.outputs.has_changes }}" == "true" ]; then
             echo "### Changed Files" >> $GITHUB_STEP_SUMMARY
-            echo "${{ fromJSON(steps.compare_did.outputs.changed_files) }}" >> $GITHUB_STEP_SUMMARY
+            echo "${{ steps.handle_did.outputs.changed_files }}" >> $GITHUB_STEP_SUMMARY
             
             echo "### Change Status" >> $GITHUB_STEP_SUMMARY
-            if [ "${{ steps.compare_did.outputs.breaking_changes }}" == "true" ]; then
+            if [ "${{ steps.handle_did.outputs.breaking_changes }}" == "true" ]; then
               echo "🚨 **Breaking changes detected in .did files**" >> $GITHUB_STEP_SUMMARY
             else
               echo "✅ No breaking changes detected" >> $GITHUB_STEP_SUMMARY
             fi
             
-            if [ "${{ steps.compare_did.outputs.differences }}" == "true" ]; then
+            if [ "${{ steps.handle_did.outputs.differences }}" == "true" ]; then
               echo "ℹ️ Non-breaking updates found in .did files" >> $GITHUB_STEP_SUMMARY
             fi
             
-            if [ "${{ steps.compare_did.outputs.new_files }}" == "true" ]; then
+            if [ "${{ steps.handle_did.outputs.new_files }}" == "true" ]; then
               echo "📄 New .did files added from release" >> $GITHUB_STEP_SUMMARY
             fi
             
             # Add PR information if available
-            if [ "${{ steps.cpr.outcome }}" == "success" ]; then
+            if [ "${{ steps.create_pr.outputs.pr_status }}" == "success" ]; then
               echo "### Pull Request" >> $GITHUB_STEP_SUMMARY
-              echo "✅ Pull Request created successfully: [${{ steps.cpr.outputs.pull-request-url }}](${{ steps.cpr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+              echo "✅ Pull Request created successfully: [${{ steps.create_pr.outputs.pr_url }}](${{ steps.create_pr.outputs.pr_url }})" >> $GITHUB_STEP_SUMMARY
             else
               echo "### Pull Request" >> $GITHUB_STEP_SUMMARY
               echo "❌ Failed to create Pull Request" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -266,22 +266,7 @@ jobs:
                     {
                       "header": "Release Notes",
                       "widgets": [
-                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } },
-                        {
-                          "buttonList": {
-                            "buttons": [
-                              {
-                                "text": "View Release",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "${{ steps.check_release.outputs.release_url }}"
-                                  }
-                                },
-                                "icon": { "knownIcon": "BOOKMARK" }
-                              }
-                            ]
-                          }
-                        }
+                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
                       ]
                     },
                     {
@@ -323,10 +308,23 @@ jobs:
                             "text": "${{ steps.compare_did.outputs.has_changes == 'true' && '✅ PR created for .did file updates' || 'ℹ️ No PR needed - no changes detected' }}"
                           }
                         }
-                        ${{ steps.compare_did.outputs.has_changes == 'true' && ',
+                      ]
+                    },
+                    {
+                      "widgets": [
                         {
                           "buttonList": {
                             "buttons": [
+                              {
+                                "text": "View Release",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "${{ steps.check_release.outputs.release_url }}"
+                                  }
+                                },
+                                "icon": { "knownIcon": "BOOKMARK" }
+                              }
+                              ${{ steps.compare_did.outputs.has_changes == 'true' && ',
                               {
                                 "text": "View PR",
                                 "onClick": {
@@ -334,10 +332,10 @@ jobs:
                                     "url": "https://github.com/dolr-ai/yral-mobile/pull/${{ github.event.pull_request.number }}"
                                   }
                                 }
-                              }
+                              }' || '' }}
                             ]
                           }
-                        }' || '' }}
+                        }
                       ]
                     }
                   ]

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -65,6 +65,8 @@ jobs:
           release_tag: ${{ steps.check_release.outputs.release_tag }}
           changed_files: ${{ steps.handle_did.outputs.changed_files }}
           breaking_changes: ${{ steps.handle_did.outputs.has_breaking_changes }}
+          differences: ${{ steps.handle_did.outputs.differences }}
+          new_files: ${{ steps.handle_did.outputs.new_files }}
           pr_url: ${{ steps.create_pr.outputs.pr_url }}
           pr_status: ${{ steps.create_pr.outputs.pr_status }}
           workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -82,15 +84,17 @@ jobs:
           echo "- **Author:** ${{ steps.check_release.outputs.author }}" >> $GITHUB_STEP_SUMMARY
           echo "- **Release URL:** [${{ steps.check_release.outputs.release_url }}](${{ steps.check_release.outputs.release_url }})" >> $GITHUB_STEP_SUMMARY
           
+          # Convert release notes to proper markdown and clean up formatting
+          PROCESSED_NOTES=$(echo '${{ steps.check_release.outputs.release_body }}' | sed 's/\\n/\n/g' | sed 's/^## /### /g')
           echo "## Release Notes" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.check_release.outputs.release_body }}" >> $GITHUB_STEP_SUMMARY
+          echo "$PROCESSED_NOTES" >> $GITHUB_STEP_SUMMARY
           
           echo "## DID Changes Analysis" >> $GITHUB_STEP_SUMMARY
           
           # Add status indicators
           if [ "${{ steps.handle_did.outputs.has_changes }}" == "true" ]; then
             echo "### Changed Files" >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.handle_did.outputs.changed_files }}" >> $GITHUB_STEP_SUMMARY
+            echo "${{ fromJSON(steps.handle_did.outputs.changed_files) }}" >> $GITHUB_STEP_SUMMARY
             
             echo "### Change Status" >> $GITHUB_STEP_SUMMARY
             if [ "${{ steps.handle_did.outputs.breaking_changes }}" == "true" ]; then

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -213,6 +213,15 @@ jobs:
 #            --base main \
 #            --label "$PR_LABELS"
 
+      - name: Send notification to Google Chat
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "text": "TEST: 🎉 *New Release Alert!*\n\n📦 **Hot-or-Not Backend Canister**\n🏷️ Release: ${{ steps.check_release.outputs.release_name }} (${{ steps.check_release.outputs.release_tag }})\n👤 Author: ${{ steps.check_release.outputs.author }}\n📅 Published: ${{ steps.check_release.outputs.published_at }}\n\n📝 **Release Notes:**\n${{ steps.check_release.outputs.release_body }}\n\n🔗 [View Release](${{ steps.check_release.outputs.release_url }})\n🔗 [Repository](https://github.com/dolr-ai/hot-or-not-backend-canister)"
+          }'
+
       - name: Log notification status
         if: steps.check_release.outputs.new_release == 'true'
         run: |

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -127,6 +127,7 @@ jobs:
           # Compare and update files
           HAS_CHANGES=false
           HAS_BREAKING_CHANGES=false
+          CHANGED_FILES=""
           for did_file in temp_release/*.did; do
             if [ -f "$did_file" ]; then
               local_file="shared/rust/rust-agent-uniffi/did/$(basename $did_file)"
@@ -143,7 +144,7 @@ jobs:
                   echo "$DIFF_OUTPUT"
                   echo "breaking_changes=true" >> $GITHUB_OUTPUT
                   HAS_BREAKING_CHANGES=true
-                  # Don't automatically update files with breaking changes
+                  CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (breaking changes)"
                 else
                   echo "✅ No breaking changes in $(basename $did_file)"
                   # Check if files are different despite being compatible
@@ -153,6 +154,7 @@ jobs:
                     echo "Updating $(basename $did_file)..."
                     cp "$did_file" "$local_file"
                     HAS_CHANGES=true
+                    CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (updated)"
                   else
                     echo "✅ Files are identical"
                   fi
@@ -163,6 +165,7 @@ jobs:
                 echo "Adding new file $(basename $did_file)..."
                 cp "$did_file" "$local_file"
                 HAS_CHANGES=true
+                CHANGED_FILES="$CHANGED_FILES\n• $(basename $did_file) (new)"
               fi
             fi
           done
@@ -173,6 +176,9 @@ jobs:
           # Set outputs for next steps
           echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
           echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
+          # Format changed files for JSON
+          CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | jq -Rs .)
+          echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT
 
 #      - name: Commit and push changes
 #        if: steps.compare_did.outputs.has_changes == 'true'
@@ -275,14 +281,24 @@ jobs:
                         },
                         {
                           "decoratedText": {
-                            "topLabel": "File Updates",
-                            "text": "${{ steps.compare_did.outputs.differences == 'true' && 'ℹ️ Non-breaking updates found in .did files' || '✅ No updates needed' }}"
+                            "topLabel": "Non Breaking Changes",
+                            "text": "${{ steps.compare_did.outputs.differences == 'true' && 'ℹ️ Non-breaking updates found in .did files' || '✅ No non breaking changes detected' }}"
                           }
                         },
                         {
                           "decoratedText": {
                             "topLabel": "New Files",
                             "text": "${{ steps.compare_did.outputs.new_files == 'true' && 'ℹ️ New .did files found in release' || '✅ No new files' }}"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "header": "📝 Changed Files",
+                      "widgets": [
+                        {
+                          "textParagraph": {
+                            "text": "${{ steps.compare_did.outputs.has_changes == 'true' && fromJSON(steps.compare_did.outputs.changed_files) || '✅ No changes needed' }}"
                           }
                         }
                       ]
@@ -296,6 +312,21 @@ jobs:
                             "text": "${{ steps.compare_did.outputs.has_changes == 'true' && '✅ PR created for .did file updates' || 'ℹ️ No PR needed - no changes detected' }}"
                           }
                         }
+                        ${{ steps.compare_did.outputs.has_changes == 'true' && ',
+                        {
+                          "buttonList": {
+                            "buttons": [
+                              {
+                                "text": "View PR",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "https://github.com/dolr-ai/yral-mobile/pull/${{ github.event.pull_request.number }}"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }' || '' }}
                       ]
                     },
                     {

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -424,3 +424,53 @@ jobs:
             echo "ℹ️ No changes needed"
           fi
 
+      - name: Create GitHub Summary
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          # Start creating the summary
+          echo "# Hot-or-Not Backend Release Summary" >> $GITHUB_STEP_SUMMARY
+          
+          echo "## Release Details" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release:** ${{ steps.check_release.outputs.release_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag:** ${{ steps.check_release.outputs.release_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Published:** ${{ steps.check_release.outputs.published_at }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Author:** ${{ steps.check_release.outputs.author }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release URL:** [${{ steps.check_release.outputs.release_url }}](${{ steps.check_release.outputs.release_url }})" >> $GITHUB_STEP_SUMMARY
+          
+          echo "## Release Notes" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.PROCESSED_NOTES }}" >> $GITHUB_STEP_SUMMARY
+          
+          echo "## DID Changes Analysis" >> $GITHUB_STEP_SUMMARY
+          
+          # Add status indicators
+          if [ "${{ steps.compare_did.outputs.has_changes }}" == "true" ]; then
+            echo "### Changed Files" >> $GITHUB_STEP_SUMMARY
+            echo "${{ fromJSON(steps.compare_did.outputs.changed_files) }}" >> $GITHUB_STEP_SUMMARY
+            
+            echo "### Change Status" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ steps.compare_did.outputs.breaking_changes }}" == "true" ]; then
+              echo "🚨 **Breaking changes detected in .did files**" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ No breaking changes detected" >> $GITHUB_STEP_SUMMARY
+            fi
+            
+            if [ "${{ steps.compare_did.outputs.differences }}" == "true" ]; then
+              echo "ℹ️ Non-breaking updates found in .did files" >> $GITHUB_STEP_SUMMARY
+            fi
+            
+            if [ "${{ steps.compare_did.outputs.new_files }}" == "true" ]; then
+              echo "📄 New .did files added from release" >> $GITHUB_STEP_SUMMARY
+            fi
+            
+            # Add PR information if available
+            if [ "${{ steps.cpr.outcome }}" == "success" ]; then
+              echo "### Pull Request" >> $GITHUB_STEP_SUMMARY
+              echo "✅ Pull Request created successfully: [${{ steps.cpr.outputs.pull-request-url }}](${{ steps.cpr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "### Pull Request" >> $GITHUB_STEP_SUMMARY
+              echo "❌ Failed to create Pull Request" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "✅ No changes needed to .did files" >> $GITHUB_STEP_SUMMARY
+          fi
+

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -19,6 +19,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache last processed release
+        uses: actions/cache@v4
+        id: release-cache
+        with:
+          path: .github/cache
+          key: last-processed-release
+          restore-keys: |
+            last-processed-release
+
       - name: Check for new releases
         id: check_release
         uses: ./.github/actions/check-release

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -213,27 +213,12 @@ jobs:
 #            --base main \
 #            --label "$PR_LABELS"
 
-      - name: Process release notes for Google Chat
-        if: steps.check_release.outputs.new_release == 'true'
-        id: process_release_notes
-        run: |
-          set -euo pipefail
-          # Save the original release notes to a file
-          echo "${{ steps.check_release.outputs.release_body }}" > release_notes_raw.txt
-
-          # Convert headings (##,###) to <b>...</b>, remove GitHub PR/commit links, incomplete Markdown links, and empty lines
-          sed -E 's/^###? (.*)$/<b>\1<\/b>/g' release_notes_raw.txt | \
-            grep -vE 'https://github.com/dolr-ai/hot-or-not-backend-canister/(pull|commit)/' | \
-            grep -vE '\[.*\]\(https://github.com/dolr-ai/h$' | \
-            grep -vE '^\s*$' > release_notes_clean.txt || true
-
-          # Read cleaned notes into a variable, escape for JSON
-          CLEANED_NOTES=$(cat release_notes_clean.txt | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
-          echo "cleaned_body=$CLEANED_NOTES" >> $GITHUB_OUTPUT
-
       - name: Send notification to Google Chat
         if: steps.check_release.outputs.new_release == 'true'
         run: |
+          # Process and escape release notes for JSON
+          RELEASE_NOTES=$(echo "${{ steps.check_release.outputs.release_body }}" | .github/helperscripts/cleanup_release_notes_for_google_chat.sh | jq -Rs .)
+          
           curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
           -H "Content-Type: application/json" \
           -d '{
@@ -242,10 +227,9 @@ jobs:
                 "cardId": "release-alert",
                 "card": {
                   "header": {
-                    "title": "🎉 New Release Alert!",
+                    "title": "New Release Alert!",
                     "subtitle": "Hot-or-Not Backend Canister",
-                    "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4",
-                    "imageType": "CIRCLE"
+                    "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4"
                   },
                   "sections": [
                     {
@@ -266,7 +250,7 @@ jobs:
                         },
                         {
                           "decoratedText": {
-                            "startIcon": { "knownIcon": "EVENT" },
+                            "startIcon": { "knownIcon": "INVITE" },
                             "topLabel": "Published",
                             "text": "${{ steps.check_release.outputs.published_at }}"
                           }
@@ -276,7 +260,7 @@ jobs:
                     {
                       "header": "📝 Release Notes",
                       "widgets": [
-                        { "textParagraph": { "text": "${{ steps.process_release_notes.outputs.cleaned_body }}" } }
+                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
                       ]
                     },
                     {
@@ -285,7 +269,7 @@ jobs:
                           "buttonList": {
                             "buttons": [
                               {
-                                "text": "🔗 View Release",
+                                "text": "View Release",
                                 "onClick": {
                                   "openLink": {
                                     "url": "${{ steps.check_release.outputs.release_url }}"
@@ -294,7 +278,7 @@ jobs:
                                 "icon": { "knownIcon": "BOOKMARK" }
                               },
                               {
-                                "text": "📦 Repository",
+                                "text": "Repository",
                                 "onClick": {
                                   "openLink": {
                                     "url": "https://github.com/dolr-ai/hot-or-not-backend-canister"

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -177,7 +177,7 @@ jobs:
           echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
           echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
           # Format changed files for JSON
-          CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | jq -Rs .)
+          CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | sed '1d' | jq -Rs .)
           echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT
 
 #      - name: Commit and push changes
@@ -264,8 +264,7 @@ jobs:
                       ]
                     },
                     {
-                      "header": "📝 Release Notes",
-                      collapsible: true,
+                      "header": "Release Notes",
                       "widgets": [
                         { "textParagraph": { "text": '"$RELEASE_NOTES"' } },
                         {
@@ -286,30 +285,27 @@ jobs:
                       ]
                     },
                     {
-                      "header": "🔍 Findings",
+                      "header": "Findings",
                       "widgets": [
                         {
                           "decoratedText": {
-                            "topLabel": "Breaking Changes",
                             "text": "${{ steps.compare_did.outputs.breaking_changes == 'true' && '🚨 Breaking changes detected in .did files' || '✅ No breaking changes detected' }}"
                           }
                         },
                         {
                           "decoratedText": {
-                            "topLabel": "Non Breaking Changes",
                             "text": "${{ steps.compare_did.outputs.differences == 'true' && 'ℹ️ Non-breaking updates found in .did files' || '✅ No non breaking changes detected' }}"
                           }
                         },
                         {
                           "decoratedText": {
-                            "topLabel": "New Files",
                             "text": "${{ steps.compare_did.outputs.new_files == 'true' && 'ℹ️ New .did files found in release' || '✅ No new files' }}"
                           }
                         }
                       ]
                     },
                     {
-                      "header": "📝 Changed Files",
+                      "header": "Changed Files",
                       "widgets": [
                         {
                           "textParagraph": {
@@ -319,7 +315,7 @@ jobs:
                       ]
                     },
                     {
-                      "header": "🔄 Actions Taken",
+                      "header": "Actions Taken",
                       "widgets": [
                         {
                           "decoratedText": {

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -1,10 +1,9 @@
 name: Hot-or-Not Backend Release Monitor
 
 on:
-  push:
   schedule:
-    # Check for new releases every 30 minutes
-    - cron: '*/30 * * * *'
+    # Check for new releases daily
+    - cron: '0 0 * * *'
   workflow_dispatch: # Allow manual triggering
 
 jobs:

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -25,8 +25,6 @@ jobs:
         with:
           path: .github/cache
           key: last-processed-release
-          restore-keys: |
-            last-processed-release
 
       - name: Check for new releases
         id: check_release

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -11,12 +11,14 @@ jobs:
   check-releases:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
+      contents: 'write'  # Changed to write to allow committing changes
       id-token: 'write'
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for proper versioning
 
       - name: Restore last notified release from cache
         id: cache-release
@@ -77,16 +79,136 @@ jobs:
           path: last_release.txt
           key: last-notified-release
 
-      - name: Send notification to Google Chat
+      - name: Install didc tool
         if: steps.check_release.outputs.new_release == 'true'
         run: |
-          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
-          -H "Content-Type: application/json" \
-          -d '{
-            "text": "🎉 *New Release Alert!*\n\n📦 **Hot-or-Not Backend Canister**\n🏷️ Release: ${{ steps.check_release.outputs.release_name }} (${{ steps.check_release.outputs.release_tag }})\n👤 Author: ${{ steps.check_release.outputs.author }}\n📅 Published: ${{ steps.check_release.outputs.published_at }}\n\n📝 **Release Notes:**\n${{ steps.check_release.outputs.release_body }}\n\n🔗 [View Release](${{ steps.check_release.outputs.release_url }})\n🔗 [Repository](https://github.com/dolr-ai/hot-or-not-backend-canister)"
-          }'
+          curl -L -o didc https://github.com/dfinity/candid/releases/download/2024-02-08/didc-linux64
+          chmod +x didc
+          sudo mv didc /usr/local/bin/
+
+      - name: Download and compare .did files
+        if: steps.check_release.outputs.new_release == 'true'
+        id: compare_did
+        run: |
+          # Create temporary directory for new release files
+          mkdir -p temp_release
+          
+          # Create did directory if it doesn't exist
+          mkdir -p shared/rust/rust-agent-uniffi/did
+          
+          # Download release assets
+          RELEASE_ASSETS=$(curl -s "https://api.github.com/repos/dolr-ai/hot-or-not-backend-canister/releases/latest" | jq -r '.assets[].browser_download_url')
+          
+          # Download .did files to temp directory
+          for asset_url in $RELEASE_ASSETS; do
+            if [[ $asset_url == *.did ]]; then
+              echo "Downloading $(basename $asset_url)..."
+              curl -L -o "temp_release/$(basename $asset_url)" "$asset_url"
+            fi
+          done
+          
+          # Compare and update files
+          HAS_CHANGES=false
+          HAS_BREAKING_CHANGES=false
+          for did_file in temp_release/*.did; do
+            if [ -f "$did_file" ]; then
+              local_file="shared/rust/rust-agent-uniffi/did/$(basename $did_file)"
+              if [ -f "$local_file" ]; then
+                echo "Comparing $(basename $did_file)..."
+                # Run didc check and capture both output and exit code
+                DIFF_OUTPUT=$(didc check "$local_file" "$did_file" 2>&1)
+                DIFF_EXIT_CODE=$?
+                
+                if [ $DIFF_EXIT_CODE -ne 0 ]; then
+                  echo "❌ Breaking changes detected in $(basename $did_file):"
+                  echo "$DIFF_OUTPUT"
+                  echo "breaking_changes=true" >> $GITHUB_OUTPUT
+                  HAS_BREAKING_CHANGES=true
+                  # Don't automatically update files with breaking changes
+                else
+                  echo "✅ No breaking changes in $(basename $did_file)"
+                  # Check if files are different despite being compatible
+                  if ! cmp -s "$local_file" "$did_file"; then
+                    echo "ℹ️ Non-breaking updates found in $(basename $did_file)"
+                    echo "differences=true" >> $GITHUB_OUTPUT
+                    echo "Updating $(basename $did_file)..."
+                    cp "$did_file" "$local_file"
+                    HAS_CHANGES=true
+                  else
+                    echo "✅ Files are identical"
+                  fi
+                fi
+              else
+                echo "⚠️ New .did file found: $(basename $did_file)"
+                echo "new_files=true" >> $GITHUB_OUTPUT
+                echo "Adding new file $(basename $did_file)..."
+                cp "$did_file" "$local_file"
+                HAS_CHANGES=true
+              fi
+            fi
+          done
+          
+          # Cleanup
+          rm -rf temp_release
+          
+          # Set outputs for next steps
+          echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
+          echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
+
+      - name: Commit and push changes
+        if: steps.compare_did.outputs.has_changes == 'true'
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          
+          # Create a new branch for the changes
+          BRANCH_NAME="update-did-files-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b $BRANCH_NAME
+          
+          # Add and commit changes
+          git add shared/rust/rust-agent-uniffi/did/
+          git commit -m "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
+          
+          # Push changes
+          git push origin $BRANCH_NAME
+          
+          # Create pull request with appropriate labels
+          PR_LABELS=""
+          if [ "${{ steps.compare_did.outputs.has_breaking_changes }}" == "true" ]; then
+            PR_LABELS="breaking-change"
+          fi
+          
+          gh pr create \
+            --title "Update .did files from release ${{ steps.check_release.outputs.release_tag }}" \
+            --body "This PR updates the .did files from the latest release.
+            
+            Release: ${{ steps.check_release.outputs.release_name }}
+            Tag: ${{ steps.check_release.outputs.release_tag }}
+            Published: ${{ steps.check_release.outputs.published_at }}
+            Author: ${{ steps.check_release.outputs.author }}
+            
+            Release Notes:
+            ${{ steps.check_release.outputs.release_body }}
+            
+            [View Release](${{ steps.check_release.outputs.release_url }})" \
+            --base main \
+            --label "$PR_LABELS"
 
       - name: Log notification status
         if: steps.check_release.outputs.new_release == 'true'
         run: |
-          echo "✅ Notification sent for release ${{ steps.check_release.outputs.release_tag }}"
+          echo "✅ Processed release ${{ steps.check_release.outputs.release_tag }}"
+          if [ "${{ steps.compare_did.outputs.differences }}" == "true" ]; then
+            echo "⚠️ Non-breaking updates found in .did files"
+          fi
+          if [ "${{ steps.compare_did.outputs.breaking_changes }}" == "true" ]; then
+            echo "🚨 Breaking changes detected in .did files"
+          fi
+          if [ "${{ steps.compare_did.outputs.new_files }}" == "true" ]; then
+            echo "ℹ️ New .did files found in release"
+          fi
+          if [ "${{ steps.compare_did.outputs.has_changes }}" == "true" ]; then
+            echo "✅ Changes committed and PR created"
+          else
+            echo "ℹ️ No changes needed"
+          fi

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -138,6 +138,15 @@ jobs:
                           }
                         }
                       ]
+                    },
+                    {
+                      "widgets": [
+                        {
+                          "textParagraph": {
+                            "text": "<i><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View workflow run</a></i>"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }
@@ -380,6 +389,15 @@ jobs:
                     {
                       "header": "Pull Request Status",
                       "widgets": '"$PR_WIDGETS"'
+                    },
+                    {
+                      "widgets": [
+                        {
+                          "textParagraph": {
+                            "text": "<i><a href=\"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\">View workflow run</a></i>"
+                          }
+                        }
+                      ]
                     }
                   ]
                 }

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -24,7 +24,9 @@ jobs:
         id: release-cache
         with:
           path: .github/cache
-          key: last-processed-release
+          key: ${{ github.ref }}-last-processed-release
+          restore-keys: |
+            ${{ github.ref }}-last-processed-release-
 
       - name: Check for new releases
         id: check_release

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -1,6 +1,7 @@
 name: Hot-or-Not Backend Release Monitor
 
 on:
+  push:
   schedule:
     # Check for new releases daily
     - cron: '0 0 * * *'

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -83,7 +83,7 @@ jobs:
         if: steps.check_release.outputs.new_release == 'true'
         run: |
           # Download didc
-          curl -L -o didc https://github.com/dfinity/candid/releases/download/2024-02-08/didc-linux64
+          curl -L -o didc https://github.com/dfinity/candid/releases/download/2024-07-29/didc-linux64
           
           # Make it executable
           chmod +x didc

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -82,14 +82,31 @@ jobs:
       - name: Install didc tool
         if: steps.check_release.outputs.new_release == 'true'
         run: |
+          # Download didc
           curl -L -o didc https://github.com/dfinity/candid/releases/download/2024-02-08/didc-linux64
+          
+          # Make it executable
           chmod +x didc
+          
+          # Move to a directory in PATH and verify installation
           sudo mv didc /usr/local/bin/
+          export PATH="/usr/local/bin:$PATH"
+          
+          # Verify installation
+          which didc
+          didc --version
+          
+          # Ensure the directory exists and is writable
+          sudo mkdir -p /usr/local/bin
+          sudo chmod 755 /usr/local/bin
 
       - name: Download and compare .did files
         if: steps.check_release.outputs.new_release == 'true'
         id: compare_did
         run: |
+          # Verify didc is available
+          which didc || { echo "didc not found in PATH"; exit 1; }
+          
           # Create temporary directory for new release files
           mkdir -p temp_release
           

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -155,44 +155,44 @@ jobs:
           echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
           echo "has_breaking_changes=$HAS_BREAKING_CHANGES" >> $GITHUB_OUTPUT
 
-      - name: Commit and push changes
-        if: steps.compare_did.outputs.has_changes == 'true'
-        run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-          
-          # Create a new branch for the changes
-          BRANCH_NAME="update-did-files-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b $BRANCH_NAME
-          
-          # Add and commit changes
-          git add shared/rust/rust-agent-uniffi/did/
-          git commit -m "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
-          
-          # Push changes
-          git push origin $BRANCH_NAME
-          
-          # Create pull request with appropriate labels
-          PR_LABELS=""
-          if [ "${{ steps.compare_did.outputs.has_breaking_changes }}" == "true" ]; then
-            PR_LABELS="breaking-change"
-          fi
-          
-          gh pr create \
-            --title "Update .did files from release ${{ steps.check_release.outputs.release_tag }}" \
-            --body "This PR updates the .did files from the latest release.
-            
-            Release: ${{ steps.check_release.outputs.release_name }}
-            Tag: ${{ steps.check_release.outputs.release_tag }}
-            Published: ${{ steps.check_release.outputs.published_at }}
-            Author: ${{ steps.check_release.outputs.author }}
-            
-            Release Notes:
-            ${{ steps.check_release.outputs.release_body }}
-            
-            [View Release](${{ steps.check_release.outputs.release_url }})" \
-            --base main \
-            --label "$PR_LABELS"
+#      - name: Commit and push changes
+#        if: steps.compare_did.outputs.has_changes == 'true'
+#        run: |
+#          git config --global user.name 'GitHub Actions'
+#          git config --global user.email 'actions@github.com'
+#
+#          # Create a new branch for the changes
+#          BRANCH_NAME="update-did-files-$(date +%Y%m%d-%H%M%S)"
+#          git checkout -b $BRANCH_NAME
+#
+#          # Add and commit changes
+#          git add shared/rust/rust-agent-uniffi/did/
+#          git commit -m "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
+#
+#          # Push changes
+#          git push origin $BRANCH_NAME
+#
+#          # Create pull request with appropriate labels
+#          PR_LABELS=""
+#          if [ "${{ steps.compare_did.outputs.has_breaking_changes }}" == "true" ]; then
+#            PR_LABELS="breaking-change"
+#          fi
+#
+#          gh pr create \
+#            --title "Update .did files from release ${{ steps.check_release.outputs.release_tag }}" \
+#            --body "This PR updates the .did files from the latest release.
+#
+#            Release: ${{ steps.check_release.outputs.release_name }}
+#            Tag: ${{ steps.check_release.outputs.release_tag }}
+#            Published: ${{ steps.check_release.outputs.published_at }}
+#            Author: ${{ steps.check_release.outputs.author }}
+#
+#            Release Notes:
+#            ${{ steps.check_release.outputs.release_body }}
+#
+#            [View Release](${{ steps.check_release.outputs.release_url }})" \
+#            --base main \
+#            --label "$PR_LABELS"
 
       - name: Log notification status
         if: steps.check_release.outputs.new_release == 'true'

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: 'write'  # Changed to write to allow committing changes
       id-token: 'write'
+      pull-requests: 'write'
 
     steps:
       - name: Checkout repository
@@ -180,44 +181,28 @@ jobs:
           CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | sed '1d' | jq -Rs .)
           echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT
 
-#      - name: Commit and push changes
-#        if: steps.compare_did.outputs.has_changes == 'true'
-#        run: |
-#          git config --global user.name 'GitHub Actions'
-#          git config --global user.email 'actions@github.com'
-#
-#          # Create a new branch for the changes
-#          BRANCH_NAME="update-did-files-$(date +%Y%m%d-%H%M%S)"
-#          git checkout -b $BRANCH_NAME
-#
-#          # Add and commit changes
-#          git add shared/rust/rust-agent-uniffi/did/
-#          git commit -m "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
-#
-#          # Push changes
-#          git push origin $BRANCH_NAME
-#
-#          # Create pull request with appropriate labels
-#          PR_LABELS=""
-#          if [ "${{ steps.compare_did.outputs.has_breaking_changes }}" == "true" ]; then
-#            PR_LABELS="breaking-change"
-#          fi
-#
-#          gh pr create \
-#            --title "Update .did files from release ${{ steps.check_release.outputs.release_tag }}" \
-#            --body "This PR updates the .did files from the latest release.
-#
-#            Release: ${{ steps.check_release.outputs.release_name }}
-#            Tag: ${{ steps.check_release.outputs.release_tag }}
-#            Published: ${{ steps.check_release.outputs.published_at }}
-#            Author: ${{ steps.check_release.outputs.author }}
-#
-#            Release Notes:
-#            ${{ steps.check_release.outputs.release_body }}
-#
-#            [View Release](${{ steps.check_release.outputs.release_url }})" \
-#            --base main \
-#            --label "$PR_LABELS"
+      - name: Create Pull Request
+        if: steps.compare_did.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v7
+        id: cpr
+        with:
+          commit-message: "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
+          title: "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
+          add-paths: |
+            *.did
+          body: |
+            This PR updates the .did files from the latest release.
+
+            Release: ${{ steps.check_release.outputs.release_name }}
+            Tag: ${{ steps.check_release.outputs.release_tag }}
+            Published: ${{ steps.check_release.outputs.published_at }}
+            Author: ${{ steps.check_release.outputs.author }}
+
+            Release Notes:
+            ${{ steps.check_release.outputs.release_body }}
+
+            [View Release](${{ steps.check_release.outputs.release_url }})
+          branch: create-pull-request/update-did-files-${{ steps.check_release.outputs.release_tag }}
 
       - name: Send notification to Google Chat
         if: steps.check_release.outputs.new_release == 'true'
@@ -324,12 +309,11 @@ jobs:
                                 },
                                 "icon": { "knownIcon": "BOOKMARK" }
                               }
-                              ${{ steps.compare_did.outputs.has_changes == 'true' && ',
-                              {
+                              ${{ steps.compare_did.outputs.has_changes == 'true' && ',{
                                 "text": "View PR",
                                 "onClick": {
                                   "openLink": {
-                                    "url": "https://github.com/dolr-ai/yral-mobile/pull/${{ github.event.pull_request.number }}"
+                                    "url": "${{ steps.cpr.outputs.pull-request-url }}"
                                   }
                                 }
                               }' || '' }}

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for proper versioning
 
 #      - name: Restore last notified release from cache
 #        id: cache-release
@@ -72,6 +70,80 @@ jobs:
             echo "No new release"
             echo "new_release=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Send release notification to Google Chat
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          # Process and escape release notes for JSON
+          RELEASE_NOTES=$(echo "${{ steps.check_release.outputs.release_body }}" | .github/helperscripts/cleanup_release_notes_for_google_chat.sh | jq -Rs .)
+          
+          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "cardsV2": [
+              {
+                "cardId": "release-alert",
+                "card": {
+                  "header": {
+                    "title": "New Release Alert!",
+                    "subtitle": "Hot-or-Not Backend Canister",
+                    "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4"
+                  },
+                  "sections": [
+                    {
+                      "widgets": [
+                        {
+                          "decoratedText": {
+                            "startIcon": { "knownIcon": "DESCRIPTION" },
+                            "topLabel": "Release",
+                            "text": "${{ steps.check_release.outputs.release_name }} ( ${{ steps.check_release.outputs.release_tag }} )"
+                          }
+                        },
+                        {
+                          "decoratedText": {
+                            "startIcon": { "knownIcon": "PERSON" },
+                            "topLabel": "Author",
+                            "text": "${{ steps.check_release.outputs.author }}"
+                          }
+                        },
+                        {
+                          "decoratedText": {
+                            "startIcon": { "knownIcon": "INVITE" },
+                            "topLabel": "Published",
+                            "text": "${{ steps.check_release.outputs.published_at }}"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "header": "Release Notes",
+                      "widgets": [
+                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
+                      ]
+                    },
+                    {
+                      "widgets": [
+                        {
+                          "buttonList": {
+                            "buttons": [
+                              {
+                                "text": "View Release",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "${{ steps.check_release.outputs.release_url }}"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }'
 
 #      - name: Save last notified release to cache
 #        if: steps.check_release.outputs.new_release == 'true'
@@ -204,80 +276,6 @@ jobs:
 
             [View Release](${{ steps.check_release.outputs.release_url }})
           branch: create-pull-request/update-did-files-${{ steps.check_release.outputs.release_tag }}
-
-      - name: Send release notification to Google Chat
-        if: steps.check_release.outputs.new_release == 'true'
-        run: |
-          # Process and escape release notes for JSON
-          RELEASE_NOTES=$(echo "${{ steps.check_release.outputs.release_body }}" | .github/helperscripts/cleanup_release_notes_for_google_chat.sh | jq -Rs .)
-          
-          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
-          -H "Content-Type: application/json" \
-          -d '{
-            "cardsV2": [
-              {
-                "cardId": "release-alert",
-                "card": {
-                  "header": {
-                    "title": "New Release Alert!",
-                    "subtitle": "Hot-or-Not Backend Canister",
-                    "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4"
-                  },
-                  "sections": [
-                    {
-                      "widgets": [
-                        {
-                          "decoratedText": {
-                            "startIcon": { "knownIcon": "DESCRIPTION" },
-                            "topLabel": "Release",
-                            "text": "${{ steps.check_release.outputs.release_name }} ( ${{ steps.check_release.outputs.release_tag }} )"
-                          }
-                        },
-                        {
-                          "decoratedText": {
-                            "startIcon": { "knownIcon": "PERSON" },
-                            "topLabel": "Author",
-                            "text": "${{ steps.check_release.outputs.author }}"
-                          }
-                        },
-                        {
-                          "decoratedText": {
-                            "startIcon": { "knownIcon": "INVITE" },
-                            "topLabel": "Published",
-                            "text": "${{ steps.check_release.outputs.published_at }}"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "header": "Release Notes",
-                      "widgets": [
-                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
-                      ]
-                    },
-                    {
-                      "widgets": [
-                        {
-                          "buttonList": {
-                            "buttons": [
-                              {
-                                "text": "View Release",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "${{ steps.check_release.outputs.release_url }}"
-                                  }
-                                }
-                              }
-                            ]
-                          }
-                        }
-                      ]
-                    }
-                  ]
-                }
-              }
-            ]
-          }'
 
       - name: Send DID changes notification to Google Chat
         if: steps.check_release.outputs.new_release == 'true' && steps.compare_did.outputs.has_changes == 'true'

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -259,8 +259,43 @@ jobs:
                     },
                     {
                       "header": "📝 Release Notes",
+                      collapsible: true,
                       "widgets": [
                         { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
+                      ]
+                    },
+                    {
+                      "header": "🔍 Findings",
+                      "widgets": [
+                        {
+                          "decoratedText": {
+                            "topLabel": "Breaking Changes",
+                            "text": "${{ steps.compare_did.outputs.breaking_changes == 'true' && '🚨 Breaking changes detected in .did files' || '✅ No breaking changes detected' }}"
+                          }
+                        },
+                        {
+                          "decoratedText": {
+                            "topLabel": "File Updates",
+                            "text": "${{ steps.compare_did.outputs.differences == 'true' && 'ℹ️ Non-breaking updates found in .did files' || '✅ No updates needed' }}"
+                          }
+                        },
+                        {
+                          "decoratedText": {
+                            "topLabel": "New Files",
+                            "text": "${{ steps.compare_did.outputs.new_files == 'true' && 'ℹ️ New .did files found in release' || '✅ No new files' }}"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "header": "🔄 Actions Taken",
+                      "widgets": [
+                        {
+                          "decoratedText": {
+                            "topLabel": "Pull Request",
+                            "text": "${{ steps.compare_did.outputs.has_changes == 'true' && '✅ PR created for .did file updates' || 'ℹ️ No PR needed - no changes detected' }}"
+                          }
+                        }
                       ]
                     },
                     {

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -185,6 +185,7 @@ jobs:
         if: steps.compare_did.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         id: cpr
+        continue-on-error: true
         with:
           commit-message: "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
           title: "Update .did files from release ${{ steps.check_release.outputs.release_tag }}"
@@ -204,7 +205,7 @@ jobs:
             [View Release](${{ steps.check_release.outputs.release_url }})
           branch: create-pull-request/update-did-files-${{ steps.check_release.outputs.release_tag }}
 
-      - name: Send notification to Google Chat
+      - name: Send release notification to Google Chat
         if: steps.check_release.outputs.new_release == 'true'
         run: |
           # Process and escape release notes for JSON
@@ -255,6 +256,82 @@ jobs:
                       ]
                     },
                     {
+                      "widgets": [
+                        {
+                          "buttonList": {
+                            "buttons": [
+                              {
+                                "text": "View Release",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "${{ steps.check_release.outputs.release_url }}"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }'
+
+      - name: Send DID changes notification to Google Chat
+        if: steps.check_release.outputs.new_release == 'true' && steps.compare_did.outputs.has_changes == 'true'
+        run: |
+          # Check if PR was created successfully
+          PR_STATUS="${{ steps.cpr.outcome }}"
+          PR_URL="${{ steps.cpr.outputs.pull-request-url }}"
+          
+          # Prepare PR status widgets
+          if [ "$PR_STATUS" = "success" ]; then
+            PR_WIDGETS='[
+              {
+                "decoratedText": {
+                  "text": "✅ Pull Request created successfully"
+                }
+              },
+              {
+                "buttonList": {
+                  "buttons": [
+                    {
+                      "text": "View Pull Request",
+                      "onClick": {
+                        "openLink": {
+                          "url": "'"$PR_URL"'"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]'
+          else
+            PR_WIDGETS='[
+              {
+                "decoratedText": {
+                  "text": "❌ Failed to create Pull Request"
+                }
+              }
+            ]'
+          fi
+          
+          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "cardsV2": [
+              {
+                "cardId": "did-changes",
+                "card": {
+                  "header": {
+                    "title": "DID File Changes Detected",
+                    "subtitle": "Changes from release ${{ steps.check_release.outputs.release_tag }}"
+                  },
+                  "sections": [
+                    {
                       "header": "Findings",
                       "widgets": [
                         {
@@ -279,48 +356,14 @@ jobs:
                       "widgets": [
                         {
                           "textParagraph": {
-                            "text": "${{ steps.compare_did.outputs.has_changes == 'true' && fromJSON(steps.compare_did.outputs.changed_files) || '✅ No changes needed' }}"
+                            "text": "${{ fromJSON(steps.compare_did.outputs.changed_files) }}"
                           }
                         }
                       ]
                     },
                     {
-                      "header": "Actions Taken",
-                      "widgets": [
-                        {
-                          "decoratedText": {
-                            "topLabel": "Pull Request",
-                            "text": "${{ steps.compare_did.outputs.has_changes == 'true' && '✅ PR created for .did file updates' || 'ℹ️ No PR needed - no changes detected' }}"
-                          }
-                        }
-                      ]
-                    },
-                    {
-                      "widgets": [
-                        {
-                          "buttonList": {
-                            "buttons": [
-                              {
-                                "text": "View Release",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "${{ steps.check_release.outputs.release_url }}"
-                                  }
-                                },
-                                "icon": { "knownIcon": "BOOKMARK" }
-                              }
-                              ${{ steps.compare_did.outputs.has_changes == 'true' && ',{
-                                "text": "View PR",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "${{ steps.cpr.outputs.pull-request-url }}"
-                                  }
-                                }
-                              }' || '' }}
-                            ]
-                          }
-                        }
-                      ]
+                      "header": "Pull Request Status",
+                      "widgets": '"$PR_WIDGETS"'
                     }
                   ]
                 }
@@ -346,3 +389,4 @@ jobs:
           else
             echo "ℹ️ No changes needed"
           fi
+

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -219,7 +219,73 @@ jobs:
           curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
           -H "Content-Type: application/json" \
           -d '{
-            "text": "TEST: 🎉 *New Release Alert!*\n\n📦 **Hot-or-Not Backend Canister**\n🏷️ Release: ${{ steps.check_release.outputs.release_name }} (${{ steps.check_release.outputs.release_tag }})\n👤 Author: ${{ steps.check_release.outputs.author }}\n📅 Published: ${{ steps.check_release.outputs.published_at }}\n\n📝 **Release Notes:**\n${{ steps.check_release.outputs.release_body }}\n\n🔗 [View Release](${{ steps.check_release.outputs.release_url }})\n🔗 [Repository](https://github.com/dolr-ai/hot-or-not-backend-canister)"
+            "cardsV2": [
+              {
+                "cardId": "release-alert",
+                "card": {
+                  "header": {
+                    "title": "🎉 New Release Alert!",
+                    "subtitle": "Hot-or-Not Backend Canister"
+                  },
+                  "sections": [
+                    {
+                      "widgets": [
+                        {
+                          "decoratedText": {
+                            "topLabel": "Release",
+                            "text": "${{ steps.check_release.outputs.release_name }} ( ${{ steps.check_release.outputs.release_tag }} )"
+                          }
+                        },
+                        {
+                          "decoratedText": {
+                            "topLabel": "Author",
+                            "text": "${{ steps.check_release.outputs.author }}"
+                          }
+                        },
+                        {
+                          "decoratedText": {
+                            "topLabel": "Published",
+                            "text": "${{ steps.check_release.outputs.published_at }}"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "header": "Release Notes",
+                      "widgets": [
+                        { "textParagraph": { "text": "${{ steps.check_release.outputs.release_body }}" } }
+                      ]
+                    },
+                    {
+                      "widgets": [
+                        {
+                          "buttonList": {
+                            "buttons": [
+                              {
+                                "text": "View Release",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "${{ steps.check_release.outputs.release_url }}"
+                                  }
+                                }
+                              },
+                              {
+                                "text": "Repository",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "https://github.com/dolr-ai/hot-or-not-backend-canister"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
           }'
 
       - name: Log notification status

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -253,6 +253,15 @@ jobs:
           CHANGED_FILES_JSON=$(echo -e "$CHANGED_FILES" | sed '1d' | jq -Rs .)
           echo "changed_files=$CHANGED_FILES_JSON" >> $GITHUB_OUTPUT
 
+      - name: Process Release Notes
+        id: process_notes
+        run: |
+          # Convert release notes to proper markdown and clean up formatting
+          NOTES=$(echo '${{ steps.check_release.outputs.release_body }}' | sed 's/\\n/\n/g' | sed 's/^## /### /g')
+          echo "PROCESSED_NOTES<<EOF" >> $GITHUB_ENV
+          echo "$NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
       - name: Create Pull Request
         if: steps.compare_did.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
@@ -266,15 +275,24 @@ jobs:
           body: |
             This PR updates the .did files from the latest release.
 
-            Release: ${{ steps.check_release.outputs.release_name }}
-            Tag: ${{ steps.check_release.outputs.release_tag }}
-            Published: ${{ steps.check_release.outputs.published_at }}
-            Author: ${{ steps.check_release.outputs.author }}
+            ## Release Details
+            - **Release:** ${{ steps.check_release.outputs.release_name }}
+            - **Tag:** ${{ steps.check_release.outputs.release_tag }}
+            - **Published:** ${{ steps.check_release.outputs.published_at }}
+            - **Author:** ${{ steps.check_release.outputs.author }}
 
-            Release Notes:
-            ${{ steps.check_release.outputs.release_body }}
+            ## Release Notes
+            ${{ env.PROCESSED_NOTES }}
 
-            [View Release](${{ steps.check_release.outputs.release_url }})
+            ## Changes Summary
+            The following .did files were affected:
+            ${{ fromJSON(steps.compare_did.outputs.changed_files) }}
+
+            ## Breaking Changes Status
+            ${{ steps.compare_did.outputs.breaking_changes == 'true' && '⚠️ **Warning:** This update contains breaking changes!' || '✅ No breaking changes detected' }}
+
+            ---
+            [View Original Release](${{ steps.check_release.outputs.release_url }})
           branch: create-pull-request/update-did-files-${{ steps.check_release.outputs.release_tag }}
 
       - name: Send DID changes notification to Google Chat

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -267,7 +267,22 @@ jobs:
                       "header": "📝 Release Notes",
                       collapsible: true,
                       "widgets": [
-                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } }
+                        { "textParagraph": { "text": '"$RELEASE_NOTES"' } },
+                        {
+                          "buttonList": {
+                            "buttons": [
+                              {
+                                "text": "View Release",
+                                "onClick": {
+                                  "openLink": {
+                                    "url": "${{ steps.check_release.outputs.release_url }}"
+                                  }
+                                },
+                                "icon": { "knownIcon": "BOOKMARK" }
+                              }
+                            ]
+                          }
+                        }
                       ]
                     },
                     {
@@ -327,34 +342,6 @@ jobs:
                             ]
                           }
                         }' || '' }}
-                      ]
-                    },
-                    {
-                      "widgets": [
-                        {
-                          "buttonList": {
-                            "buttons": [
-                              {
-                                "text": "View Release",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "${{ steps.check_release.outputs.release_url }}"
-                                  }
-                                },
-                                "icon": { "knownIcon": "BOOKMARK" }
-                              },
-                              {
-                                "text": "Repository",
-                                "onClick": {
-                                  "openLink": {
-                                    "url": "https://github.com/dolr-ai/hot-or-not-backend-canister"
-                                  }
-                                },
-                                "icon": { "materialIcon": { "name": "code", "fill": true } }
-                              }
-                            ]
-                          }
-                        }
                       ]
                     }
                   ]

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -1,0 +1,92 @@
+name: Hot-or-Not Backend Release Monitor
+
+on:
+  push:
+  schedule:
+    # Check for new releases every 30 minutes (more frequent)
+    - cron: '*/30 * * * *'
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  check-releases:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Restore last notified release from cache
+        id: cache-release
+        uses: actions/cache/restore@v4
+        with:
+          path: last_release.txt
+          key: last-notified-release
+
+      - name: Check for new releases
+        id: check_release
+        run: |
+          # Get the latest release from the target repository
+          LATEST_RELEASE=$(curl -s "https://api.github.com/repos/dolr-ai/hot-or-not-backend-canister/releases/latest")
+          
+          # Extract release information
+          RELEASE_TAG=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
+          RELEASE_NAME=$(echo "$LATEST_RELEASE" | jq -r '.name')
+          RELEASE_URL=$(echo "$LATEST_RELEASE" | jq -r '.html_url')
+          RELEASE_BODY=$(echo "$LATEST_RELEASE" | jq -r '.body')
+          PUBLISHED_AT=$(echo "$LATEST_RELEASE" | jq -r '.published_at')
+          AUTHOR=$(echo "$LATEST_RELEASE" | jq -r '.author.login')
+          
+          echo "Latest release tag: $RELEASE_TAG"
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
+          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
+          echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
+          echo "published_at=$PUBLISHED_AT" >> $GITHUB_OUTPUT
+          echo "author=$AUTHOR" >> $GITHUB_OUTPUT
+          
+          # Escape newlines and quotes in release body for JSON
+          ESCAPED_BODY=$(echo "$RELEASE_BODY" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g' | head -c 500)
+          echo "release_body=$ESCAPED_BODY" >> $GITHUB_OUTPUT
+          
+          # Check if we've seen this release before
+          if [ -f "last_release.txt" ]; then
+            LAST_NOTIFIED=$(cat last_release.txt)
+            echo "Last notified release: $LAST_NOTIFIED"
+          else
+            LAST_NOTIFIED="v3.5.4"  # Initialize with current latest
+            echo "No previous notifications found, initializing with v3.5.4"
+          fi
+          
+          if [ "$RELEASE_TAG" != "$LAST_NOTIFIED" ] && [ "$RELEASE_TAG" != "null" ]; then
+            echo "New release detected!"
+            echo "new_release=true" >> $GITHUB_OUTPUT
+            
+            # Update the last notified release
+            echo "$RELEASE_TAG" > last_release.txt
+          else
+            echo "No new release"
+            echo "new_release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Save last notified release to cache
+        if: steps.check_release.outputs.new_release == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: last_release.txt
+          key: last-notified-release
+
+      - name: Send notification to Google Chat
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          curl -X POST "${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}" \
+          -H "Content-Type: application/json" \
+          -d '{
+            "text": "🎉 *New Release Alert!*\n\n📦 **Hot-or-Not Backend Canister**\n🏷️ Release: ${{ steps.check_release.outputs.release_name }} (${{ steps.check_release.outputs.release_tag }})\n👤 Author: ${{ steps.check_release.outputs.author }}\n📅 Published: ${{ steps.check_release.outputs.published_at }}\n\n📝 **Release Notes:**\n${{ steps.check_release.outputs.release_body }}\n\n🔗 [View Release](${{ steps.check_release.outputs.release_url }})\n🔗 [Repository](https://github.com/dolr-ai/hot-or-not-backend-canister)"
+          }'
+
+      - name: Log notification status
+        if: steps.check_release.outputs.new_release == 'true'
+        run: |
+          echo "✅ Notification sent for release ${{ steps.check_release.outputs.release_tag }}"

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -213,6 +213,24 @@ jobs:
 #            --base main \
 #            --label "$PR_LABELS"
 
+      - name: Process release notes for Google Chat
+        if: steps.check_release.outputs.new_release == 'true'
+        id: process_release_notes
+        run: |
+          set -euo pipefail
+          # Save the original release notes to a file
+          echo "${{ steps.check_release.outputs.release_body }}" > release_notes_raw.txt
+
+          # Convert headings (##,###) to <b>...</b>, remove GitHub PR/commit links, incomplete Markdown links, and empty lines
+          sed -E 's/^###? (.*)$/<b>\1<\/b>/g' release_notes_raw.txt | \
+            grep -vE 'https://github.com/dolr-ai/hot-or-not-backend-canister/(pull|commit)/' | \
+            grep -vE '\[.*\]\(https://github.com/dolr-ai/h$' | \
+            grep -vE '^\s*$' > release_notes_clean.txt || true
+
+          # Read cleaned notes into a variable, escape for JSON
+          CLEANED_NOTES=$(cat release_notes_clean.txt | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
+          echo "cleaned_body=$CLEANED_NOTES" >> $GITHUB_OUTPUT
+
       - name: Send notification to Google Chat
         if: steps.check_release.outputs.new_release == 'true'
         run: |
@@ -225,25 +243,30 @@ jobs:
                 "card": {
                   "header": {
                     "title": "🎉 New Release Alert!",
-                    "subtitle": "Hot-or-Not Backend Canister"
+                    "subtitle": "Hot-or-Not Backend Canister",
+                    "imageUrl": "https://avatars.githubusercontent.com/u/79742232?s=200&v=4",
+                    "imageType": "CIRCLE"
                   },
                   "sections": [
                     {
                       "widgets": [
                         {
                           "decoratedText": {
+                            "startIcon": { "knownIcon": "DESCRIPTION" },
                             "topLabel": "Release",
                             "text": "${{ steps.check_release.outputs.release_name }} ( ${{ steps.check_release.outputs.release_tag }} )"
                           }
                         },
                         {
                           "decoratedText": {
+                            "startIcon": { "knownIcon": "PERSON" },
                             "topLabel": "Author",
                             "text": "${{ steps.check_release.outputs.author }}"
                           }
                         },
                         {
                           "decoratedText": {
+                            "startIcon": { "knownIcon": "EVENT" },
                             "topLabel": "Published",
                             "text": "${{ steps.check_release.outputs.published_at }}"
                           }
@@ -251,9 +274,9 @@ jobs:
                       ]
                     },
                     {
-                      "header": "Release Notes",
+                      "header": "📝 Release Notes",
                       "widgets": [
-                        { "textParagraph": { "text": "${{ steps.check_release.outputs.release_body }}" } }
+                        { "textParagraph": { "text": "${{ steps.process_release_notes.outputs.cleaned_body }}" } }
                       ]
                     },
                     {
@@ -262,20 +285,22 @@ jobs:
                           "buttonList": {
                             "buttons": [
                               {
-                                "text": "View Release",
+                                "text": "🔗 View Release",
                                 "onClick": {
                                   "openLink": {
                                     "url": "${{ steps.check_release.outputs.release_url }}"
                                   }
-                                }
+                                },
+                                "icon": { "knownIcon": "BOOKMARK" }
                               },
                               {
-                                "text": "Repository",
+                                "text": "📦 Repository",
                                 "onClick": {
                                   "openLink": {
                                     "url": "https://github.com/dolr-ai/hot-or-not-backend-canister"
                                   }
-                                }
+                                },
+                                "icon": { "materialIcon": { "name": "code", "fill": true } }
                               }
                             ]
                           }

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -133,8 +133,10 @@ jobs:
               if [ -f "$local_file" ]; then
                 echo "Comparing $(basename $did_file)..."
                 # Run didc check and capture both output and exit code
+                set +e  # Disable exit on error
                 DIFF_OUTPUT=$(didc check "$local_file" "$did_file" 2>&1)
                 DIFF_EXIT_CODE=$?
+                set -e  # Re-enable exit on error
                 
                 if [ $DIFF_EXIT_CODE -ne 0 ]; then
                   echo "❌ Breaking changes detected in $(basename $did_file):"

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -134,7 +134,7 @@ jobs:
                 echo "Comparing $(basename $did_file)..."
                 # Run didc check and capture both output and exit code
                 set +e  # Disable exit on error
-                DIFF_OUTPUT=$(didc check "$local_file" "$did_file" 2>&1)
+                DIFF_OUTPUT=$(didc check "$did_file" "$local_file" 2>&1)
                 DIFF_EXIT_CODE=$?
                 set -e  # Re-enable exit on error
                 

--- a/.github/workflows/did-notifier.yml
+++ b/.github/workflows/did-notifier.yml
@@ -20,12 +20,12 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history for proper versioning
 
-      - name: Restore last notified release from cache
-        id: cache-release
-        uses: actions/cache/restore@v4
-        with:
-          path: last_release.txt
-          key: last-notified-release
+#      - name: Restore last notified release from cache
+#        id: cache-release
+#        uses: actions/cache/restore@v4
+#        with:
+#          path: last_release.txt
+#          key: last-notified-release
 
       - name: Check for new releases
         id: check_release
@@ -72,12 +72,12 @@ jobs:
             echo "new_release=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Save last notified release to cache
-        if: steps.check_release.outputs.new_release == 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: last_release.txt
-          key: last-notified-release
+#      - name: Save last notified release to cache
+#        if: steps.check_release.outputs.new_release == 'true'
+#        uses: actions/cache/save@v4
+#        with:
+#          path: last_release.txt
+#          key: last-notified-release
 
       - name: Install didc tool
         if: steps.check_release.outputs.new_release == 'true'

--- a/shared/rust/rust-agent-uniffi/did/individual_user_template.did
+++ b/shared/rust/rust-agent-uniffi/did/individual_user_template.did
@@ -1,0 +1,669 @@
+type AggregateStats = record {
+  total_number_of_not_bets : nat64;
+  total_amount_bet : nat64;
+  total_number_of_hot_bets : nat64;
+};
+type AirdropDistribution = record { airdrop_neurons : vec NeuronDistribution };
+type AirdropError = variant {
+  NoBalance;
+  CanisterPrincipalDoNotMatch;
+  AlreadyClaimedAirdrop;
+  RequestedAmountTooLow;
+  InvalidRoot;
+  CallError : record { RejectionCode; text };
+  Transfer : TransferError;
+};
+type AirdropInfo = record {
+  principals_who_successfully_claimed : vec record { principal; ClaimStatus };
+};
+type BetDetails = record {
+  bet_direction : BetDirection;
+  bet_maker_canister_id : principal;
+  bet_maker_informed_status : opt BetMakerInformedStatus;
+  amount : nat64;
+  payout : BetPayout;
+};
+type BetDirection = variant { Hot; Not };
+type BetMakerInformedStatus = variant { InformedSuccessfully; Failed : text };
+type BetOnCurrentlyViewingPostError = variant {
+  UserPrincipalNotSet;
+  InsufficientBalance;
+  UserAlreadyParticipatedInThisPost;
+  BettingClosed;
+  Unauthorized;
+  PostCreatorCanisterCallFailed;
+  UserNotLoggedIn;
+};
+type BetOutcomeForBetMaker = variant {
+  Won : nat64;
+  Draw : nat64;
+  Lost;
+  AwaitingResult;
+};
+type BetPayout = variant { NotCalculatedYet; Calculated : nat64 };
+type BettingStatus = variant {
+  BettingOpen : record {
+    number_of_participants : nat8;
+    ongoing_room : nat64;
+    ongoing_slot : nat8;
+    has_this_user_participated_in_this_post : opt bool;
+    started_at : SystemTime;
+  };
+  BettingClosed;
+};
+type Canister = record { id : opt principal };
+type CdaoDeployError = variant {
+  CycleError : text;
+  Unregistered;
+  CallError : record { RejectionCode; text };
+  InvalidInitPayload : text;
+  TokenLimit : nat64;
+  Unauthenticated;
+};
+type CdaoTokenError = variant {
+  NoBalance;
+  InvalidRoot;
+  CallError : record { RejectionCode; text };
+  Transfer : TransferError;
+  Unauthenticated;
+};
+type ClaimStatus = variant { Unclaimed; Claiming; Claimed };
+type Committed = record {
+  total_direct_participation_icp_e8s : opt nat64;
+  total_neurons_fund_participation_icp_e8s : opt nat64;
+  sns_governance_canister_id : opt principal;
+};
+type Countries = record { iso_codes : vec text };
+type DappCanisters = record { canisters : vec Canister };
+type DeployedCdaoCanisters = record {
+  airdrop_info : AirdropInfo;
+  root : principal;
+  swap : principal;
+  ledger : principal;
+  index : principal;
+  governance : principal;
+};
+type DeveloperDistribution = record {
+  developer_neurons : vec NeuronDistribution;
+};
+type DeviceIdentity = record { device_id : text; timestamp : nat64 };
+type FeedScore = record {
+  current_score : nat64;
+  last_synchronized_at : SystemTime;
+  last_synchronized_score : nat64;
+};
+type FollowAnotherUserProfileError = variant {
+  UserITriedToFollowCrossCanisterCallFailed;
+  UsersICanFollowListIsFull;
+  Unauthorized;
+  UserITriedToFollowHasTheirFollowersListFull;
+  Unauthenticated;
+};
+type FollowEntryDetail = record {
+  canister_id : principal;
+  principal_id : principal;
+};
+type FolloweeArg = record {
+  followee_canister_id : principal;
+  followee_principal_id : principal;
+};
+type FollowerArg = record {
+  follower_canister_id : principal;
+  follower_principal_id : principal;
+};
+type FractionalDeveloperVotingPower = record {
+  treasury_distribution : opt TreasuryDistribution;
+  developer_distribution : opt DeveloperDistribution;
+  airdrop_distribution : opt AirdropDistribution;
+  swap_distribution : opt SwapDistribution;
+};
+type GetPostsOfUserProfileError = variant {
+  ReachedEndOfItemsList;
+  InvalidBoundsPassed;
+  ExceededMaxNumberOfItemsAllowedInOneRequest;
+};
+type GovernanceError = record { error_message : text; error_type : int32 };
+type HotOrNotDetails = record {
+  hot_or_not_feed_score : FeedScore;
+  aggregate_stats : AggregateStats;
+  slot_history : vec record { nat8; SlotDetails };
+};
+type HotOrNotOutcomePayoutEvent = variant {
+  WinningsEarnedFromBet : record {
+    slot_id : nat8;
+    post_id : nat64;
+    room_id : nat64;
+    post_canister_id : principal;
+    winnings_amount : nat64;
+    event_outcome : BetOutcomeForBetMaker;
+  };
+  CommissionFromHotOrNotBet : record {
+    slot_id : nat8;
+    post_id : nat64;
+    room_pot_total_amount : nat64;
+    room_id : nat64;
+    post_canister_id : principal;
+  };
+};
+type HttpRequest = record {
+  url : text;
+  method : text;
+  body : blob;
+  headers : vec record { text; text };
+};
+type HttpResponse = record {
+  body : blob;
+  headers : vec record { text; text };
+  status_code : nat16;
+};
+type IdealMatchedParticipationFunction = record {
+  serialized_representation : opt text;
+};
+type IndividualUserTemplateInitArgs = record {
+  known_principal_ids : opt vec record { KnownPrincipalType; principal };
+  version : text;
+  url_to_send_canister_metrics_to : opt text;
+  profile_owner : opt principal;
+  upgrade_version_number : opt nat64;
+};
+type InitialTokenDistribution = variant {
+  FractionalDeveloperVotingPower : FractionalDeveloperVotingPower;
+};
+type KnownPrincipalType = variant {
+  CanisterIdUserIndex;
+  CanisterIdPlatformOrchestrator;
+  CanisterIdConfiguration;
+  CanisterIdHotOrNotSubnetOrchestrator;
+  CanisterIdProjectMemberIndex;
+  CanisterIdTopicCacheIndex;
+  CanisterIdRootCanister;
+  CanisterIdDataBackup;
+  CanisterIdSnsWasm;
+  CanisterIdPostCache;
+  CanisterIdSNSController;
+  CanisterIdSnsGovernance;
+  UserIdGlobalSuperAdmin;
+};
+type LinearScalingCoefficient = record {
+  slope_numerator : opt nat64;
+  intercept_icp_e8s : opt nat64;
+  from_direct_participation_icp_e8s : opt nat64;
+  slope_denominator : opt nat64;
+  to_direct_participation_icp_e8s : opt nat64;
+};
+type MLFeedCacheItem = record {
+  post_id : nat64;
+  canister_id : principal;
+  video_id : text;
+  creator_principal_id : opt principal;
+};
+type MigrationErrors = variant {
+  InvalidToCanister;
+  InvalidFromCanister;
+  MigrationInfoNotFound;
+  UserNotRegistered;
+  RequestCycleFromUserIndexFailed : text;
+  UserIndexCanisterIdNotFound;
+  Unauthorized;
+  TransferToCanisterCallFailed : text;
+  HotOrNotSubnetCanisterIdNotFound;
+  AlreadyUsedForMigration;
+  CanisterInfoFailed;
+  AlreadyMigrated;
+};
+type MigrationInfo = variant {
+  MigratedFromHotOrNot : record { account_principal : principal };
+  NotMigrated;
+  MigratedToYral : record { account_principal : principal };
+};
+type MintEvent = variant {
+  NewUserSignup : record { new_user_principal_id : principal };
+  Referral : record {
+    referrer_user_principal_id : principal;
+    referee_user_principal_id : principal;
+  };
+};
+type NamespaceErrors = variant {
+  UserNotSignedUp;
+  ValueTooBig;
+  NamespaceNotFound;
+  Unauthorized;
+};
+type NamespaceForFrontend = record {
+  id : nat64;
+  title : text;
+  owner_id : principal;
+};
+type NeuronBasketConstructionParameters = record {
+  dissolve_delay_interval_seconds : nat64;
+  count : nat64;
+};
+type NeuronDistribution = record {
+  controller : opt principal;
+  dissolve_delay_seconds : nat64;
+  memo : nat64;
+  stake_e8s : nat64;
+  vesting_period_seconds : opt nat64;
+};
+type NeuronsFundNeuron = record {
+  controller : opt principal;
+  hotkeys : opt Principals;
+  is_capped : opt bool;
+  nns_neuron_id : opt nat64;
+  amount_icp_e8s : opt nat64;
+};
+type NeuronsFundParticipationConstraints = record {
+  coefficient_intervals : vec LinearScalingCoefficient;
+  max_neurons_fund_participation_icp_e8s : opt nat64;
+  min_direct_participation_threshold_icp_e8s : opt nat64;
+  ideal_matched_participation_function : opt IdealMatchedParticipationFunction;
+};
+type Ok = record { neurons_fund_neuron_portions : vec NeuronsFundNeuron };
+type PaginationError = variant {
+  ReachedEndOfItemsList;
+  InvalidBoundsPassed;
+  ExceededMaxNumberOfItemsAllowedInOneRequest;
+};
+type PlaceBetArg = record {
+  bet_amount : nat64;
+  post_id : nat64;
+  bet_direction : BetDirection;
+  post_canister_id : principal;
+};
+type PlacedBetDetail = record {
+  outcome_received : BetOutcomeForBetMaker;
+  slot_id : nat8;
+  post_id : nat64;
+  room_id : nat64;
+  canister_id : principal;
+  bet_direction : BetDirection;
+  amount_bet : nat64;
+  bet_placed_at : SystemTime;
+};
+type Post = record {
+  id : nat64;
+  is_nsfw : bool;
+  status : PostStatus;
+  share_count : nat64;
+  hashtags : vec text;
+  description : text;
+  created_at : SystemTime;
+  likes : vec principal;
+  video_uid : text;
+  home_feed_score : FeedScore;
+  slots_left_to_be_computed : blob;
+  view_stats : PostViewStatistics;
+  hot_or_not_details : opt HotOrNotDetails;
+};
+type PostDetailsForFrontend = record {
+  id : nat64;
+  is_nsfw : bool;
+  status : PostStatus;
+  home_feed_ranking_score : nat64;
+  hashtags : vec text;
+  hot_or_not_betting_status : opt BettingStatus;
+  like_count : nat64;
+  description : text;
+  total_view_count : nat64;
+  created_by_display_name : opt text;
+  created_at : SystemTime;
+  created_by_unique_user_name : opt text;
+  video_uid : text;
+  created_by_user_principal_id : principal;
+  hot_or_not_feed_ranking_score : opt nat64;
+  liked_by_me : bool;
+  created_by_profile_photo_url : opt text;
+};
+type PostDetailsFromFrontend = record {
+  is_nsfw : bool;
+  hashtags : vec text;
+  description : text;
+  video_uid : text;
+  creator_consent_for_inclusion_in_hot_or_not : bool;
+};
+type PostStatus = variant {
+  BannedForExplicitness;
+  BannedDueToUserReporting;
+  Uploaded;
+  CheckingExplicitness;
+  ReadyToView;
+  Transcoding;
+  Deleted;
+};
+type PostViewDetailsFromFrontend = variant {
+  WatchedMultipleTimes : record {
+    percentage_watched : nat8;
+    watch_count : nat8;
+  };
+  WatchedPartially : record { percentage_watched : nat8 };
+};
+type PostViewStatistics = record {
+  total_view_count : nat64;
+  average_watch_percentage : nat8;
+  threshold_view_count : nat64;
+};
+type Principals = record { principals : vec principal };
+type RejectionCode = variant {
+  NoError;
+  CanisterError;
+  SysTransient;
+  DestinationInvalid;
+  Unknown;
+  SysFatal;
+  CanisterReject;
+};
+type Result = variant { Ok : bool; Err : text };
+type Result_1 = variant { Ok : nat64; Err : text };
+type Result_10 = variant { Ok : Post; Err };
+type Result_11 = variant { Ok : SystemTime; Err : text };
+type Result_12 = variant {
+  Ok : vec PostDetailsForFrontend;
+  Err : GetPostsOfUserProfileError;
+};
+type Result_13 = variant { Ok : SessionType; Err : text };
+type Result_14 = variant { Ok : vec SuccessHistoryItemV1; Err : text };
+type Result_15 = variant { Ok : vec principal; Err : PaginationError };
+type Result_16 = variant {
+  Ok : vec record { nat64; TokenEvent };
+  Err : PaginationError;
+};
+type Result_17 = variant { Ok : vec WatchHistoryItem; Err : text };
+type Result_18 = variant { Ok : vec text; Err : NamespaceErrors };
+type Result_19 = variant { Ok : vec record { nat64; nat8 }; Err : text };
+type Result_2 = variant { Ok : bool; Err : CdaoTokenError };
+type Result_20 = variant { Ok; Err : MigrationErrors };
+type Result_21 = variant { Ok; Err : AirdropError };
+type Result_22 = variant { Committed : Committed; Aborted : record {} };
+type Result_23 = variant { Ok : Ok; Err : GovernanceError };
+type Result_24 = variant { Ok; Err : CdaoTokenError };
+type Result_25 = variant { Ok : text; Err : text };
+type Result_26 = variant {
+  Ok : UserProfileDetailsForFrontend;
+  Err : UpdateProfileDetailsError;
+};
+type Result_27 = variant { Ok; Err : text };
+type Result_28 = variant { Ok; Err : UpdateProfileSetUniqueUsernameError };
+type Result_3 = variant {
+  Ok : BettingStatus;
+  Err : BetOnCurrentlyViewingPostError;
+};
+type Result_4 = variant { Ok : NamespaceForFrontend; Err : NamespaceErrors };
+type Result_5 = variant { Ok : opt text; Err : NamespaceErrors };
+type Result_6 = variant { Ok; Err : NamespaceErrors };
+type Result_7 = variant { Ok : DeployedCdaoCanisters; Err : CdaoDeployError };
+type Result_8 = variant { Ok : bool; Err : FollowAnotherUserProfileError };
+type Result_9 = variant { Ok : BetDetails; Err : text };
+type RoomBetPossibleOutcomes = variant { HotWon; BetOngoing; Draw; NotWon };
+type RoomDetails = record {
+  total_hot_bets : nat64;
+  bets_made : vec record { principal; BetDetails };
+  total_not_bets : nat64;
+  room_bets_total_pot : nat64;
+  bet_outcome : RoomBetPossibleOutcomes;
+};
+type SessionType = variant { AnonymousSession; RegisteredSession };
+type SettleNeuronsFundParticipationRequest = record {
+  result : opt Result_22;
+  nns_proposal_id : opt nat64;
+};
+type SettleNeuronsFundParticipationResponse = record { result : opt Result_23 };
+type SlotDetails = record { room_details : vec record { nat64; RoomDetails } };
+type SnsInitPayload = record {
+  url : opt text;
+  max_dissolve_delay_seconds : opt nat64;
+  max_dissolve_delay_bonus_percentage : opt nat64;
+  nns_proposal_id : opt nat64;
+  neurons_fund_participation : opt bool;
+  min_participant_icp_e8s : opt nat64;
+  neuron_basket_construction_parameters : opt NeuronBasketConstructionParameters;
+  fallback_controller_principal_ids : vec text;
+  token_symbol : opt text;
+  final_reward_rate_basis_points : opt nat64;
+  max_icp_e8s : opt nat64;
+  neuron_minimum_stake_e8s : opt nat64;
+  confirmation_text : opt text;
+  logo : opt text;
+  name : opt text;
+  swap_start_timestamp_seconds : opt nat64;
+  swap_due_timestamp_seconds : opt nat64;
+  initial_voting_period_seconds : opt nat64;
+  neuron_minimum_dissolve_delay_to_vote_seconds : opt nat64;
+  description : opt text;
+  max_neuron_age_seconds_for_age_bonus : opt nat64;
+  min_participants : opt nat64;
+  initial_reward_rate_basis_points : opt nat64;
+  wait_for_quiet_deadline_increase_seconds : opt nat64;
+  transaction_fee_e8s : opt nat64;
+  dapp_canisters : opt DappCanisters;
+  neurons_fund_participation_constraints : opt NeuronsFundParticipationConstraints;
+  max_age_bonus_percentage : opt nat64;
+  initial_token_distribution : opt InitialTokenDistribution;
+  reward_rate_transition_duration_seconds : opt nat64;
+  token_logo : opt text;
+  token_name : opt text;
+  max_participant_icp_e8s : opt nat64;
+  min_direct_participation_icp_e8s : opt nat64;
+  proposal_reject_cost_e8s : opt nat64;
+  restricted_countries : opt Countries;
+  min_icp_e8s : opt nat64;
+  max_direct_participation_icp_e8s : opt nat64;
+};
+type StakeEvent = variant { BetOnHotOrNotPost : PlaceBetArg };
+type SuccessHistoryItemV1 = record {
+  post_id : nat64;
+  percentage_watched : float32;
+  item_type : text;
+  publisher_canister_id : principal;
+  cf_video_id : text;
+  interacted_at : SystemTime;
+};
+type SwapDistribution = record {
+  total_e8s : nat64;
+  initial_swap_amount_e8s : nat64;
+};
+type SystemTime = record {
+  nanos_since_epoch : nat32;
+  secs_since_epoch : nat64;
+};
+type TokenEvent = variant {
+  Stake : record {
+    timestamp : SystemTime;
+    details : StakeEvent;
+    amount : nat64;
+  };
+  Burn;
+  Mint : record { timestamp : SystemTime; details : MintEvent; amount : nat64 };
+  Transfer : record {
+    to_account : principal;
+    timestamp : SystemTime;
+    amount : nat64;
+  };
+  HotOrNotOutcomePayout : record {
+    timestamp : SystemTime;
+    details : HotOrNotOutcomePayoutEvent;
+    amount : nat64;
+  };
+  Receive : record {
+    from_account : principal;
+    timestamp : SystemTime;
+    amount : nat64;
+  };
+};
+type TransferError = variant {
+  GenericError : record { message : text; error_code : nat };
+  TemporarilyUnavailable;
+  BadBurn : record { min_burn_amount : nat };
+  Duplicate : record { duplicate_of : nat };
+  BadFee : record { expected_fee : nat };
+  CreatedInFuture : record { ledger_time : nat64 };
+  TooOld;
+  InsufficientFunds : record { balance : nat };
+};
+type TreasuryDistribution = record { total_e8s : nat64 };
+type UpdateProfileDetailsError = variant { NotAuthorized };
+type UpdateProfileSetUniqueUsernameError = variant {
+  UsernameAlreadyTaken;
+  UserIndexCrossCanisterCallFailed;
+  SendingCanisterDoesNotMatchUserCanisterId;
+  NotAuthorized;
+  UserCanisterEntryDoesNotExist;
+};
+type UserCanisterDetails = record {
+  user_canister_id : principal;
+  profile_owner : principal;
+};
+type UserProfileDetailsForFrontend = record {
+  unique_user_name : opt text;
+  lifetime_earnings : nat64;
+  following_count : nat64;
+  profile_picture_url : opt text;
+  display_name : opt text;
+  principal_id : principal;
+  profile_stats : UserProfileGlobalStats;
+  followers_count : nat64;
+  referrer_details : opt UserCanisterDetails;
+};
+type UserProfileDetailsForFrontendV2 = record {
+  unique_user_name : opt text;
+  lifetime_earnings : nat64;
+  migration_info : MigrationInfo;
+  following_count : nat64;
+  profile_picture_url : opt text;
+  display_name : opt text;
+  principal_id : principal;
+  profile_stats : UserProfileGlobalStats;
+  followers_count : nat64;
+  referrer_details : opt UserCanisterDetails;
+};
+type UserProfileGlobalStats = record {
+  hot_bets_received : nat64;
+  not_bets_received : nat64;
+};
+type UserProfileUpdateDetailsFromFrontend = record {
+  profile_picture_url : opt text;
+  display_name : opt text;
+};
+type WatchHistoryItem = record {
+  post_id : nat64;
+  viewed_at : SystemTime;
+  percentage_watched : float32;
+  publisher_canister_id : principal;
+  cf_video_id : text;
+};
+service : {
+  add_device_id : (text) -> (Result);
+  add_post_v2 : (PostDetailsFromFrontend) -> (Result_1);
+  add_token : (principal) -> (Result_2);
+  bet_on_currently_viewing_post : (PlaceBetArg) -> (Result_3);
+  check_and_update_scores_and_share_with_post_cache_if_difference_beyond_threshold : (
+      vec nat64,
+    ) -> ();
+  clear_snapshot : () -> ();
+  create_a_namespace : (text) -> (Result_4);
+  delete_key_value_pair : (nat64, text) -> (Result_5);
+  delete_multiple_key_value_pairs : (nat64, vec text) -> (Result_6);
+  deploy_cdao_sns : (SnsInitPayload, nat64) -> (Result_7);
+  deployed_cdao_canisters : () -> (vec DeployedCdaoCanisters) query;
+  do_i_follow_this_user : (FolloweeArg) -> (Result_8) query;
+  download_snapshot : (nat64, nat64) -> (blob) query;
+  get_bet_details_for_a_user_on_a_post : (principal, nat64) -> (Result_9) query;
+  get_device_identities : () -> (vec DeviceIdentity) query;
+  get_entire_individual_post_detail_by_id : (nat64) -> (Result_10) query;
+  get_hot_or_not_bet_details_for_this_post : (nat64) -> (BettingStatus) query;
+  get_hot_or_not_bets_placed_by_this_profile_with_pagination : (nat64) -> (
+      vec PlacedBetDetail,
+    ) query;
+  get_individual_hot_or_not_bet_placed_by_this_profile : (principal, nat64) -> (
+      opt PlacedBetDetail,
+    ) query;
+  get_individual_post_details_by_id : (nat64) -> (PostDetailsForFrontend) query;
+  get_last_access_time : () -> (Result_11) query;
+  get_last_canister_functionality_access_time : () -> (Result_11) query;
+  get_ml_feed_cache_paginated : (nat64, nat64) -> (vec MLFeedCacheItem) query;
+  get_posts_of_this_user_profile_with_pagination : (nat64, nat64) -> (
+      Result_12,
+    ) query;
+  get_posts_of_this_user_profile_with_pagination_cursor : (nat64, nat64) -> (
+      Result_12,
+    ) query;
+  get_principals_that_follow_this_profile_paginated : (opt nat64) -> (
+      vec record { nat64; FollowEntryDetail },
+    ) query;
+  get_principals_this_profile_follows_paginated : (opt nat64) -> (
+      vec record { nat64; FollowEntryDetail },
+    ) query;
+  get_profile_details : () -> (UserProfileDetailsForFrontend) query;
+  get_profile_details_v2 : () -> (UserProfileDetailsForFrontendV2) query;
+  get_rewarded_for_referral : (principal, principal) -> ();
+  get_rewarded_for_signing_up : () -> ();
+  get_session_type : () -> (Result_13) query;
+  get_stable_memory_size : () -> (nat64) query;
+  get_success_history : () -> (Result_14) query;
+  get_token_roots_of_this_user_with_pagination_cursor : (nat64, nat64) -> (
+      Result_15,
+    ) query;
+  get_user_caniser_cycle_balance : () -> (nat) query;
+  get_user_propensity : () -> (float64) query;
+  get_user_utility_token_transaction_history_with_pagination : (
+      nat64,
+      nat64,
+    ) -> (Result_16) query;
+  get_utility_token_balance : () -> (nat64) query;
+  get_version : () -> (text) query;
+  get_version_number : () -> (nat64) query;
+  get_watch_history : () -> (Result_17) query;
+  get_well_known_principal_value : (KnownPrincipalType) -> (
+      opt principal,
+    ) query;
+  http_request : (HttpRequest) -> (HttpResponse) query;
+  list_namespace_keys : (nat64) -> (Result_18) query;
+  list_namespaces : (nat64, nat64) -> (vec NamespaceForFrontend) query;
+  load_snapshot : (nat64) -> ();
+  once_reenqueue_timers_for_pending_bet_outcomes : () -> (Result_19);
+  read_key_value_pair : (nat64, text) -> (Result_5) query;
+  receive_and_save_snaphot : (nat64, blob) -> ();
+  receive_bet_from_bet_makers_canister : (PlaceBetArg, principal) -> (Result_3);
+  receive_bet_winnings_when_distributed : (nat64, BetOutcomeForBetMaker) -> ();
+  receive_data_from_hotornot : (principal, nat64, vec Post) -> (Result_20);
+  request_airdrop : (principal, opt blob, nat, principal) -> (Result_21);
+  return_cycles_to_user_index_canister : (opt nat) -> ();
+  save_snapshot_json : () -> (nat32);
+  set_controller_as_subnet_orchestrator : (principal) -> ();
+  settle_neurons_fund_participation : (
+      SettleNeuronsFundParticipationRequest,
+    ) -> (SettleNeuronsFundParticipationResponse);
+  transfer_token_to_user_canister : (principal, principal, opt blob, nat) -> (
+      Result_24,
+    );
+  transfer_tokens_and_posts : (principal, principal) -> (Result_20);
+  update_last_access_time : () -> (Result_25);
+  update_last_canister_functionality_access_time : () -> ();
+  update_ml_feed_cache : (vec MLFeedCacheItem) -> (Result_25);
+  update_post_add_view_details : (nat64, PostViewDetailsFromFrontend) -> ();
+  update_post_as_ready_to_view : (nat64) -> ();
+  update_post_increment_share_count : (nat64) -> (nat64);
+  update_post_status : (nat64, PostStatus) -> ();
+  update_post_toggle_like_status_by_caller : (nat64) -> (bool);
+  update_profile_display_details : (UserProfileUpdateDetailsFromFrontend) -> (
+      Result_26,
+    );
+  update_profile_owner : (opt principal) -> (Result_27);
+  update_profile_set_unique_username_once : (text) -> (Result_28);
+  update_profiles_i_follow_toggle_list_with_specified_profile : (
+      FolloweeArg,
+    ) -> (Result_8);
+  update_profiles_that_follow_me_toggle_list_with_specified_profile : (
+      FollowerArg,
+    ) -> (Result_8);
+  update_referrer_details : (UserCanisterDetails) -> (Result_25);
+  update_session_type : (SessionType) -> (Result_25);
+  update_success_history : (SuccessHistoryItemV1) -> (Result_25);
+  update_user_propensity : (float64) -> (Result_25);
+  update_watch_history : (WatchHistoryItem) -> (Result_25);
+  update_well_known_principal : (KnownPrincipalType, principal) -> ();
+  upgrade_creator_dao_governance_canisters : (blob) -> (Result_27);
+  write_key_value_pair : (nat64, text, text) -> (Result_5);
+  write_multiple_key_value_pairs : (nat64, vec record { text; text }) -> (
+      Result_6,
+    );
+}


### PR DESCRIPTION
This PR implements a comprehensive GitHub workflow to monitor Hot-or-Not Backend releases and manage DID file updates. The workflow includes:

### New Features
- Automated daily checks for new backend releases
- Release notification system via Google Chat
- DID file comparison and management
- Automated PR creation for DID file updates
- Detailed GitHub summary generation for each workflow run

### Workflow Components
1. **Release Monitoring**
   - Daily scheduled checks for new releases
   - Manual trigger support via workflow_dispatch
   - Caching mechanism for processed releases

2. **Notification System**
   - Google Chat integration for release notifications
   - Detailed DID changes notifications
   - Comprehensive release information including:
     - Release name, tag, and URL
     - Publication date and author
     - Release notes
     - Breaking changes status

3. **DID File Management**
   - Automated download and comparison of DID files
   - Detection of breaking changes
   - Tracking of new and modified files
   - Automated PR creation for necessary updates

4. **GitHub Summary**
   - Detailed release information
   - DID changes analysis
   - PR status and links
   - Breaking changes indicators

### Security
- Proper permission scoping for repository access
- Secure handling of webhook URLs via secrets

This workflow ensures timely updates and proper management of DID files while keeping the team informed of all changes through automated notifications.