### PR TITLE
fix: Player stuck when scrolling

### DIFF
--- a/shared/libs/videoPlayer/src/androidMain/kotlin/com/yral/shared/libs/videoPlayer/pool/PlayerPool.android.kt
+++ b/shared/libs/videoPlayer/src/androidMain/kotlin/com/yral/shared/libs/videoPlayer/pool/PlayerPool.android.kt
@@ -41,19 +41,6 @@ actual class PlayerPool(
 
     actual suspend fun getPlayer(url: String): PlatformPlayer =
         mutex.withLock {
-            // First, check if we already have a player for this URL (even if marked as not in use)
-            val existingPlayer = pool.find { it.currentUrl == url }
-            if (existingPlayer != null) {
-                // Reuse the existing player for this URL
-                if (!existingPlayer.isInUse) {
-                    existingPlayer.isInUse = true
-                    // Move to end of pool (most recently used)
-                    pool.remove(existingPlayer)
-                    pool.add(existingPlayer)
-                }
-                return@withLock existingPlayer.platformPlayer
-            }
-
             // Find available player or create new one
             val availablePlayer = pool.find { !it.isInUse }
 


### PR DESCRIPTION
Removes finding existing player since it remains in paused state, this was added to avoid duplicate performance tracing but it is handled differently now