### PR TITLE
Displays FCM notifications as toasts for foregrounded app

### DIFF
--- a/androidApp/src/main/kotlin/com/yral/android/MyFirebaseMessagingService.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/MyFirebaseMessagingService.kt
@@ -4,6 +4,9 @@ import androidx.annotation.WorkerThread
 import co.touchlab.kermit.Logger
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.yral.android.ui.components.ToastManager
+import com.yral.android.ui.components.ToastStatus
+import com.yral.android.ui.components.ToastType
 import com.yral.shared.features.auth.domain.useCases.RegisterNotificationTokenUseCase
 import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.android.inject
@@ -18,8 +21,40 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     override fun onMessageReceived(message: RemoteMessage) {
-        Logger.d("MyFirebaseMessagingService") { "onMessageReceived: $message" }
+        Logger.d("MyFirebaseMessagingService") {
+            "onMessageReceived: ${message.notification?.clickAction}"
+        }
+
+        if (message.notification != null) {
+            // notification messages are received here only when app is in foreground
+            showToastForForegroundMessage(message)
+        }
+
         super.onMessageReceived(message)
+    }
+
+    private fun showToastForForegroundMessage(message: RemoteMessage) {
+        val notification = message.notification
+        if (notification != null) {
+            val title = notification.title
+            val body = notification.body
+            val toastType =
+                if (title != null && body != null) {
+                    ToastType.Big(title, body)
+                } else {
+                    val message = title ?: body
+                    if (message != null) {
+                        ToastType.Small(message)
+                    } else {
+                        return
+                    }
+                }
+
+            ToastManager.showToast(
+                type = toastType,
+                status = ToastStatus.Success, // currently we don't have any information about status
+            )
+        }
     }
 
     private fun sendTokenToServer(token: String) =


### PR DESCRIPTION
From [FCM doc](https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages)

> FCM SDK displays the message to end-user devices on behalf of the client app when it's running in the background. Otherwise, if the app is running in the foreground when the notification is received, the app's code determines the behavior. Notification messages have a predefined set of user-visible keys and an optional data payload of custom key-value pairs.
