### PR TITLE
Refactor: Removes intent nullification after handling

### DIFF
--- a/androidApp/src/main/kotlin/com/yral/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/MainActivity.kt
@@ -70,7 +70,6 @@ class MainActivity : ComponentActivity() {
     // Shared Branch session callback for both init() and reInit()
     private val branchSessionCallback: (BranchUniversalObject?, LinkProperties?, BranchError?) -> Unit =
         { branchUniversalObject, linkProperties, error ->
-            intent = null
             if (error != null) {
                 Logger.d("BranchSDK") { "branch session error: " + error.message }
             } else {
@@ -159,7 +158,6 @@ class MainActivity : ComponentActivity() {
         // Handle OAuth redirect URIs
         handleOAuthIntent(intent)?.let {
             oAuthUtils.invokeCallback(it)
-            setIntent(null)
             return
         }
 
@@ -169,7 +167,6 @@ class MainActivity : ComponentActivity() {
             Logger.d("MainActivity") { "Handling notification payload: $payload" }
             val destination = mapPayloadToDestination(payload)
             if (destination != null) {
-                setIntent(null)
                 handleNotificationDeepLink(destination)
             }
         }


### PR DESCRIPTION
Fixes NPE on android 11 and 12
- https://issuetracker.google.com/issues/240585930
- https://github.com/BranchMetrics/android-branch-deep-linking-attribution/issues/1277

No need to set intent to null as branch internally handles duplicate intent requests

https://console.firebase.google.com/project/yral-mobile/crashlytics/app/android:com.yral.android.app/issues/c6a665b6b1a9d34294d5d5f1b7aeb637?time=last-seven-days&types=crash&versions=1.7.0%20(18);1.7.0%20(17)&sessionEventKey=68C97CAB02D000016E4550ED49E077F3_2129149683290142689