### PR TITLE
Refactor: Moves UI components to design system module

### DIFF
--- a/androidApp/src/main/kotlin/com/yral/android/ui/components/DeleteConfirmationSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/components/DeleteConfirmationSheet.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.yral.android.ui.widgets.YralBottomSheet
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.component.YralButton
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/RootScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/RootScreen.kt
@@ -33,11 +33,11 @@ import com.yral.android.ui.components.UpdateNotificationHost
 import com.yral.android.ui.nav.RootComponent
 import com.yral.android.ui.nav.RootComponent.Child
 import com.yral.android.ui.screens.home.HomeScreen
-import com.yral.android.ui.widgets.YralErrorMessage
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.shared.core.session.SessionState
 import com.yral.shared.features.root.viewmodels.RootError
 import com.yral.shared.features.root.viewmodels.RootViewModel
+import com.yral.shared.libs.designsystem.component.YralErrorMessage
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.lottie.LottieRes
 import com.yral.shared.libs.designsystem.component.lottie.YralLottieAnimation
 import com.yral.shared.libs.designsystem.component.toast.ToastHost

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/AccountScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/AccountScreen.kt
@@ -44,7 +44,6 @@ import com.yral.android.ui.components.DeleteConfirmationSheet
 import com.yral.android.ui.screens.account.AccountScreenConstants.SOCIAL_MEDIA_LINK_BOTTOM_SPACER_WEIGHT
 import com.yral.android.ui.screens.account.nav.AccountComponent
 import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.YralErrorMessage
 import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.shared.analytics.events.MenuCtaType
 import com.yral.shared.analytics.events.SignupPageName
@@ -55,6 +54,7 @@ import com.yral.shared.features.account.viewmodel.AccountHelpLinkType
 import com.yral.shared.features.account.viewmodel.AccountsState
 import com.yral.shared.features.account.viewmodel.AccountsViewModel
 import com.yral.shared.features.account.viewmodel.ErrorType
+import com.yral.shared.libs.designsystem.component.YralErrorMessage
 import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/LoginBottomSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/LoginBottomSheet.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.yral.android.ui.components.signup.SignupView
 import com.yral.android.ui.screens.account.LoginBottomSheetConstants.BOTTOM_SHEET_SPACER_PERCENT_TO_SCREEN
-import com.yral.android.ui.widgets.YralBottomSheet
 import com.yral.shared.analytics.events.SignupPageName
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @OptIn(ExperimentalMaterial3Api::class)

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/WebViewSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/WebViewSheet.kt
@@ -7,8 +7,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.yral.android.ui.widgets.YralBottomSheet
-import com.yral.android.ui.widgets.YralWebView
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
+import com.yral.shared.libs.designsystem.component.YralWebView
 import com.yral.shared.libs.designsystem.theme.YralColors
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/alertsrequest/AlertsRequestBottomSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/alertsrequest/AlertsRequestBottomSheet.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import com.yral.android.R
 import com.yral.android.ui.screens.alertsrequest.nav.AlertsRequestComponent
-import com.yral.android.ui.widgets.YralBottomSheet
 import com.yral.shared.analytics.AnalyticsManager
 import com.yral.shared.analytics.events.PushNotificationsEnabledEventData
 import com.yral.shared.analytics.events.PushNotificationsPopupEventData
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.component.YralButton
 import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/FeedScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/FeedScreen.kt
@@ -51,8 +51,6 @@ import com.yral.android.ui.screens.game.CoinBalance
 import com.yral.android.ui.screens.game.GameResultSheet
 import com.yral.android.ui.screens.game.SmileyGame
 import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.YralErrorMessage
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.shared.data.feed.domain.FeedDetails
 import com.yral.shared.features.feed.viewmodel.FeedState
 import com.yral.shared.features.feed.viewmodel.FeedViewModel
@@ -63,6 +61,8 @@ import com.yral.shared.features.feed.viewmodel.ReportSheetState
 import com.yral.shared.features.game.viewmodel.GameState
 import com.yral.shared.features.game.viewmodel.GameViewModel
 import com.yral.shared.features.game.viewmodel.NudgeType
+import com.yral.shared.libs.designsystem.component.YralErrorMessage
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.lottie.PreloadLottieAnimations
 import com.yral.shared.libs.designsystem.theme.YralColors
 import com.yral.shared.libs.videoPlayer.YRALReelPlayer

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/uiComponets/ReportVideo.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/uiComponets/ReportVideo.kt
@@ -38,8 +38,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
-import com.yral.android.ui.widgets.YralBottomSheet
 import com.yral.shared.features.feed.viewmodel.VideoReportReason
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.component.YralButtonState
 import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/AboutGameSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/AboutGameSheet.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
 import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.YralBottomSheet
 import com.yral.shared.features.game.domain.models.AboutGameBodyType
 import com.yral.shared.features.game.domain.models.AboutGameItem
 import com.yral.shared.features.game.domain.models.AboutGameItemBody
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameIconStrip.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameIconStrip.kt
@@ -21,8 +21,8 @@ import com.yral.android.ui.screens.game.GameIconStrip.GAME_ICON_ANIMATION_DURATI
 import com.yral.android.ui.screens.game.GameIconStrip.GAME_ICON_NUDGE_ANIMATION_DURATION
 import com.yral.android.ui.screens.game.GameIconStrip.GAME_ICON_ROTATION_DEGREE
 import com.yral.android.ui.screens.game.GameIconStrip.GAME_ICON_SCALING_FACTOR
-import com.yral.android.ui.widgets.YralFeedback
 import com.yral.shared.features.game.domain.models.GameIcon
+import com.yral.shared.libs.designsystem.component.YralFeedback
 import kotlinx.coroutines.delay
 
 @Suppress("LongMethod")

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameResultSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameResultSheet.kt
@@ -21,9 +21,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
-import com.yral.android.ui.widgets.YralBottomSheet
 import com.yral.shared.analytics.events.GameConcludedCtaType
 import com.yral.shared.features.game.domain.models.GameIcon
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.component.YralButton
 import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.component.lottie.LottieRes

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameStripBackground.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameStripBackground.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.yral.android.ui.screens.game.SmileyGameConstants.NUDGE_ANIMATION_DURATION
-import com.yral.android.ui.widgets.YralNeonBorder
+import com.yral.shared.libs.designsystem.component.YralNeonBorder
 import com.yral.shared.libs.designsystem.theme.YralColors.SmileyGameCardBackground
 
 @Composable

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/SmileyGame.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/SmileyGame.kt
@@ -44,9 +44,9 @@ import com.yral.android.R
 import com.yral.android.ui.screens.game.SmileyGameConstants.MANDATORY_NUDGE_ANIMATION_ICON_ITERATIONS
 import com.yral.android.ui.screens.game.SmileyGameConstants.NUDGE_ANIMATION_DURATION
 import com.yral.android.ui.screens.game.SmileyGameConstants.NUDGE_ANIMATION_ICON_ITERATIONS
-import com.yral.android.ui.widgets.YralFeedback
 import com.yral.shared.features.game.domain.models.GameIcon
 import com.yral.shared.features.game.viewmodel.NudgeType
+import com.yral.shared.libs.designsystem.component.YralFeedback
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import kotlin.coroutines.cancellation.CancellationException

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/home/HomeScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/home/HomeScreen.kt
@@ -51,7 +51,6 @@ import com.yral.android.ui.screens.leaderboard.LeaderboardScreen
 import com.yral.android.ui.screens.profile.ProfileScreen
 import com.yral.android.ui.screens.uploadVideo.UploadVideoRootScreen
 import com.yral.android.ui.screens.wallet.WalletScreen
-import com.yral.android.ui.widgets.YralFeedback
 import com.yral.featureflag.FeatureFlagManager
 import com.yral.featureflag.WalletFeatureFlags
 import com.yral.shared.analytics.events.CategoryName
@@ -63,6 +62,7 @@ import com.yral.shared.features.account.viewmodel.AccountsViewModel
 import com.yral.shared.features.feed.viewmodel.FeedViewModel
 import com.yral.shared.features.game.viewmodel.GameViewModel
 import com.yral.shared.features.profile.viewmodel.ProfileViewModel
+import com.yral.shared.libs.designsystem.component.YralFeedback
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import org.koin.compose.koinInject

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/details/LeaderboardDetailsScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/details/LeaderboardDetailsScreen.kt
@@ -41,8 +41,8 @@ import com.yral.android.R
 import com.yral.android.ui.screens.leaderboard.LeaderboardRow
 import com.yral.android.ui.screens.leaderboard.LeaderboardTableHeader
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardConfetti
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.shared.features.game.viewmodel.LeaderboardHistoryViewModel
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import org.koin.compose.viewmodel.koinViewModel

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/main/LeaderboardModes.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/main/LeaderboardModes.kt
@@ -45,9 +45,9 @@ import com.yral.android.R
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstants.COUNT_DOWN_ANIMATION_DURATION
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstants.COUNT_DOWN_BG_ALPHA
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstants.COUNT_DOWN_BORDER_ANIMATION_DURATION
-import com.yral.android.ui.widgets.YralNeonBorder
 import com.yral.shared.features.game.data.models.LeaderboardMode
 import com.yral.shared.libs.designsystem.component.YralMaskedVectorTextV2
+import com.yral.shared.libs.designsystem.component.YralNeonBorder
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import kotlinx.coroutines.delay

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/main/TrophyGallery.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/main/TrophyGallery.kt
@@ -45,9 +45,9 @@ import com.yral.android.ui.screens.leaderboard.main.LeaderboardHelpers.POS_SILVE
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardHelpers.getTrophyImageHeight
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardHelpers.getTrophyImageOffset
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardHelpers.getTrophyImageWidth
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.shared.features.game.data.models.LeaderboardMode
 import com.yral.shared.features.game.domain.models.LeaderboardItem
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.lottie.LottieRes
 import com.yral.shared.libs.designsystem.component.lottie.YralLottieAnimation
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/profile/ProfileReelPlayer.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/profile/ProfileReelPlayer.kt
@@ -36,8 +36,8 @@ import androidx.paging.compose.LazyPagingItems
 import com.yral.android.R
 import com.yral.android.ui.screens.feed.performance.PrefetchVideoListenerImpl
 import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.shared.data.feed.domain.FeedDetails
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.lottie.LottieRes
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/profile/main/ProfileMainScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/profile/main/ProfileMainScreen.kt
@@ -68,8 +68,6 @@ import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants.PULL_
 import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants.PULL_TO_REFRESH_OFFSET_MULTIPLIER
 import com.yral.android.ui.widgets.LoaderSize
 import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.YralErrorMessage
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.shared.analytics.events.VideoDeleteCTA
 import com.yral.shared.core.session.AccountInfo
 import com.yral.shared.data.feed.domain.FeedDetails
@@ -78,7 +76,9 @@ import com.yral.shared.features.profile.viewmodel.ProfileViewModel
 import com.yral.shared.features.profile.viewmodel.VideoViewState
 import com.yral.shared.libs.designsystem.component.YralButtonState
 import com.yral.shared.libs.designsystem.component.YralButtonType
+import com.yral.shared.libs.designsystem.component.YralErrorMessage
 import com.yral.shared.libs.designsystem.component.YralGradientButton
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.lottie.LottieRes
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/AiVideoGenScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/AiVideoGenScreen.kt
@@ -54,9 +54,6 @@ import com.yral.android.ui.screens.account.LoginBottomSheet
 import com.yral.android.ui.screens.account.WebViewBottomSheet
 import com.yral.android.ui.screens.uploadVideo.aiVideoGen.AiVideoGenScreenConstants.LOADING_MESSAGE_DELAY
 import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.YralBottomSheet
-import com.yral.android.ui.widgets.YralConfirmationMessage
-import com.yral.android.ui.widgets.YralLoader
 import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.android.ui.widgets.video.YralVideoPlayer
 import com.yral.shared.analytics.events.SignupPageName
@@ -65,8 +62,11 @@ import com.yral.shared.features.uploadvideo.domain.models.Provider
 import com.yral.shared.features.uploadvideo.presentation.AiVideoGenViewModel
 import com.yral.shared.features.uploadvideo.presentation.AiVideoGenViewModel.BottomSheetType
 import com.yral.shared.libs.arch.presentation.UiState
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.component.YralButtonState
+import com.yral.shared.libs.designsystem.component.YralConfirmationMessage
 import com.yral.shared.libs.designsystem.component.YralGradientButton
+import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.YralMaskedVectorTextV2
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/ModelSelection.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/ModelSelection.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
 import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.YralBottomSheet
 import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.shared.features.uploadvideo.domain.models.Provider
+import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/fileUpload/UploadVideoView.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/fileUpload/UploadVideoView.kt
@@ -49,7 +49,6 @@ import com.google.accompanist.permissions.MultiplePermissionsState
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.shouldShowRationale
 import com.yral.android.R
-import com.yral.android.ui.widgets.YralErrorMessage
 import com.yral.android.ui.widgets.video.VideoFileManager
 import com.yral.android.ui.widgets.video.VideoMetadataExtractor
 import com.yral.android.ui.widgets.video.VideoPermissionUtils
@@ -57,6 +56,7 @@ import com.yral.android.ui.widgets.video.VideoValidator
 import com.yral.android.ui.widgets.video.YralVideoPlayer
 import com.yral.shared.libs.designsystem.component.YralButton
 import com.yral.shared.libs.designsystem.component.YralButtonState
+import com.yral.shared.libs.designsystem.component.YralErrorMessage
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import kotlinx.coroutines.Dispatchers

--- a/androidApp/src/main/kotlin/com/yral/android/ui/widgets/YralAsyncImage.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/widgets/YralAsyncImage.kt
@@ -28,6 +28,7 @@ import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.svg.SvgDecoder
+import com.yral.shared.libs.designsystem.component.YralLoader
 import kotlin.math.min
 
 @SuppressLint("UnusedBoxWithConstraintsScope")

--- a/shared/libs/designsystem/src/androidMain/kotlin/com/yral/shared/libs/designsystem/component/YralFeedback.android.kt
+++ b/shared/libs/designsystem/src/androidMain/kotlin/com/yral/shared/libs/designsystem/component/YralFeedback.android.kt
@@ -1,4 +1,4 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
 import android.media.MediaPlayer
 import androidx.compose.runtime.Composable
@@ -17,11 +17,11 @@ private const val HAPTIC_FEEDBACK_DELAY = 30L
 
 @Suppress("TooGenericExceptionCaught")
 @Composable
-fun YralFeedback(
+actual fun YralFeedback(
     sound: Int,
-    withHapticFeedback: Boolean = false,
-    hapticFeedbackType: HapticFeedbackType = HapticFeedbackType.ContextClick,
-    onPlayed: () -> Unit = {},
+    withHapticFeedback: Boolean,
+    hapticFeedbackType: HapticFeedbackType,
+    onPlayed: () -> Unit,
 ) {
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current

--- a/shared/libs/designsystem/src/androidMain/kotlin/com/yral/shared/libs/designsystem/component/YralNeonBorder.android.kt
+++ b/shared/libs/designsystem/src/androidMain/kotlin/com/yral/shared/libs/designsystem/component/YralNeonBorder.android.kt
@@ -1,0 +1,40 @@
+package com.yral.shared.libs.designsystem.component
+
+import android.graphics.Paint
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.Dp
+
+internal actual fun Modifier.neonBorder(
+    glowingColor: Color,
+    containerColor: Color,
+    glowingRadius: Dp,
+    cornerRadius: Dp,
+    xShifting: Dp,
+    yShifting: Dp,
+) = this.drawBehind {
+    val canvasSize = size
+    drawContext.canvas.nativeCanvas.apply {
+        drawRoundRect(
+            0f, // Left
+            0f, // Top
+            canvasSize.width, // Right
+            canvasSize.height, // Bottom
+            cornerRadius.toPx(), // Radius X
+            cornerRadius.toPx(), // Radius Y
+            Paint().apply {
+                color = containerColor.toArgb()
+                isAntiAlias = true
+                setShadowLayer(
+                    glowingRadius.toPx(),
+                    xShifting.toPx(),
+                    yShifting.toPx(),
+                    glowingColor.toArgb(),
+                )
+            },
+        )
+    }
+}

--- a/shared/libs/designsystem/src/androidMain/kotlin/com/yral/shared/libs/designsystem/component/YralWebView.android.kt
+++ b/shared/libs/designsystem/src/androidMain/kotlin/com/yral/shared/libs/designsystem/component/YralWebView.android.kt
@@ -1,4 +1,4 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
 import android.content.ActivityNotFoundException
 import android.content.Intent
@@ -31,11 +31,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
-fun YralWebView(
+actual fun YralWebView(
     url: String,
-    modifier: Modifier = Modifier,
-    maxRetries: Int = 3,
-    retryDelayMillis: Long = 1000,
+    modifier: Modifier,
+    maxRetries: Int,
+    retryDelayMillis: Long,
 ) {
     var isLoading by remember { mutableStateOf(true) }
     val scope = rememberCoroutineScope()

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralBottomSheet.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralBottomSheet.kt
@@ -1,4 +1,4 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.safeDrawingPadding

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralConfirmationMessage.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralConfirmationMessage.kt
@@ -1,4 +1,4 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,8 +16,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.yral.shared.libs.designsystem.component.YralButton
-import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralErrorMessage.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralErrorMessage.kt
@@ -1,4 +1,4 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralFeedback.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralFeedback.kt
@@ -1,0 +1,12 @@
+package com.yral.shared.libs.designsystem.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+
+@Composable
+expect fun YralFeedback(
+    sound: Int,
+    withHapticFeedback: Boolean = false,
+    hapticFeedbackType: HapticFeedbackType = HapticFeedbackType.ContextClick,
+    onPlayed: () -> Unit = {},
+)

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralLoader.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralLoader.kt
@@ -1,4 +1,4 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,7 +8,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.airbnb.lottie.compose.LottieConstants
 import com.yral.shared.libs.designsystem.component.lottie.LottieRes
 import com.yral.shared.libs.designsystem.component.lottie.YralLottieAnimation
 
@@ -28,7 +27,7 @@ fun YralLoader(
                 Modifier
                     .size(size),
             rawRes = resource,
-            iterations = LottieConstants.IterateForever,
+            iterations = Int.MAX_VALUE,
         )
     }
 }

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralNeonBorder.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralNeonBorder.kt
@@ -1,6 +1,5 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
-import android.graphics.Paint
 import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -16,10 +15,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.yral.shared.libs.designsystem.theme.YralColors
@@ -62,33 +58,11 @@ fun BoxScope.YralNeonBorder(
     )
 }
 
-private fun Modifier.neonBorder(
+internal expect fun Modifier.neonBorder(
     glowingColor: Color,
     containerColor: Color,
     glowingRadius: Dp,
     cornerRadius: Dp,
     xShifting: Dp = 0.dp,
     yShifting: Dp = 0.dp,
-) = this.drawBehind {
-    val canvasSize = size
-    drawContext.canvas.nativeCanvas.apply {
-        drawRoundRect(
-            0f, // Left
-            0f, // Top
-            canvasSize.width, // Right
-            canvasSize.height, // Bottom
-            cornerRadius.toPx(), // Radius X
-            cornerRadius.toPx(), // Radius Y
-            Paint().apply {
-                color = containerColor.toArgb()
-                isAntiAlias = true
-                setShadowLayer(
-                    glowingRadius.toPx(),
-                    xShifting.toPx(),
-                    yShifting.toPx(),
-                    glowingColor.toArgb(),
-                )
-            },
-        )
-    }
-}
+): Modifier

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralWebView.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralWebView.kt
@@ -1,0 +1,12 @@
+package com.yral.shared.libs.designsystem.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+expect fun YralWebView(
+    url: String,
+    modifier: Modifier = Modifier,
+    maxRetries: Int = 3,
+    retryDelayMillis: Long = 1000,
+)

--- a/shared/libs/designsystem/src/iosMain/kotlin/com/yral/shared/libs/designsystem/component/YralFeedback.ios.kt
+++ b/shared/libs/designsystem/src/iosMain/kotlin/com/yral/shared/libs/designsystem/component/YralFeedback.ios.kt
@@ -1,0 +1,14 @@
+package com.yral.shared.libs.designsystem.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+
+@Composable
+actual fun YralFeedback(
+    sound: Int,
+    withHapticFeedback: Boolean,
+    hapticFeedbackType: HapticFeedbackType,
+    onPlayed: () -> Unit,
+) {
+    // stub
+}

--- a/shared/libs/designsystem/src/iosMain/kotlin/com/yral/shared/libs/designsystem/component/YralNeonBorder.ios.kt
+++ b/shared/libs/designsystem/src/iosMain/kotlin/com/yral/shared/libs/designsystem/component/YralNeonBorder.ios.kt
@@ -1,0 +1,14 @@
+package com.yral.shared.libs.designsystem.component
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+
+internal actual fun Modifier.neonBorder(
+    glowingColor: Color,
+    containerColor: Color,
+    glowingRadius: Dp,
+    cornerRadius: Dp,
+    xShifting: Dp,
+    yShifting: Dp,
+): Modifier = this

--- a/shared/libs/designsystem/src/iosMain/kotlin/com/yral/shared/libs/designsystem/component/YralWebView.ios.kt
+++ b/shared/libs/designsystem/src/iosMain/kotlin/com/yral/shared/libs/designsystem/component/YralWebView.ios.kt
@@ -1,0 +1,14 @@
+package com.yral.shared.libs.designsystem.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+actual fun YralWebView(
+    url: String,
+    modifier: Modifier,
+    maxRetries: Int,
+    retryDelayMillis: Long,
+) {
+    // stub
+}


### PR DESCRIPTION
This commit moves several UI widget composables from the `androidApp` module to the `shared/libs/designsystem` module. This change allows these components to be reused across different modules and platforms (Android and iOS).

Specifically, the following components were moved:
- `YralBottomSheet`
- `YralConfirmationMessage`
- `YralErrorMessage`
- `YralFeedback`
- `YralLoader`
- `YralNeonBorder`
- `YralWebView`

The import paths for these components have been updated in the files where they are used. Additionally, `expect`/`actual` implementations have been provided for platform-specific components like `YralFeedback`, `YralNeonBorder`, and `YralWebView` to ensure compatibility with both Android and iOS.