### PR TITLE
Refactor: Moves YralAsyncImage to design system

### DIFF
--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/AccountScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/account/AccountScreen.kt
@@ -43,8 +43,6 @@ import com.yral.android.R
 import com.yral.android.ui.components.DeleteConfirmationSheet
 import com.yral.android.ui.screens.account.AccountScreenConstants.SOCIAL_MEDIA_LINK_BOTTOM_SPACER_WEIGHT
 import com.yral.android.ui.screens.account.nav.AccountComponent
-import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.shared.analytics.events.MenuCtaType
 import com.yral.shared.analytics.events.SignupPageName
 import com.yral.shared.core.session.AccountInfo
@@ -54,8 +52,10 @@ import com.yral.shared.features.account.viewmodel.AccountHelpLinkType
 import com.yral.shared.features.account.viewmodel.AccountsState
 import com.yral.shared.features.account.viewmodel.AccountsViewModel
 import com.yral.shared.features.account.viewmodel.ErrorType
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralErrorMessage
 import com.yral.shared.libs.designsystem.component.YralGradientButton
+import com.yral.shared.libs.designsystem.component.getSVGImageModel
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import com.yral.shared.libs.designsystem.theme.YralDimens

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/FeedScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/FeedScreen.kt
@@ -50,7 +50,6 @@ import com.yral.android.ui.screens.game.AboutGameSheet
 import com.yral.android.ui.screens.game.CoinBalance
 import com.yral.android.ui.screens.game.GameResultSheet
 import com.yral.android.ui.screens.game.SmileyGame
-import com.yral.android.ui.widgets.YralAsyncImage
 import com.yral.shared.data.feed.domain.FeedDetails
 import com.yral.shared.features.feed.viewmodel.FeedState
 import com.yral.shared.features.feed.viewmodel.FeedViewModel
@@ -61,6 +60,7 @@ import com.yral.shared.features.feed.viewmodel.ReportSheetState
 import com.yral.shared.features.game.viewmodel.GameState
 import com.yral.shared.features.game.viewmodel.GameViewModel
 import com.yral.shared.features.game.viewmodel.NudgeType
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralErrorMessage
 import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.lottie.PreloadLottieAnimations

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/uiComponets/UserBrief.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/feed/uiComponets/UserBrief.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.yral.android.ui.screens.feed.uiComponets.UserBriefConstants.MAX_LINES_FOR_POST_DESCRIPTION
-import com.yral.android.ui.widgets.YralAsyncImage
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/AboutGameSheet.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/AboutGameSheet.kt
@@ -26,10 +26,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
-import com.yral.android.ui.widgets.YralAsyncImage
 import com.yral.shared.features.game.domain.models.AboutGameBodyType
 import com.yral.shared.features.game.domain.models.AboutGameItem
 import com.yral.shared.features.game.domain.models.AboutGameItemBody
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameIcon.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/game/GameIcon.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
 import com.yral.android.R
-import com.yral.android.ui.widgets.YralAsyncImage
 import com.yral.shared.features.game.domain.models.GameIcon
 import com.yral.shared.features.game.domain.models.GameIconNames
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 
 @Composable
 fun GameIcon(

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/LeaderBoardUIComponents.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/leaderboard/LeaderBoardUIComponents.kt
@@ -37,7 +37,7 @@ import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstan
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstants.MAX_CHAR_OF_NAME
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstants.POSITION_TEXT_WEIGHT
 import com.yral.android.ui.screens.leaderboard.main.LeaderboardMainScreenConstants.USER_DETAIL_WEIGHT
-import com.yral.android.ui.widgets.YralAsyncImage
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralMaskedVectorTextV2
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/profile/main/ProfileMainScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/profile/main/ProfileMainScreen.kt
@@ -66,14 +66,14 @@ import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants.PADDI
 import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants.PULL_TO_REFRESH_INDICATOR_SIZE
 import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants.PULL_TO_REFRESH_INDICATOR_THRESHOLD
 import com.yral.android.ui.screens.profile.main.ProfileMainScreenConstants.PULL_TO_REFRESH_OFFSET_MULTIPLIER
-import com.yral.android.ui.widgets.LoaderSize
-import com.yral.android.ui.widgets.YralAsyncImage
 import com.yral.shared.analytics.events.VideoDeleteCTA
 import com.yral.shared.core.session.AccountInfo
 import com.yral.shared.data.feed.domain.FeedDetails
 import com.yral.shared.features.profile.viewmodel.DeleteConfirmationState
 import com.yral.shared.features.profile.viewmodel.ProfileViewModel
 import com.yral.shared.features.profile.viewmodel.VideoViewState
+import com.yral.shared.libs.designsystem.component.LoaderSize
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralButtonState
 import com.yral.shared.libs.designsystem.component.YralButtonType
 import com.yral.shared.libs.designsystem.component.YralErrorMessage

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/AiVideoGenScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/AiVideoGenScreen.kt
@@ -53,8 +53,6 @@ import com.yral.android.ui.screens.account.ErrorMessageSheet
 import com.yral.android.ui.screens.account.LoginBottomSheet
 import com.yral.android.ui.screens.account.WebViewBottomSheet
 import com.yral.android.ui.screens.uploadVideo.aiVideoGen.AiVideoGenScreenConstants.LOADING_MESSAGE_DELAY
-import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.android.ui.widgets.video.YralVideoPlayer
 import com.yral.shared.analytics.events.SignupPageName
 import com.yral.shared.features.account.viewmodel.ErrorType
@@ -62,12 +60,14 @@ import com.yral.shared.features.uploadvideo.domain.models.Provider
 import com.yral.shared.features.uploadvideo.presentation.AiVideoGenViewModel
 import com.yral.shared.features.uploadvideo.presentation.AiVideoGenViewModel.BottomSheetType
 import com.yral.shared.libs.arch.presentation.UiState
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralBottomSheet
 import com.yral.shared.libs.designsystem.component.YralButtonState
 import com.yral.shared.libs.designsystem.component.YralConfirmationMessage
 import com.yral.shared.libs.designsystem.component.YralGradientButton
 import com.yral.shared.libs.designsystem.component.YralLoader
 import com.yral.shared.libs.designsystem.component.YralMaskedVectorTextV2
+import com.yral.shared.libs.designsystem.component.getSVGImageModel
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import kotlinx.coroutines.delay

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/ModelDetails.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/ModelDetails.kt
@@ -29,10 +29,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
 import com.yral.android.ui.screens.uploadVideo.aiVideoGen.AiVideoGenScreenConstants.ARROW_ROTATION
-import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.shared.features.uploadvideo.domain.models.Provider
 import com.yral.shared.features.uploadvideo.presentation.AiVideoGenViewModel.ViewState
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
+import com.yral.shared.libs.designsystem.component.getSVGImageModel
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/ModelSelection.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/uploadVideo/aiVideoGen/ModelSelection.kt
@@ -24,10 +24,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.yral.android.R
-import com.yral.android.ui.widgets.YralAsyncImage
-import com.yral.android.ui.widgets.getSVGImageModel
 import com.yral.shared.features.uploadvideo.domain.models.Provider
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.component.YralBottomSheet
+import com.yral.shared.libs.designsystem.component.getSVGImageModel
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 

--- a/androidApp/src/main/kotlin/com/yral/android/ui/screens/wallet/WalletScreen.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/ui/screens/wallet/WalletScreen.kt
@@ -28,11 +28,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yral.android.R
 import com.yral.android.ui.screens.wallet.nav.WalletComponent
-import com.yral.android.ui.widgets.YralAsyncImage
 import com.yral.shared.core.session.AccountInfo
 import com.yral.shared.features.wallet.viewmodel.WalletViewModel
 import com.yral.shared.libs.CurrencyFormatter
 import com.yral.shared.libs.NumberFormatter
+import com.yral.shared.libs.designsystem.component.YralAsyncImage
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import org.koin.compose.viewmodel.koinViewModel

--- a/shared/libs/designsystem/build.gradle.kts
+++ b/shared/libs/designsystem/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.implementation
+
 plugins {
     alias(libs.plugins.yral.shared.library)
     alias(libs.plugins.yral.android.library)
@@ -19,6 +21,8 @@ kotlin {
                 implementation(projects.shared.libs.crashlytics)
                 implementation(projects.shared.core)
                 implementation(libs.koin.compose)
+                implementation(libs.coil.compose)
+                implementation(libs.coil.svg)
             }
         }
         androidMain {

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralAsyncImage.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralAsyncImage.kt
@@ -1,6 +1,5 @@
-package com.yral.android.ui.widgets
+package com.yral.shared.libs.designsystem.component
 
-import android.annotation.SuppressLint
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -21,17 +20,15 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import coil3.svg.SvgDecoder
-import com.yral.shared.libs.designsystem.component.YralLoader
 import kotlin.math.min
 
-@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun YralAsyncImage(
     imageUrl: Any,
@@ -94,7 +91,7 @@ fun YralAsyncImage(
 @Composable
 fun getSVGImageModel(url: String) =
     ImageRequest
-        .Builder(LocalContext.current)
+        .Builder(LocalPlatformContext.current)
         .data(url)
         .decoderFactory(SvgDecoder.Factory())
         .build()


### PR DESCRIPTION
This commit moves the `YralAsyncImage` composable and its related helper function `getSVGImageModel` from the `androidApp` module to the `shared/libs/designsystem` module.

This change also updates all usages of `YralAsyncImage` and `getSVGImageModel` across the `androidApp` to reference the new location in the design system module. Additionally, Coil dependencies (`coil-compose` and `coil-svg`) are added to the `designsystem` module's build file.