### PR TITLE
feat: Adds stub iOS implementation for videoPlayer

### DIFF
--- a/shared/libs/videoPlayer/build.gradle.kts
+++ b/shared/libs/videoPlayer/build.gradle.kts
@@ -1,17 +1,16 @@
 plugins {
     alias(libs.plugins.yral.shared.library)
     alias(libs.plugins.yral.android.library)
-    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.yral.shared.library.compose)
     alias(libs.plugins.composeCompiler)
 }
 
 kotlin {
     androidTarget()
-//    listOf(
-//        iosX64(),
-//        iosArm64(),
-//        iosSimulatorArm64()
-//    )
+    listOf(
+        iosArm64(),
+        iosSimulatorArm64(),
+    )
 
     sourceSets {
         androidMain.dependencies {

--- a/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/YRALReelPlayer.kt
+++ b/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/YRALReelPlayer.kt
@@ -132,7 +132,7 @@ internal fun YRALReelsPlayerView(
             url = reel.videoUrl,
             listener = prefetchVideoListener,
             onUrlReady = {
-                prefetchQueue.removeIf { it.videoId == reel.videoId }
+                prefetchQueue.removeAll { it.videoId == reel.videoId }
                 prefetchedReels.add(reel.videoId)
             },
         )

--- a/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/YralBlurThumbnail.kt
+++ b/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/YralBlurThumbnail.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 
 private const val RENDER_PIXELS = 100
@@ -17,7 +17,7 @@ fun YralBlurredThumbnail(url: String) {
     AsyncImage(
         model =
             ImageRequest
-                .Builder(LocalContext.current)
+                .Builder(LocalPlatformContext.current)
                 .data(url)
                 .size(RENDER_PIXELS)
                 .build(),

--- a/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/pool/PlayerPool.ios.kt
+++ b/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/pool/PlayerPool.ios.kt
@@ -1,0 +1,61 @@
+@file:Suppress("EmptyFunctionBlock")
+
+package com.yral.shared.libs.videoPlayer.pool
+
+import com.yral.shared.libs.videoPlayer.model.PlayerData
+
+/**
+ * STUB implementation
+ */
+actual class PlayerPool actual constructor(
+    maxPoolSize: Int,
+) {
+    actual suspend fun getPlayer(
+        playerData: PlayerData,
+        videoListener: VideoListener?,
+    ): PlatformPlayer = PlatformPlayer()
+
+    actual suspend fun releasePlayer(player: PlatformPlayer) {
+    }
+
+    actual fun dispose() {
+    }
+
+    actual fun onPlayBackStarted(playerData: PlayerData) {
+    }
+
+    actual fun onPlayBackStopped(playerData: PlayerData) {
+    }
+}
+
+/**
+ * STUB implementation
+ */
+actual class PlatformPlayer {
+    actual fun play() {
+    }
+
+    actual fun pause() {
+    }
+
+    actual fun stop() {
+    }
+
+    actual fun release() {
+    }
+
+    actual fun clearMediaItems() {
+    }
+
+    actual fun setMediaSource(source: Any) {
+    }
+
+    actual fun prepare() {
+    }
+
+    actual fun seekTo(
+        mediaItemIndex: Int,
+        positionMs: Long,
+    ) {
+    }
+}

--- a/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/pool/RememberPlayerPool.ios.kt
+++ b/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/pool/RememberPlayerPool.ios.kt
@@ -1,0 +1,8 @@
+package com.yral.shared.libs.videoPlayer.pool
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun rememberPlayerPool(maxPoolSize: Int): PlayerPool {
+    return PlayerPool(maxPoolSize) // STUB
+}

--- a/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/util/CMPPlayer.ios.kt
+++ b/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/util/CMPPlayer.ios.kt
@@ -1,0 +1,18 @@
+package com.yral.shared.libs.videoPlayer.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.yral.shared.libs.videoPlayer.model.PlayerData
+import com.yral.shared.libs.videoPlayer.pool.PlayerPool
+import com.yral.shared.libs.videoPlayer.pool.VideoListener
+
+@Composable
+actual fun CMPPlayer(
+    modifier: Modifier,
+    playerData: PlayerData,
+    playerParams: CMPPlayerParams,
+    playerPool: PlayerPool,
+    videoListener: VideoListener?,
+) {
+    // STUB
+}

--- a/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/util/RememberPrefetchPlayer.ios.kt
+++ b/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/util/RememberPrefetchPlayer.ios.kt
@@ -1,0 +1,19 @@
+package com.yral.shared.libs.videoPlayer.util
+
+import androidx.compose.runtime.Composable
+import com.yral.shared.libs.videoPlayer.pool.PlatformPlayer
+
+@Composable
+actual fun rememberPrefetchPlayerWithLifecycle(): PlatformPlayer {
+    return PlatformPlayer() // STUB
+}
+
+@Composable
+actual fun PrefetchVideo(
+    player: PlatformPlayer,
+    url: String,
+    listener: PrefetchVideoListener?,
+    onUrlReady: (String) -> Unit,
+) {
+    // STUB
+}

--- a/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/util/Util.ios.kt
+++ b/shared/libs/videoPlayer/src/iosMain/kotlin/com/yral/shared/libs/videoPlayer/util/Util.ios.kt
@@ -1,0 +1,13 @@
+@file:Suppress("MagicNumber")
+
+package com.yral.shared.libs.videoPlayer.util
+
+import com.yral.shared.libs.videoPlayer.model.Platform
+
+internal actual fun formatMinSec(value: Int): String = "STUB"
+
+internal actual fun formatInterval(value: Int): Int = value * 1000 // STUB
+
+internal actual fun formatYoutubeInterval(value: Int): Int = value * 1000 // STUB
+
+actual fun isPlatform(): Platform = Platform.Ios


### PR DESCRIPTION
This commit introduces initial stub implementations for the iOS platform within the `videoPlayer` shared library.

Key changes:
- Adds `iosArm64` and `iosSimulatorArm64` targets in `build.gradle.kts`.
- Replaces `LocalContext.current` with `LocalPlatformContext.current` in `YralBlurThumbnail.kt` for multiplatform compatibility.
- Implements stub functions and classes for iOS in:
    - `Util.ios.kt`: `formatMinSec`, `formatInterval`, `formatYoutubeInterval`, `isPlatform`.
    - `CMPPlayer.ios.kt`: `CMPPlayer` composable.
    - `RememberPrefetchPlayer.ios.kt`: `rememberPrefetchPlayerWithLifecycle`, `PrefetchVideo`.
    - `RememberPlayerPool.ios.kt`: `rememberPlayerPool`.
    - `PlayerPool.ios.kt`: `PlayerPool` and `PlatformPlayer` classes.
- Updates `YRALReelPlayer.kt` to use `removeAll` instead of `removeIf` for `prefetchQueue` modification.