### PR TITLE
Change yral-common dependencies to master branch

### DIFF
--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -26,11 +26,11 @@ k256 = { version = "0.13.4", default-features = false, features = [
 ] }
 ic-cdk = "0.15.1"
 
-yral-types = { git = "https://github.com/dolr-ai/yral-common.git", branch="feat/support-new-service-canisters"  }
-yral-canisters-client = { git = "https://github.com/dolr-ai/yral-common.git", branch="feat/support-new-service-canisters", features = [
+yral-types = { git = "https://github.com/dolr-ai/yral-common.git", branch="master"  }
+yral-canisters-client = { git = "https://github.com/dolr-ai/yral-common.git", branch="master", features = [
     "full",
 ] }
-yral-canisters-common = { git = "https://github.com/dolr-ai/yral-common.git", branch="feat/support-new-service-canisters" }
+yral-canisters-common = { git = "https://github.com/dolr-ai/yral-common.git", branch="master" }
 yral-metadata-client = { git = "https://github.com/yral-dapp/yral-metadata", branch = "master", default-features = false }
 yral-metadata-types = { git = "https://github.com/yral-dapp/yral-metadata", branch = "master", default-features = false }
 yral-identity = { git = "https://github.com/dolr-ai/yral-common.git", branch="master", default-features = false, features = [


### PR DESCRIPTION
Updated dependencies to use 'master' branch instead of 'feat/support-new-service-canisters'.