### PR TITLE
Remove default flexible update type

### DIFF
--- a/androidApp/src/main/kotlin/com/yral/android/update/InAppUpdateManager.kt
+++ b/androidApp/src/main/kotlin/com/yral/android/update/InAppUpdateManager.kt
@@ -169,7 +169,6 @@ class InAppUpdateManager(
 
         Logger.d(TAG) { "Update available - Priority: $priority, Staleness: $stalenessDays days" }
 
-        return UpdateType.FLEXIBLE
         return when {
             // Priority 4 or 5 = Immediate update
             priority >= PRIORITY_IMMEDIATE -> UpdateType.IMMEDIATE


### PR DESCRIPTION
The default `UpdateType.FLEXIBLE` is removed to allow the `when` block to correctly determine the update type based on priority and staleness.