### PR TITLE
feat: Adds copy feedback for Principal ID on iOS

### DIFF
--- a/shared/features/profile/src/androidMain/kotlin/com/yral/shared/features/profile/ui/EditProfileScreen.android.kt
+++ b/shared/features/profile/src/androidMain/kotlin/com/yral/shared/features/profile/ui/EditProfileScreen.android.kt
@@ -1,0 +1,3 @@
+package com.yral.shared.features.profile.ui
+
+internal actual fun notifyClipboardCopy(): Boolean = false

--- a/shared/features/profile/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/profile/src/commonMain/composeResources/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="download_successful">Your video has been downloaded successfully.</string>
     <string name="download_failed">Your video couldn't be downloaded. Please try again.</string>
     <string name="storage_permission_required">Storage permission is required to download videos. Please grant permission in Settings.</string>
+    <string name="msg_principal_id_copied">Your Principal ID has been copied successfully!</string>
 </resources>

--- a/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/ui/EditProfileScreen.kt
+++ b/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/ui/EditProfileScreen.kt
@@ -73,6 +73,8 @@ import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import yral_mobile.shared.features.profile.generated.resources.Res
+import yral_mobile.shared.features.profile.generated.resources.msg_principal_id_copied
 import yral_mobile.shared.libs.designsystem.generated.resources.arrow_left
 import yral_mobile.shared.libs.designsystem.generated.resources.bio
 import yral_mobile.shared.libs.designsystem.generated.resources.copy_profile_name
@@ -243,11 +245,17 @@ fun EditProfileScreen(
                 )
                 Spacer(modifier = Modifier.height(24.dp))
 
+                val copiedMessage = stringResource(Res.string.msg_principal_id_copied)
                 UniqueIdSection(
                     uniqueId = state.uniqueId,
                     onCopy = {
                         if (state.uniqueId.isNotEmpty()) {
                             clipboardManager.setText(AnnotatedString(state.uniqueId))
+                            if (notifyClipboardCopy()) {
+                                ToastManager.showSuccess(
+                                    type = ToastType.Small(copiedMessage),
+                                )
+                            }
                         }
                     },
                 )
@@ -746,3 +754,9 @@ private fun EmailSection(email: String) {
         }
     }
 }
+
+/**
+ * Some platforms like Android natively shows a notification if something is copied to clipboard.
+ * On other platforms like iOS app is responsible for notifying the user
+ */
+internal expect fun notifyClipboardCopy(): Boolean

--- a/shared/features/profile/src/iosMain/kotlin/com/yral/shared/features/profile/ui/EditProfileScreen.ios.kt
+++ b/shared/features/profile/src/iosMain/kotlin/com/yral/shared/features/profile/ui/EditProfileScreen.ios.kt
@@ -1,0 +1,3 @@
+package com.yral.shared.features.profile.ui
+
+internal actual fun notifyClipboardCopy(): Boolean = true


### PR DESCRIPTION
Adds a toast notification to inform the user when their Principal ID has been successfully copied to the clipboard. This feedback is implemented specifically for iOS, as Android provides a native notification for clipboard actions.