### PR TITLE
chore: Flush analytics after auth failure events

### DIFF
--- a/shared/features/auth/src/commonMain/kotlin/com/yral/shared/features/auth/analytics/AuthTelemetry.kt
+++ b/shared/features/auth/src/commonMain/kotlin/com/yral/shared/features/auth/analytics/AuthTelemetry.kt
@@ -76,6 +76,7 @@ class AuthTelemetry(
                 reason = reason?.take(MAX_ERROR_MESSAGE_LENGTH),
             ),
         )
+        analyticsManager.flush()
     }
 
     private fun SocialProvider.toAuthJourney(): AuthJourney =


### PR DESCRIPTION
Calls `analyticsManager.flush()` immediately after tracking an authentication failure event. This ensures that critical auth failure telemetry is sent without delay.