### PR TITLE
Track token-driven auto logout via session state event

### DIFF
--- a/shared/features/auth/src/commonMain/kotlin/com/yral/shared/features/auth/analytics/AuthTelemetry.kt
+++ b/shared/features/auth/src/commonMain/kotlin/com/yral/shared/features/auth/analytics/AuthTelemetry.kt
@@ -5,6 +5,11 @@ import com.yral.shared.analytics.events.AnonymousAuthFailedEventData
 import com.yral.shared.analytics.events.AuthFailedEventData
 import com.yral.shared.analytics.events.AuthJourney
 import com.yral.shared.analytics.events.AuthScreenViewedEventData
+import com.yral.shared.analytics.events.AuthSessionCause
+import com.yral.shared.analytics.events.AuthSessionFlow
+import com.yral.shared.analytics.events.AuthSessionInitiator
+import com.yral.shared.analytics.events.AuthSessionState
+import com.yral.shared.analytics.events.AuthSessionStateChangedEventData
 import com.yral.shared.analytics.events.LoginSuccessEventData
 import com.yral.shared.analytics.events.SignupJourneySelected
 import com.yral.shared.analytics.events.SignupPageName
@@ -74,6 +79,25 @@ class AuthTelemetry(
             AnonymousAuthFailedEventData(
                 affiliate = affiliate,
                 reason = reason?.take(MAX_ERROR_MESSAGE_LENGTH),
+            ),
+        )
+        analyticsManager.flush()
+    }
+
+    fun sessionStateChanged(
+        fromState: AuthSessionState,
+        toState: AuthSessionState,
+        initiator: AuthSessionInitiator,
+        cause: AuthSessionCause,
+        flow: AuthSessionFlow? = null,
+    ) {
+        analyticsManager.forceTrackEvent(
+            AuthSessionStateChangedEventData(
+                fromState = fromState,
+                toState = toState,
+                initiator = initiator,
+                cause = cause,
+                flow = flow,
             ),
         )
         analyticsManager.flush()

--- a/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/constants/FeatureEvents.kt
+++ b/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/constants/FeatureEvents.kt
@@ -17,6 +17,7 @@ enum class FeatureEvents {
     LOGIN_SUCCESS,
     AUTH_FAILED,
     ANONYMOUS_AUTH_FAILED,
+    AUTH_SESSION_STATE_CHANGED,
 
     // Home
     HOME_PAGE_VIEWED,

--- a/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/events/YralEvents.kt
+++ b/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/events/YralEvents.kt
@@ -179,6 +179,73 @@ data class AnonymousAuthFailedEventData(
     )
 }
 
+@Serializable
+data class AuthSessionStateChangedEventData(
+    @SerialName("event") override val event: String = FeatureEvents.AUTH_SESSION_STATE_CHANGED.getEventName(),
+    @SerialName("feature_name") override val featureName: String = Features.AUTH.getFeatureName(),
+    @SerialName("from_state") val fromState: AuthSessionState,
+    @SerialName("to_state") val toState: AuthSessionState,
+    @SerialName("initiator") val initiator: AuthSessionInitiator,
+    @SerialName("cause") val cause: AuthSessionCause,
+    @SerialName("flow") val flow: AuthSessionFlow? = null,
+) : BaseEventData(),
+    EventData {
+    constructor(
+        fromState: AuthSessionState,
+        toState: AuthSessionState,
+        initiator: AuthSessionInitiator,
+        cause: AuthSessionCause,
+        flow: AuthSessionFlow? = null,
+    ) : this(
+        FeatureEvents.AUTH_SESSION_STATE_CHANGED.getEventName(),
+        Features.AUTH.getFeatureName(),
+        fromState,
+        toState,
+        initiator,
+        cause,
+        flow,
+    )
+}
+
+@Serializable
+enum class AuthSessionState {
+    @SerialName("authenticated")
+    AUTHENTICATED,
+
+    @SerialName("unauthenticated")
+    UNAUTHENTICATED,
+}
+
+@Serializable
+enum class AuthSessionInitiator {
+    @SerialName("user")
+    USER,
+
+    @SerialName("system")
+    SYSTEM,
+}
+
+@Serializable
+enum class AuthSessionCause {
+    @SerialName("refresh_token_missing")
+    REFRESH_TOKEN_MISSING,
+
+    @SerialName("refresh_token_expired_or_invalid")
+    REFRESH_TOKEN_EXPIRED_OR_INVALID,
+
+    @SerialName("refresh_access_token_failed")
+    REFRESH_ACCESS_TOKEN_FAILED,
+}
+
+@Serializable
+enum class AuthSessionFlow {
+    @SerialName("token_validation")
+    TOKEN_VALIDATION,
+
+    @SerialName("token_refresh")
+    TOKEN_REFRESH,
+}
+
 // --- Home ---
 @Serializable
 data class HomePageViewedEventData(


### PR DESCRIPTION
  - Add AUTH_SESSION_STATE_CHANGED event + payload enums
  - Add AuthTelemetry.sessionStateChanged() (force track + flush)
  - Emit session-ended analytics on token validation/refresh failures before logout