### PR TITLE
Implements Tournament screen UI

### DIFF
--- a/shared/features/tournament/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/tournament/src/commonMain/composeResources/values/strings.xml
@@ -7,4 +7,7 @@
     <string name="starts_in">Starts in %1$s</string>
     <string name="ends_in">Ends in %1$s</string>
     <string name="ended">Ended</string>
+    <string name="screen_heading">Tournaments</string>
+    <string name="tab_all">All</string>
+    <string name="tab_history">History</string>
 </resources>

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/di/TournamentModule.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/di/TournamentModule.kt
@@ -1,0 +1,10 @@
+package com.yral.shared.features.tournament.di
+
+import com.yral.shared.features.tournament.viewmodel.TournamentViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+val tournamentModule =
+    module {
+        viewModelOf(::TournamentViewModel)
+    }

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/ui/TournamentScreen.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/ui/TournamentScreen.kt
@@ -1,0 +1,154 @@
+package com.yral.shared.features.tournament.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.yral.shared.features.tournament.viewmodel.TournamentUiState
+import com.yral.shared.features.tournament.viewmodel.TournamentViewModel
+import com.yral.shared.libs.designsystem.theme.LocalAppTopography
+import com.yral.shared.libs.designsystem.theme.YralColors
+import com.yral.shared.libs.designsystem.theme.appTypoGraphy
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import yral_mobile.shared.features.tournament.generated.resources.Res
+import yral_mobile.shared.features.tournament.generated.resources.screen_heading
+import yral_mobile.shared.features.tournament.generated.resources.tab_all
+import yral_mobile.shared.features.tournament.generated.resources.tab_history
+
+@Composable
+fun TournamentScreen(viewModel: TournamentViewModel) {
+    val uiState by viewModel.state.collectAsState()
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(YralColors.Neutral950),
+    ) {
+        Text(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            text = stringResource(Res.string.screen_heading),
+            textAlign = TextAlign.Center,
+            style = LocalAppTopography.current.xlBold,
+            color = YralColors.NeutralTextPrimary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        TournamentTabs(
+            selectedTab = uiState.selectedTab,
+            onTabSelected = viewModel::onTabSelected,
+        )
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding =
+                androidx.compose.foundation.layout
+                    .PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            items(uiState.tournaments) { tournament ->
+                TournamentCard(
+                    tournament = tournament,
+                    onPrizeBreakdownClick = { viewModel.openPrizeBreakdown(tournament) },
+                    onShareClick = { viewModel.onShareClicked(tournament) },
+                    onTournamentCtaClick = { viewModel.onTournamentCtaClick(tournament) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TournamentTabs(
+    selectedTab: TournamentUiState.Tab,
+    onTabSelected: (TournamentUiState.Tab) -> Unit,
+) {
+    Surface(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        color = YralColors.Neutral900,
+        shape = RoundedCornerShape(999.dp),
+        border = androidx.compose.foundation.BorderStroke(1.dp, YralColors.Neutral700),
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            SegmentedTab(
+                modifier = Modifier.weight(1f),
+                isSelected = selectedTab == TournamentUiState.Tab.All,
+                text = stringResource(Res.string.tab_all),
+                onClick = { onTabSelected(TournamentUiState.Tab.All) },
+            )
+            SegmentedTab(
+                modifier = Modifier.weight(1f),
+                isSelected = selectedTab == TournamentUiState.Tab.History,
+                text = stringResource(Res.string.tab_history),
+                onClick = { onTabSelected(TournamentUiState.Tab.History) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SegmentedTab(
+    isSelected: Boolean,
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val background = if (isSelected) YralColors.Neutral50 else Color.Transparent
+    val contentColor = if (isSelected) YralColors.Neutral950 else YralColors.NeutralTextSecondary
+
+    Box(
+        modifier =
+            modifier
+                .height(36.dp)
+                .background(background, RoundedCornerShape(999.dp))
+                .clickable(onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = text,
+            style = LocalAppTopography.current.regSemiBold,
+            color = contentColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Suppress("UnusedPrivateMember")
+@Preview
+@Composable
+private fun TournamentScreenPreview() {
+    CompositionLocalProvider(LocalAppTopography provides appTypoGraphy()) {
+        TournamentScreen(viewModel = TournamentViewModel())
+    }
+}

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/SampleAllTournaments.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/SampleAllTournaments.kt
@@ -1,0 +1,72 @@
+package com.yral.shared.features.tournament.viewmodel
+
+import com.yral.shared.features.tournament.domain.model.PrizeBreakdownRow
+import com.yral.shared.features.tournament.domain.model.Tournament
+import com.yral.shared.features.tournament.domain.model.TournamentParticipationState
+import com.yral.shared.features.tournament.domain.model.TournamentStatus
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+internal fun sampleAllTournaments(): List<Tournament> =
+    listOf(
+        Tournament(
+            id = "t1",
+            title = "SMILY SHOWDOWN",
+            subtitle = "Win up to ₹10,000 in",
+            participantsLabel = "32 Playing",
+            scheduleLabel = "Dec 4th • 6:00-6:30 pm",
+            status = TournamentStatus.Live(Clock.System.now() + 10.minutes),
+            participationState = TournamentParticipationState.Registered,
+            prizeBreakdown = samplePrizeRows(),
+        ),
+        Tournament(
+            id = "t2",
+            title = "SMILY SHOWDOWN",
+            subtitle = "Win up to ₹10,000 in",
+            participantsLabel = "15 Registered",
+            scheduleLabel = "Dec 5th • 6:00-6:30 pm",
+            status = TournamentStatus.Upcoming(Clock.System.now() + 10.minutes),
+            participationState = TournamentParticipationState.Registered,
+            prizeBreakdown = samplePrizeRows(),
+        ),
+        Tournament(
+            id = "t3",
+            title = "SMILY SHOWDOWN",
+            subtitle = "Win up to ₹10,000 in",
+            participantsLabel = "15 Participants",
+            scheduleLabel = "Dec 5th • 6:00-6:30 pm",
+            status = TournamentStatus.Ended,
+            participationState = TournamentParticipationState.Registered,
+            prizeBreakdown = samplePrizeRows(),
+        ),
+    )
+
+internal fun sampleHistoryTournaments(): List<Tournament> =
+    listOf(
+        Tournament(
+            id = "h1",
+            title = "SMILY SHOWDOWN",
+            subtitle = "Win up to ₹10,000 in",
+            participantsLabel = "15 Participants",
+            scheduleLabel = "Dec 5th • 6:00-6:30 pm",
+            status = TournamentStatus.Ended,
+            participationState = TournamentParticipationState.Registered,
+            prizeBreakdown = samplePrizeRows(),
+        ),
+    )
+
+private fun samplePrizeRows(): List<PrizeBreakdownRow> =
+    listOf(
+        PrizeBreakdownRow(rankLabel = "1st Place", amountLabel = "₹10,000 worth of"),
+        PrizeBreakdownRow(rankLabel = "2nd Place", amountLabel = "₹5,000 in"),
+        PrizeBreakdownRow(rankLabel = "3rd Place", amountLabel = "₹4,000 in"),
+        PrizeBreakdownRow(rankLabel = "4th Place", amountLabel = "₹3,000 in"),
+        PrizeBreakdownRow(rankLabel = "5th Place", amountLabel = "₹2,000 in"),
+        PrizeBreakdownRow(rankLabel = "6th Place", amountLabel = "₹1,000 in"),
+        PrizeBreakdownRow(rankLabel = "7th Place", amountLabel = "₹500 in"),
+        PrizeBreakdownRow(rankLabel = "8th Place", amountLabel = "₹400 in"),
+        PrizeBreakdownRow(rankLabel = "9th Place", amountLabel = "₹300 in"),
+        PrizeBreakdownRow(rankLabel = "10th Place", amountLabel = "₹100 in"),
+    )

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/TournamentUiState.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/TournamentUiState.kt
@@ -1,0 +1,11 @@
+package com.yral.shared.features.tournament.viewmodel
+
+import com.yral.shared.features.tournament.domain.model.Tournament
+
+data class TournamentUiState(
+    val selectedTab: Tab = Tab.All,
+    val tournaments: List<Tournament> = emptyList(),
+    val prizeBreakdownTournament: Tournament? = null,
+) {
+    enum class Tab { All, History }
+}

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/TournamentViewModel.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/TournamentViewModel.kt
@@ -1,0 +1,44 @@
+package com.yral.shared.features.tournament.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.yral.shared.features.tournament.domain.model.Tournament
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+
+class TournamentViewModel : ViewModel() {
+    private val _state: MutableStateFlow<TournamentUiState> =
+        MutableStateFlow(
+            TournamentUiState(
+                tournaments = sampleAllTournaments(),
+            ),
+        )
+    val state: StateFlow<TournamentUiState> = _state
+
+    fun onTabSelected(tab: TournamentUiState.Tab) {
+        _state.update {
+            val tournaments =
+                when (tab) {
+                    TournamentUiState.Tab.All -> sampleAllTournaments()
+                    TournamentUiState.Tab.History -> sampleHistoryTournaments()
+                }
+            it.copy(selectedTab = tab, tournaments = tournaments)
+        }
+    }
+
+    fun openPrizeBreakdown(tournament: Tournament) {
+        _state.update { it.copy(prizeBreakdownTournament = tournament) }
+    }
+
+    fun closePrizeBreakdown() {
+        _state.update { it.copy(prizeBreakdownTournament = null) }
+    }
+
+    @Suppress("EmptyFunctionBlock", "UnusedParameter")
+    fun onShareClicked(tournament: Tournament) {
+    }
+
+    @Suppress("EmptyFunctionBlock", "UnusedParameter")
+    fun onTournamentCtaClick(tournament: Tournament) {
+    }
+}


### PR DESCRIPTION
* feat: Creates `TournamentScreen` composable featuring a segmented tab layout (All vs History) and a list of tournaments.
* feat: Implements `TournamentViewModel` and `TournamentUiState` to manage screen state and tab switching logic.
* feat: Adds sample mock data generation for tournaments and prize breakdowns to populate the UI.
* build: Adds `TournamentModule` for Koin dependency injection setup.
* chore: Adds necessary string resources for the tournament feature.