### PR TITLE
feat: Integrates Tournament feature into main app navigation

### DIFF
--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/di/AppDI.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/di/AppDI.kt
@@ -20,6 +20,7 @@ import com.yral.shared.features.game.di.gameModule
 import com.yral.shared.features.leaderboard.di.leaderboardModule
 import com.yral.shared.features.profile.di.profileModule
 import com.yral.shared.features.root.di.rootModule
+import com.yral.shared.features.tournament.di.tournamentModule
 import com.yral.shared.features.uploadvideo.di.uploadVideoModule
 import com.yral.shared.features.wallet.di.walletModule
 import com.yral.shared.firebaseAuth.di.firebaseAuthModule
@@ -81,6 +82,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
             accountsModule,
             gameModule,
             leaderboardModule,
+            tournamentModule,
             uploadVideoModule,
             profileModule,
             walletModule,

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/HomeScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/HomeScreen.kt
@@ -68,6 +68,8 @@ import com.yral.shared.features.game.viewmodel.GameViewModel
 import com.yral.shared.features.leaderboard.ui.LeaderboardScreen
 import com.yral.shared.features.leaderboard.viewmodel.LeaderBoardViewModel
 import com.yral.shared.features.profile.viewmodel.ProfileViewModel
+import com.yral.shared.features.tournament.ui.TournamentScreen
+import com.yral.shared.features.tournament.viewmodel.TournamentViewModel
 import com.yral.shared.features.wallet.ui.WalletScreen
 import com.yral.shared.features.wallet.ui.btcRewards.VideoViewsRewardsBottomSheet
 import com.yral.shared.libs.designsystem.component.YralFeedback
@@ -115,6 +117,7 @@ internal fun HomeScreen(
                     is HomeComponent.Child.Account -> HomeTab.ACCOUNT
                     is HomeComponent.Child.Feed -> HomeTab.HOME
                     is HomeComponent.Child.Leaderboard -> HomeTab.LEADER_BOARD
+                    is HomeComponent.Child.Tournament -> HomeTab.TOURNAMENT
                     is HomeComponent.Child.Profile -> HomeTab.PROFILE
                     is HomeComponent.Child.UploadVideo -> HomeTab.UPLOAD_VIDEO
                     is HomeComponent.Child.Wallet -> HomeTab.WALLET
@@ -124,6 +127,7 @@ internal fun HomeScreen(
                     HomeTab.ACCOUNT -> component.onAccountTabClick()
                     HomeTab.HOME -> component.onFeedTabClick()
                     HomeTab.LEADER_BOARD -> component.onLeaderboardTabClick()
+                    HomeTab.TOURNAMENT -> component.onTournamentTabClick()
                     HomeTab.PROFILE -> component.onProfileTabClick()
                     HomeTab.UPLOAD_VIDEO -> component.onUploadVideoTabClick()
                     HomeTab.WALLET -> component.onWalletTabClick()
@@ -185,6 +189,7 @@ private fun HomeScreenContent(
         }
     val accountViewModel = koinViewModel<AccountsViewModel>(key = "account-$sessionKey")
     val leaderBoardViewModel = koinViewModel<LeaderBoardViewModel>(key = "leaderboard-$sessionKey")
+    val tournamentViewModel = koinViewModel<TournamentViewModel>(key = "tournament-$sessionKey")
 
     val profileVideos = getProfileVideos(profileViewModel, sessionKey, updateProfileVideosCount)
 
@@ -216,6 +221,11 @@ private fun HomeScreenContent(
                 LeaderboardScreen(
                     component = child.component,
                     leaderBoardViewModel = leaderBoardViewModel,
+                )
+
+            is HomeComponent.Child.Tournament ->
+                TournamentScreen(
+                    viewModel = tournamentViewModel,
                 )
 
             is HomeComponent.Child.UploadVideo ->
@@ -311,6 +321,7 @@ private fun HomeNavigationBar(
                 when (it) {
                     HomeTab.ACCOUNT -> !isWalletEnabled
                     HomeTab.WALLET -> isWalletEnabled
+                    HomeTab.TOURNAMENT -> false
                     else -> true
                 }
             }
@@ -452,6 +463,13 @@ private enum class HomeTab(
         categoryName = CategoryName.LEADERBOARD,
         icon = Res.drawable.leaderboard_nav_selected,
         unSelectedIcon = Res.drawable.leaderboard_nav_unselected,
+    ),
+    TOURNAMENT(
+        title = "Tournament",
+        categoryName = CategoryName.TOURNAMENTS,
+        icon = Res.drawable.leaderboard_nav_selected,
+        unSelectedIcon = Res.drawable.leaderboard_nav_unselected,
+        isNew = true,
     ),
     UPLOAD_VIDEO(
         title = "UploadVideo",

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/DefaultHomeComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/DefaultHomeComponent.kt
@@ -22,6 +22,7 @@ import com.yral.shared.features.auth.ui.LoginBottomSheetType
 import com.yral.shared.features.feed.nav.FeedComponent
 import com.yral.shared.features.leaderboard.nav.LeaderboardComponent
 import com.yral.shared.features.root.viewmodels.HomeViewModel
+import com.yral.shared.features.tournament.nav.TournamentComponent
 import com.yral.shared.features.uploadvideo.nav.UploadVideoRootComponent
 import com.yral.shared.features.wallet.nav.WalletComponent
 import com.yral.shared.features.wallet.ui.btcRewards.nav.DefaultVideoViewRewardsComponent
@@ -37,6 +38,7 @@ import com.yral.shared.libs.routing.routes.api.PostDetailsRoute
 import com.yral.shared.libs.routing.routes.api.Profile
 import com.yral.shared.libs.routing.routes.api.RewardOn
 import com.yral.shared.libs.routing.routes.api.RewardsReceived
+import com.yral.shared.libs.routing.routes.api.Tournaments
 import com.yral.shared.libs.routing.routes.api.VideoUploadSuccessful
 import com.yral.shared.libs.routing.routes.api.Wallet
 import com.yral.shared.rust.service.utils.CanisterData
@@ -106,6 +108,10 @@ internal class DefaultHomeComponent(
         navigation.replaceKeepingFeed(Config.Leaderboard)
     }
 
+    override fun onTournamentTabClick() {
+        navigation.replaceKeepingFeed(Config.Tournament)
+    }
+
     override fun onUploadVideoTabClick() {
         navigation.replaceKeepingFeed(Config.UploadVideo)
     }
@@ -123,6 +129,7 @@ internal class DefaultHomeComponent(
                     }.also { Logger.d("LinkSharing") { "Link details received $appRoute" } }
             is Wallet -> onWalletTabClick()
             is Leaderboard -> onLeaderboardTabClick()
+            is Tournaments -> onTournamentTabClick()
             is Profile -> onProfileTabClick()
             is AddVideo -> onUploadVideoTabClick()
             is GenerateAIVideo ->
@@ -182,6 +189,7 @@ internal class DefaultHomeComponent(
         when (config) {
             is Config.Feed -> Child.Feed(feedComponent(componentContext))
             is Config.Leaderboard -> Child.Leaderboard(leaderboardComponent(componentContext))
+            is Config.Tournament -> Child.Tournament(tournamentComponent(componentContext))
             is Config.UploadVideo -> Child.UploadVideo(uploadVideoComponent(componentContext))
             is Config.Profile -> Child.Profile(profileComponent(componentContext))
             is Config.Account -> Child.Account(accountComponent(componentContext))
@@ -192,6 +200,7 @@ internal class DefaultHomeComponent(
         when (child) {
             is Child.Feed -> Config.Feed to (child.component as? HomeChildSnapshotProvider)
             is Child.Leaderboard -> Config.Leaderboard to (child.component as? HomeChildSnapshotProvider)
+            is Child.Tournament -> Config.Tournament to (child.component as? HomeChildSnapshotProvider)
             is Child.UploadVideo -> Config.UploadVideo to child.component
             is Child.Profile -> Config.Profile to (child.component as? HomeChildSnapshotProvider)
             is Child.Account -> Config.Account to (child.component as? HomeChildSnapshotProvider)
@@ -224,6 +233,9 @@ internal class DefaultHomeComponent(
                 }
             },
         )
+
+    private fun tournamentComponent(componentContext: ComponentContext): TournamentComponent =
+        TournamentComponent(componentContext = componentContext)
 
     private fun uploadVideoComponent(componentContext: ComponentContext): UploadVideoRootComponent =
         UploadVideoRootComponent.Companion(
@@ -296,6 +308,9 @@ internal class DefaultHomeComponent(
 
         @Serializable
         data object Leaderboard : Config
+
+        @Serializable
+        data object Tournament : Config
 
         @Serializable
         data object UploadVideo : Config

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/HomeComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/HomeComponent.kt
@@ -13,6 +13,7 @@ import com.yral.shared.features.auth.ui.LoginBottomSheetType
 import com.yral.shared.features.feed.nav.FeedComponent
 import com.yral.shared.features.leaderboard.nav.LeaderboardComponent
 import com.yral.shared.features.root.viewmodels.HomeViewModel
+import com.yral.shared.features.tournament.nav.TournamentComponent
 import com.yral.shared.features.uploadvideo.nav.UploadVideoRootComponent
 import com.yral.shared.features.wallet.nav.WalletComponent
 import com.yral.shared.features.wallet.ui.btcRewards.nav.VideoViewRewardsComponent
@@ -28,6 +29,7 @@ abstract class HomeComponent {
 
     abstract fun onFeedTabClick()
     abstract fun onLeaderboardTabClick()
+    abstract fun onTournamentTabClick()
     abstract fun onUploadVideoTabClick()
     abstract fun onProfileTabClick()
     abstract fun onAccountTabClick()
@@ -47,6 +49,9 @@ abstract class HomeComponent {
         ) : Child()
         class Leaderboard(
             val component: LeaderboardComponent,
+        ) : Child()
+        class Tournament(
+            val component: TournamentComponent,
         ) : Child()
         class UploadVideo(
             val component: UploadVideoRootComponent,

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/nav/TournamentComponent.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/nav/TournamentComponent.kt
@@ -1,0 +1,17 @@
+package com.yral.shared.features.tournament.nav
+
+import com.arkivanov.decompose.ComponentContext
+
+interface TournamentComponent {
+    companion object {
+        operator fun invoke(componentContext: ComponentContext): TournamentComponent =
+            DefaultTournamentComponent(
+                componentContext,
+            )
+    }
+}
+
+internal class DefaultTournamentComponent(
+    componentContext: ComponentContext,
+) : TournamentComponent,
+    ComponentContext by componentContext

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/ui/TournamentScreen.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/ui/TournamentScreen.kt
@@ -136,7 +136,7 @@ private fun SegmentedTab(
     ) {
         Text(
             text = text,
-            style = LocalAppTopography.current.regSemiBold,
+            style = LocalAppTopography.current.baseBold,
             color = contentColor,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,

--- a/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/events/YralEvents.kt
+++ b/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/events/YralEvents.kt
@@ -1546,6 +1546,9 @@ enum class CategoryName {
     @SerialName("leaderboard")
     LEADERBOARD,
 
+    @SerialName("tournaments")
+    TOURNAMENTS,
+
     @SerialName("profile")
     PROFILE,
 

--- a/shared/libs/routing/routes-api/src/commonMain/kotlin/com/yral/shared/libs/routing/routes/api/AppRoute.kt
+++ b/shared/libs/routing/routes-api/src/commonMain/kotlin/com/yral/shared/libs/routing/routes/api/AppRoute.kt
@@ -44,6 +44,11 @@ object Leaderboard : AppRoute, ExternallyExposedRoute {
 }
 
 @Serializable
+object Tournaments : AppRoute, ExternallyExposedRoute {
+    const val PATH = "/tournaments"
+}
+
+@Serializable
 object AddVideo : AppRoute, ExternallyExposedRoute {
     const val PATH = "/addVideo"
 }


### PR DESCRIPTION
* feat: Adds Tournament tab to the bottom navigation bar in `HomeScreen`.
* feat: Implements routing and deep linking for the `/tournaments` path in `DefaultHomeComponent`.
* feat: Sets up `TournamentComponent` using Decompose for screen management.
* build: Registers `tournamentModule` in the app's Dependency Injection graph.
* style: Updates text style in `TournamentScreen` to `baseBold`.
* chore: Adds `TOURNAMENTS` entry to analytics events.