### PR TITLE
feat: Adds empty state for tournament history

### DIFF
--- a/shared/features/tournament/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/tournament/src/commonMain/composeResources/values/strings.xml
@@ -11,4 +11,9 @@
     <string name="tab_all">All</string>
     <string name="tab_history">History</string>
     <string name="title_price_breakdown">Prize Breakdown</string>
+    <string name="login_and_join_tournament">Login &amp; Join Tournament</string>
+    <string name="no_tournament_history_yet">No tournament history yet.</string>
+    <string name="msg_login_to_join_tournament">Login to join tournaments and start building your winning streak.</string>
+    <string name="msg_join_tournament">Join tournaments and start building your winning streak.</string>
+    <string name="join_tournament">Join Tournament</string>
 </resources>

--- a/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/TournamentUiState.kt
+++ b/shared/features/tournament/src/commonMain/kotlin/com/yral/shared/features/tournament/viewmodel/TournamentUiState.kt
@@ -6,6 +6,7 @@ data class TournamentUiState(
     val selectedTab: Tab = Tab.All,
     val tournaments: List<Tournament> = emptyList(),
     val prizeBreakdownTournament: Tournament? = null,
+    val isLoggedIn: Boolean = false,
 ) {
     enum class Tab { All, History }
 }


### PR DESCRIPTION
This commit introduces an empty state for the "History" tab on the tournament screen.

When a user has not participated in any tournaments, a message is now displayed.
- For logged-in users, it prompts them to "Join Tournament" and redirects them to the "All" tab.
- For logged-out users, it prompts them to "Login & Join Tournament" and initiates the login flow.