### PR TITLE
feat: Enables profile navigation from Tournament Leaderboard

### DIFF
--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/RootScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/RootScreen.kt
@@ -137,6 +137,7 @@ fun RootScreen(
                             participantsLabel = child.participantsLabel,
                             scheduleLabel = child.scheduleLabel,
                             onBack = rootComponent::onBackClicked,
+                            onOpenProfile = rootComponent::openProfile,
                         )
                     }
                 }


### PR DESCRIPTION
* build: Adds navigation logic to open user profiles from leaderboard rows

This commit enables users to navigate to a participant's profile by clicking on their row in the Tournament Leaderboard.

Key changes include:
*   Updating `TournamentLeaderboardScreen` to make leaderboard rows clickable.
*   Implementing `onUserClick` logic in `TournamentLeaderboardViewModel` to handle profile resolution.
*   Integrating `GetProfileDetailsV4UseCase` to fetch required profile data (like follow status) for other users before navigation.
*   Adding an `OpenProfile` event to the ViewModel and handling it in the UI to trigger the `onOpenProfile` callback.
*   Connecting the navigation callback in `RootScreen` to the `rootComponent::openProfile` function.