### PR TITLE
Migrates to Media3 Compose UI and implements Feed screen wake lock

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,7 @@ kotlinx-io = "0.8.2"
 kotlinxSerialization = "1.9.0"
 ksp = "2.1.21-2.0.2"
 ktor = "3.3.0"
-media3Exoplayer = "1.6.1"
+media3Exoplayer = "1.9.0"
 mixpanel = "8.2.0"
 mixpanel-session-replay = "1.0.0"
 sentryKmp = "0.23.0"
@@ -92,6 +92,7 @@ androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", versi
 androidx-media3-exoplayer-dash = { module = "androidx.media3:media3-exoplayer-dash", version.ref = "media3Exoplayer" }
 androidx-media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3Exoplayer" }
 androidx-media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3Exoplayer" }
+androidx-media3-ui-compose-material3 = { module = "androidx.media3:media3-ui-compose-material3", version.ref = "media3Exoplayer" }
 
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 

--- a/shared/features/feed/src/androidMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.android.kt
+++ b/shared/features/feed/src/androidMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.android.kt
@@ -1,7 +1,19 @@
 package com.yral.shared.features.feed.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 
 @Composable
 internal actual fun getContext(): Any = LocalContext.current
+
+@Composable
+internal actual fun KeepScreenOnEffect(keepScreenOn: Boolean) {
+    val view = LocalView.current
+    DisposableEffect(view, keepScreenOn) {
+        val previous = view.keepScreenOn
+        view.keepScreenOn = keepScreenOn
+        onDispose { view.keepScreenOn = previous }
+    }
+}

--- a/shared/features/feed/src/commonMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.kt
+++ b/shared/features/feed/src/commonMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.kt
@@ -134,6 +134,7 @@ fun FeedScreen(
 
     Column(modifier = modifier) {
         if (state.feedDetails.isNotEmpty()) {
+            KeepScreenOnEffect(true)
             YRALReelPlayer(
                 modifier = Modifier.weight(1f),
                 reels = getReels(state),
@@ -344,3 +345,6 @@ private fun ActionsRight(
 
 @Composable
 internal expect fun getContext(): Any
+
+@Composable
+internal expect fun KeepScreenOnEffect(keepScreenOn: Boolean)

--- a/shared/features/feed/src/iosMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.ios.kt
+++ b/shared/features/feed/src/iosMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.ios.kt
@@ -1,6 +1,18 @@
 package com.yral.shared.features.feed.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import platform.UIKit.UIApplication
 
 @Composable
 internal actual fun getContext(): Any = Unit // STUB
+
+@Composable
+internal actual fun KeepScreenOnEffect(keepScreenOn: Boolean) {
+    DisposableEffect(keepScreenOn) {
+        val application = UIApplication.sharedApplication
+        val previous = application.idleTimerDisabled
+        application.idleTimerDisabled = keepScreenOn
+        onDispose { application.idleTimerDisabled = previous }
+    }
+}

--- a/shared/libs/videoPlayer/build.gradle.kts
+++ b/shared/libs/videoPlayer/build.gradle.kts
@@ -21,6 +21,7 @@ kotlin {
             implementation(libs.androidx.media3.exoplayer.dash)
             implementation(libs.androidx.media3.ui)
             implementation(libs.androidx.media3.exoplayer.hls)
+            implementation(libs.androidx.media3.ui.compose.material3)
         }
         commonMain.dependencies {
             implementation(compose.runtime)

--- a/shared/libs/videoPlayer/src/androidMain/kotlin/com/yral/shared/libs/videoPlayer/util/CMPPlayer.android.kt
+++ b/shared/libs/videoPlayer/src/androidMain/kotlin/com/yral/shared/libs/videoPlayer/util/CMPPlayer.android.kt
@@ -2,15 +2,13 @@
 
 package com.yral.shared.libs.videoPlayer.util
 
-import android.view.ViewGroup
 import androidx.annotation.OptIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.layout.ContentScale
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.ui.AspectRatioFrameLayout
-import androidx.media3.ui.PlayerView
+import androidx.media3.ui.compose.ContentFrame
 import com.yral.shared.libs.videoPlayer.PlatformPlayer
 import com.yral.shared.libs.videoPlayer.PlatformPlayerError
 import com.yral.shared.libs.videoPlayer.model.ScreenResize
@@ -25,38 +23,14 @@ internal actual fun PlatformVideoPlayerView(
     platformPlayer: PlatformPlayer?,
     screenResize: ScreenResize,
 ) {
-    AndroidView(
-        factory = { context ->
-            PlayerView(context)
-                .apply {
-                    layoutParams =
-                        ViewGroup.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                        )
-                    useController = false
-                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                    setShowBuffering(PlayerView.SHOW_BUFFERING_NEVER)
-                    artworkDisplayMode = PlayerView.ARTWORK_DISPLAY_MODE_FILL
-                }
-        },
+    ContentFrame(
         modifier = modifier,
-        update = { playerView ->
-            playerView.player = platformPlayer?.internalExoPlayer
-            playerView.keepScreenOn = true
-            playerView.resizeMode =
-                when (screenResize) {
-                    ScreenResize.FIT -> AspectRatioFrameLayout.RESIZE_MODE_FIT
-                    ScreenResize.FILL -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                }
-        },
-        onReset = { playerView ->
-            playerView.keepScreenOn = false
-            playerView.player = null
-        },
-        onRelease = { playerView ->
-            playerView.keepScreenOn = false
-            playerView.player = null
-        },
+        player = platformPlayer?.internalExoPlayer,
+        contentScale =
+            when (screenResize) {
+                ScreenResize.FIT -> ContentScale.Fit
+                ScreenResize.FILL -> ContentScale.Crop
+            },
+        shutter = {},
     )
 }


### PR DESCRIPTION
* build: Upgrades Media3 Exoplayer to 1.9.0 and adds `media3-ui-compose-material3` dependency.
* refactor: Updates `CMPPlayer` on Android to use the native Compose `ContentFrame` component, replacing the legacy `PlayerView` wrapped in `AndroidView`.
* feat: Implements `KeepScreenOnEffect` mechanism for `FeedScreen` to prevent device sleep during playback.
    *   Adds common `expect`/`actual` definitions and invokes the effect when feed content is active.
    *   Android: Uses `LocalView.keepScreenOn` to manage state.
    *   iOS: Uses `UIApplication.idleTimerDisabled` to manage state.
* chore: Removes unused `SessionState` import in `ChatWallViewModel`.