### PR TITLE
Adds `contentScale` support to `VideoSurface`

### DIFF
--- a/shared/libs/video-playback/src/androidMain/kotlin/com/yral/shared/libs/videoplayback/ui/AndroidVideoSurface.kt
+++ b/shared/libs/video-playback/src/androidMain/kotlin/com/yral/shared/libs/videoplayback/ui/AndroidVideoSurface.kt
@@ -22,6 +22,7 @@ internal class AndroidVideoSurfaceHandle(
 @Composable
 actual fun VideoSurface(
     modifier: Modifier,
+    contentScale: ContentScale,
     shutter: @Composable () -> Unit,
     onHandleReady: (VideoSurfaceHandle) -> Unit,
 ) {
@@ -31,7 +32,7 @@ actual fun VideoSurface(
     ContentFrame(
         modifier = modifier,
         player = playerState.value,
-        contentScale = ContentScale.Fit,
+        contentScale = contentScale,
         shutter = shutter,
     )
 

--- a/shared/libs/video-playback/src/commonMain/kotlin/com/yral/shared/libs/videoplayback/ui/VideoFeed.kt
+++ b/shared/libs/video-playback/src/commonMain/kotlin/com/yral/shared/libs/videoplayback/ui/VideoFeed.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.yral.shared.libs.videoplayback.MediaDescriptor
 import com.yral.shared.libs.videoplayback.PlaybackCoordinator
 import com.yral.shared.libs.videoplayback.VideoSurfaceHandle
@@ -153,6 +154,7 @@ fun VideoSurfaceSlot(
     index: Int,
     coordinator: PlaybackCoordinator,
     modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
     shutter: @Composable () -> Unit = {},
     overlay: @Composable () -> Unit = {},
 ) {
@@ -161,6 +163,7 @@ fun VideoSurfaceSlot(
 
         VideoSurface(
             modifier = Modifier.fillMaxSize(),
+            contentScale = contentScale,
             shutter = shutter,
             onHandleReady = { handle -> surfaceHandle = handle },
         )

--- a/shared/libs/video-playback/src/commonMain/kotlin/com/yral/shared/libs/videoplayback/ui/VideoSurface.kt
+++ b/shared/libs/video-playback/src/commonMain/kotlin/com/yral/shared/libs/videoplayback/ui/VideoSurface.kt
@@ -2,11 +2,13 @@ package com.yral.shared.libs.videoplayback.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.yral.shared.libs.videoplayback.VideoSurfaceHandle
 
 @Composable
 expect fun VideoSurface(
     modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
     shutter: @Composable () -> Unit = {},
     onHandleReady: (VideoSurfaceHandle) -> Unit,
 )


### PR DESCRIPTION
*   **feat**: Adds an optional `contentScale` parameter to the `VideoSurface` expect/actual composable, defaulting to `ContentScale.Fit`.
*   **android**: Updates `AndroidVideoSurface` to propagate the `contentScale` parameter to the underlying `ContentFrame`.
*   **ios**: Implements `contentScale` support in `IosVideoSurface` by mapping `ContentScale.Crop` to `AVLayerVideoGravityResizeAspectFill` and other scales to `AVLayerVideoGravityResizeAspect`.
*   **ios**: Updates `PlayerViewContainer` and `UIKitView` logic to apply and update `videoGravity` based on the provided `contentScale`.