### PR TITLE
Refactors video playback architecture in `YRALReelPlayerCardStack` to…

### DIFF
--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/feed/FeedScaffoldScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/feed/FeedScaffoldScreen.kt
@@ -26,8 +26,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yral.shared.analytics.events.GameType
 import com.yral.shared.app.ui.screens.feed.FeedScaffoldScreenConstants.TOP_OVERLAY_ITEM_OFFSET_X
-import com.yral.shared.app.ui.screens.feed.performance.PrefetchVideoListenerImpl
-import com.yral.shared.app.ui.screens.feed.performance.VideoListenerImpl
 import com.yral.shared.features.feed.nav.FeedComponent
 import com.yral.shared.features.feed.ui.FeedActionsRight
 import com.yral.shared.features.feed.ui.FeedScreen
@@ -147,18 +145,6 @@ fun FeedScaffoldScreen(
             } else {
                 feedState.feedDetails.size
             },
-        getPrefetchListener = { PrefetchVideoListenerImpl(it) },
-        getVideoListener = {
-            VideoListenerImpl(
-                reel = it,
-                registerTrace = { id, tractType ->
-                    feedViewModel.registerTrace(id, tractType.name)
-                },
-                isTraced = { id, traceType ->
-                    feedViewModel.isAlreadyTraced(id, traceType.name)
-                },
-            )
-        },
     )
     RefreshBalanceAnimation(
         refreshBalanceState = gameState.refreshBalanceState.toRefreshBalanceAnimationState(),

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/tournament/TournamentGameScaffoldScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/tournament/TournamentGameScaffoldScreen.kt
@@ -171,7 +171,6 @@ fun TournamentGameScaffoldScreen(
                 onEdgeScrollAttempt = { _ -> },
                 limitReelCount = feedState.feedDetails.size,
                 getPrefetchListener = { reel -> PrefetchVideoListenerImpl(reel) },
-                getVideoListener = { null },
                 onSwipeVote = { direction, pageIndex ->
                     // Hot or Not voting: right swipe = hot, left swipe = not
                     val videoId = feedState.feedDetails.getOrNull(pageIndex)?.videoID

--- a/shared/features/feed/src/commonMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.kt
+++ b/shared/features/feed/src/commonMain/kotlin/com/yral/shared/features/feed/ui/FeedScreen.kt
@@ -51,8 +51,6 @@ import com.yral.shared.libs.videoPlayer.YRALReelPlayer
 import com.yral.shared.libs.videoPlayer.YRALReelPlayerCardStack
 import com.yral.shared.libs.videoPlayer.cardstack.SwipeDirection
 import com.yral.shared.libs.videoPlayer.model.Reels
-import com.yral.shared.libs.videoPlayer.pool.VideoListener
-import com.yral.shared.libs.videoPlayer.util.PrefetchVideoListener
 import com.yral.shared.libs.videoPlayer.util.ReelScrollDirection
 import com.yral.shared.reportVideo.domain.models.ReportSheetState
 import com.yral.shared.reportVideo.ui.ReportVideoSheet
@@ -83,8 +81,6 @@ fun FeedScreen(
     onPageChanged: (pageNo: Int, currentPage: Int) -> Unit,
     onEdgeScrollAttempt: (pageNo: Int) -> Unit,
     limitReelCount: Int,
-    getPrefetchListener: (reel: Reels) -> PrefetchVideoListener,
-    getVideoListener: (reel: Reels) -> VideoListener?,
     onSwipeVote: ((direction: SwipeDirection, pageIndex: Int) -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
@@ -175,8 +171,6 @@ fun FeedScreen(
                         onEdgeScrollAttempt(page)
                     },
                     onSwipeVote = onSwipeVote,
-                    getPrefetchListener = getPrefetchListener,
-                    getVideoListener = getVideoListener,
                 ) { pageNo, scrollToNext ->
                     FeedOverlay(
                         pageNo = pageNo,

--- a/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/YRALReelPlayerCardStack.kt
+++ b/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/YRALReelPlayerCardStack.kt
@@ -5,11 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.yral.shared.libs.videoPlayer.cardstack.SwipeDirection
 import com.yral.shared.libs.videoPlayer.cardstack.SwipeableCardStack
-import com.yral.shared.libs.videoPlayer.model.PlayerConfig
 import com.yral.shared.libs.videoPlayer.model.Reels
-import com.yral.shared.libs.videoPlayer.model.ScreenResize
-import com.yral.shared.libs.videoPlayer.pool.VideoListener
-import com.yral.shared.libs.videoPlayer.util.PrefetchVideoListener
 import com.yral.shared.libs.videoPlayer.util.ReelScrollDirection
 
 /**
@@ -35,7 +31,6 @@ import com.yral.shared.libs.videoPlayer.util.ReelScrollDirection
  * @param didVideoEnd Callback when the current video ends.
  * @param onEdgeScrollAttempt Callback when user tries to swipe past the last video.
  * @param getPrefetchListener Factory for creating prefetch listeners per reel.
- * @param getVideoListener Factory for creating video listeners per reel.
  * @param overlayContent Content to overlay on each video card (UI controls, etc.).
  * @param onSwipeVote Callback when a swipe vote is registered (direction, pageIndex).
  */
@@ -49,8 +44,6 @@ fun YRALReelPlayerCardStack(
     recordTime: (Int, Int) -> Unit,
     didVideoEnd: () -> Unit,
     onEdgeScrollAttempt: (pageNo: Int, atStart: Boolean, direction: ReelScrollDirection) -> Unit = { _, _, _ -> },
-    getPrefetchListener: (reel: Reels) -> PrefetchVideoListener,
-    getVideoListener: (reel: Reels) -> VideoListener?,
     onSwipeVote: ((direction: SwipeDirection, pageIndex: Int) -> Unit)? = null,
     overlayContent: @Composable (pageNo: Int, scrollToNext: () -> Unit) -> Unit,
 ) {
@@ -61,26 +54,8 @@ fun YRALReelPlayerCardStack(
         initialPage = initialPage,
         onPageLoaded = onPageLoaded,
         recordTime = recordTime,
-        playerConfig =
-            PlayerConfig(
-                isAutoHideControlEnabled = true,
-                isPauseResumeEnabled = false,
-                isFastForwardBackwardEnabled = false,
-                isSeekBarVisible = false,
-                isDurationVisible = false,
-                isMuteControlEnabled = false,
-                isSpeedControlEnabled = false,
-                isFullScreenEnabled = false,
-                isScreenLockEnabled = false,
-                isScreenResizeEnabled = false,
-                defaultScreenResize = ScreenResize.FILL,
-                reelVerticalScrolling = true,
-                loaderView = {},
-                didEndVideo = didVideoEnd,
-            ),
+        didVideoEnd = didVideoEnd,
         onEdgeScrollAttempt = onEdgeScrollAttempt,
-        getPrefetchListener = getPrefetchListener,
-        getVideoListener = { getVideoListener(it) },
         overlayContent = overlayContent,
         onSwipeVote = onSwipeVote,
     )

--- a/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/cardstack/CardStackItem.kt
+++ b/shared/libs/videoPlayer/src/commonMain/kotlin/com/yral/shared/libs/videoPlayer/cardstack/CardStackItem.kt
@@ -18,12 +18,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import coil3.compose.AsyncImage
-import com.yral.shared.libs.videoPlayer.YRALVideoPlayerWithControl
-import com.yral.shared.libs.videoPlayer.model.PlayerConfig
-import com.yral.shared.libs.videoPlayer.model.PlayerControls
 import com.yral.shared.libs.videoPlayer.model.PlayerData
-import com.yral.shared.libs.videoPlayer.pool.PlayerPool
-import com.yral.shared.libs.videoPlayer.pool.VideoListener
+import com.yral.shared.libs.videoplayback.PlaybackCoordinator
+import com.yral.shared.libs.videoplayback.ui.VideoSurfaceSlot
 import org.jetbrains.compose.resources.painterResource
 import yral_mobile.shared.libs.videoplayer.generated.resources.Res
 import yral_mobile.shared.libs.videoplayer.generated.resources.bakwaas
@@ -35,13 +32,12 @@ import yral_mobile.shared.libs.videoplayer.generated.resources.mast
  *
  * @param stackIndex Position in the stack (0 = front card, 1+ = stacked behind).
  * @param playerData Data for the video player.
- * @param playerConfig Configuration for the video player.
- * @param playerControls Controls for the video player (pause, record time, etc.).
- * @param playerPool Pool of video players for efficient resource management.
- * @param videoListener Listener for video events.
+ * @param coordinator Playback coordinator for video surfaces.
+ * @param mediaIndex Index of this media item in the coordinator feed.
  * @param swipeState State holder for swipe gestures (only used by front card).
  * @param screenWidth Width of the screen for calculating transforms.
  * @param screenHeight Height of the screen for calculating transforms.
+ * @param showVideoPlayer Whether to render the video surface for this card.
  * @param modifier Modifier for the card.
  * @param overlayContent Content to overlay on the video (UI controls, etc.).
  */
@@ -50,14 +46,11 @@ import yral_mobile.shared.libs.videoplayer.generated.resources.mast
 internal fun CardStackItem(
     stackIndex: Int,
     playerData: PlayerData,
-    playerConfig: PlayerConfig,
-    playerControls: PlayerControls,
-    playerPool: PlayerPool,
-    videoListener: VideoListener?,
+    coordinator: PlaybackCoordinator,
+    mediaIndex: Int,
     swipeState: SwipeableCardState,
     screenWidth: Float,
     screenHeight: Float,
-    showVideoPlayer: Boolean,
     modifier: Modifier = Modifier,
     overlayContent: @Composable () -> Unit,
 ) {
@@ -166,28 +159,21 @@ internal fun CardStackItem(
                 },
         contentAlignment = Alignment.TopStart,
     ) {
-        // Thumbnail for all cards (shows next videos in stack)
         key(playerData.videoId) {
-            AsyncImage(
-                model = playerData.thumbnailUrl,
-                contentDescription = null,
+            VideoSurfaceSlot(
+                index = mediaIndex,
+                coordinator = coordinator,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop,
+                shutter = {
+                    AsyncImage(
+                        model = playerData.thumbnailUrl,
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop,
+                    )
+                },
             )
-        }
-
-        // Video player: show based on activeVideoId from parent
-        if (showVideoPlayer) {
-            key(playerData.videoId) {
-                YRALVideoPlayerWithControl(
-                    modifier = Modifier.fillMaxSize(),
-                    playerData = playerData,
-                    playerConfig = playerConfig,
-                    playerControls = playerControls,
-                    playerPool = playerPool,
-                    videoListener = videoListener,
-                )
-            }
         }
 
         // Swipe feedback overlay for front card only


### PR DESCRIPTION
… use a centralized playback coordinator

* refactor: Replaces `PlayerPool` and `VideoListener` logic with `PlaybackCoordinator` and `VideoFeedSync` in `SwipeableCardStack`.
* refactor: Migrates `CardStackItem` to use `VideoSurfaceSlot` for rendering video content instead of `YRALVideoPlayerWithControl`.
* feat: Implements `PlaybackEventReporter` within `SwipeableCardStack` to handle video end events and progress tracking (recording time).
* build: Simplifies `YRALReelPlayerCardStack` API by removing `getVideoListener` and internalizing `PlayerConfig` management.
* chore: Removes legacy `VideoListenerImpl` and related tracing logic from `FeedScaffoldScreen`.
* perf: Updates `SwipeableCardStack` to synchronize media items with the playback coordinator and manage active indices based on swipe transitions.