### PR TITLE
fix: Increase hot or not tournament creation timeout to 1 hour

### DIFF
--- a/functions/hot_or_not_tournament.py
+++ b/functions/hot_or_not_tournament.py
@@ -409,7 +409,7 @@ def _analyze_videos_batch(videos: List[Dict], api_key: str, max_workers: int = 5
     return results
 
 # ─────────────────────  TOURNAMENT CREATION  ────────────────────────
-@https_fn.on_request(region="us-central1", timeout_sec=1500, memory=2048, secrets=["BALANCE_UPDATE_TOKEN", "GEMINI_API_KEY", "BACKEND_ADMIN_KEY", "MIXPANEL_TOKEN"])
+@https_fn.on_request(region="us-central1", timeout_sec=3600, memory=2048, secrets=["BALANCE_UPDATE_TOKEN", "GEMINI_API_KEY", "BACKEND_ADMIN_KEY", "MIXPANEL_TOKEN"])
 def create_hot_or_not_tournament(request: Request):
     """
     Create a new Hot or Not tournament with AI-analyzed videos.


### PR DESCRIPTION
The 25-minute timeout was insufficient for processing all videos with Gemini AI analysis. Increased to 1 hour to ensure reliable tournament creation.