### PR TITLE
Update permissions and authentication for Actions variable updates

### DIFF
--- a/.github/workflows/deploy-staging-app-to-play-store-on-merge-to-main.yml
+++ b/.github/workflows/deploy-staging-app-to-play-store-on-merge-to-main.yml
@@ -9,10 +9,10 @@ permissions:
   id-token: write
   contents: read
   pull-requests: read
-  actions: write
-  # This workflow updates a repository Actions variable via the REST API
-  # (`/repos/{owner}/{repo}/actions/variables/...`), which requires `actions: write`
-  # on the GITHUB_TOKEN. Keep this in sync with any variable update steps below.
+  # Note: GITHUB_TOKEN has no `variables` permission scope and cannot update
+  # repository Actions variables regardless of what is declared here. The
+  # "Persist new versionCode" step uses GH_VARIABLES_PAT (a fine-grained PAT
+  # with `variables:write` on this repo) instead.
 
 # Serialize all Play Store deployments to prevent race conditions on the
 # PLAY_STORE_ALPHA_APP_VERSION_CODE repo variable. Two concurrent runs could read the same
@@ -151,9 +151,12 @@ jobs:
           # The variable must be created manually before the first run — PATCH only updates an
           # existing variable (HTTP 204) and returns 404 if it is absent. Any non-204 response
           # is treated as a hard failure so version drift is caught immediately.
+          # GITHUB_TOKEN cannot update repository variables (no `variables` permission scope
+          # exists for it), so GH_VARIABLES_PAT is used — a fine-grained PAT with
+          # `variables:write` on this repository, stored as a repository secret.
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -X PATCH \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.GH_VARIABLES_PAT }}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${{ github.repository }}/actions/variables/PLAY_STORE_ALPHA_APP_VERSION_CODE" \


### PR DESCRIPTION
Revise the permissions and authentication method in the deployment workflow to utilize a fine-grained PAT for updating repository Actions variables, addressing the limitations of the GITHUB_TOKEN.