### PR TITLE
chore: route chat service to chat-ai.rishi.yral.com

### DIFF
--- a/shared/core/src/commonMain/kotlin/com/yral/shared/core/AppConfigurations.kt
+++ b/shared/core/src/commonMain/kotlin/com/yral/shared/core/AppConfigurations.kt
@@ -13,7 +13,7 @@ object AppConfigurations {
     const val PUMP_DUMP_BASE_URL = "yral-hot-or-not.go-bazzinga.workers.dev"
     const val UPLOAD_BASE_URL = "upload.yral.com"
     const val ANALYTICS_BASE_URL = "analytics.yral.com"
-    const val CHAT_BASE_URL = "chat.yral.com"
+    const val CHAT_BASE_URL = "chat-ai.rishi.yral.com"
     const val BILLING_BASE_URL = "billing.yral.com"
     const val DAILY_STREAK_BASE_URL = "daily-streaks.naitik.yral.com"
     const val SNOWPLOW_COLLECTOR_URL = "snowplow-collector.yral.com"


### PR DESCRIPTION
Flip `CHAT_BASE_URL` to the new Python chat service (`chat-ai.rishi.yral.com`) that replaces the Rust `yral-ai-chat`. Same 33 API endpoints, same contract, full prod-data migration in place with incremental sync.

**How verified:** End-to-end tested on my Moto g96 5G staging build — login, chat (text + image), Gemini vision, delete conversation all succeed against live migrated prod data.

**Rollback:** Revert this single-line commit if anything regresses on alpha.
