### PR TITLE
feat(chat): Chat as Human Creator (takeover) behind feature flag

### DIFF
--- a/HANDOFF-CHAT-AS-HUMAN.md
+++ b/HANDOFF-CHAT-AS-HUMAN.md
@@ -1,0 +1,362 @@
+# Handoff — Chat as Human (Creator Takeover)
+
+**For:** Sarvesh
+**From:** Rishi (built with Claude assistance)
+**Date:** 2026-05-28
+**Branch:** `rishi/test-v2-chat-url` (local only — not pushed)
+**Backend:** v2 (`agent.rishi.yral.com`)
+**Build target:** `prod debug` APK installed on Motorola `ZN52225232`
+
+---
+
+## TL;DR
+
+A human creator who owns AI influencers (max 3) can now **take over** any conversation a user is having with their bot — reply as a real human from inside the bot's avatar/name. The user sees system banners letting them know a human has joined / left.
+
+This is **additive only**. The existing user-to-AI chat flow is unchanged. The takeover UI replaces a previously inactive "switch to your human profile" prompt (`BotAccountConversationPrompt`) that was only shown to bot-account creators in their own conversations.
+
+**Critical architectural decision:** This feature uses **REST polling**, not WebSocket. The mobile app currently has zero WebSocket infrastructure (no Ktor WebSocket plugin, no event bus, no reconnection layer). Rather than build that out as a prerequisite for this one feature, we extended the existing REST pattern. Backend continues to emit WebSocket events for future use; mobile ignores them. **No new mobile infrastructure was added.**
+
+---
+
+## What's in scope
+
+### Three UI changes
+
+1. **Creator-side: takeover bar inside the conversation view** (`CreatorTakeoverBar.kt`)
+   - Visible only when `viewState.isBotAccount == true` (i.e., creator is operating one of their bot profiles).
+   - Replaces the old `BotAccountConversationPrompt` ("Switch to your human profile to chat") that used to occupy this slot.
+   - Toggle OFF (default): just shows a "Take over as [Creator Name]" button. No input.
+   - Toggle ON: shows "Release control" + countdown timer (`M:SS`) + reused `ChatInputArea` for typing.
+
+2. **Countdown timer**
+   - Initial value comes from the backend's `remaining_seconds` field (POST takeover / GET status).
+   - Decrements locally each second via a coroutine ticker.
+   - Reconciled with the server every ~6 seconds via the status poll (so it doesn't drift, and so it picks up resets when the user sends a new message).
+   - Visual states:
+     - Hidden when toggle is OFF.
+     - Normal style (white, 14sp) when remaining > 30 seconds.
+     - Prominent style (`YralColors.Red300`, 18sp, bold) when remaining ≤ 30 seconds.
+   - At 0 seconds, the next poll auto-flips the toggle OFF.
+
+3. **User-side system messages** (`SystemBannerMessage.kt`)
+   - Rendered inline in the existing message list when a message has `role="system"`.
+   - Centered, italic, 13sp, lighter background (`YralColors.Neutral800 @ 0.45 alpha`).
+   - Backend already persists takeover_started/ended as `role="system"` messages in the `messages` table (`app/routes/creator_takeover.py:63-70` and `:107-114`). So they come through the normal `GET /messages` paging — no extra mobile work was needed beyond rendering.
+
+---
+
+## Polling cadence
+
+While the creator is on a conversation screen with `isBotAccount=true` AND has takeover ON:
+
+| What | Interval | Implementation |
+|---|---|---|
+| Message refresh (pick up new user messages) | 3s | `ConversationViewModel.startTakeoverPolling()` — calls `refreshHistory()` which resets the existing paging source |
+| Takeover status reconciliation | ~6s (every 2nd message-refresh tick) | Same loop calls `GetHumanCreatorTakeoverStatusUseCase` |
+| Countdown display tick | 1s | Separate `takeoverCountdownJob` decrements `humanCreatorTakeoverRemainingSeconds` in state |
+
+The polling jobs are scoped to `viewModelScope` and stop on `onCleared()` AND in `resetState()` AND when the toggle goes OFF AND when the status poll returns `active=false`.
+
+**No polling happens** when:
+- The creator is not in bot-account mode
+- The toggle is OFF
+- The conversation screen is not the active ViewModel
+- The app is backgrounded (viewModelScope is paused — Android lifecycle behavior)
+
+When the app foregrounds, the `LaunchedEffect(viewState.isBotAccount, viewState.conversationId)` in `ChatConversationScreen.kt` calls `refreshHumanCreatorTakeoverStatus()` to reconcile, which restarts polling if still active.
+
+---
+
+## API endpoints used
+
+All on `agent.rishi.yral.com`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/v1/creator/conversations/{id}/human-creator-takeover` | Toggle ON. Returns `{ status, started_at, user_last_message_at, remaining_seconds }`. |
+| POST | `/api/v1/creator/conversations/{id}/human-creator-release` | Toggle OFF (manual). Returns `{ status: "released" }`. |
+| POST | `/api/v1/creator/conversations/{id}/human-creator-messages` | Send a message as the creator. Body `{ "content": "..." }`. Returns a `ChatMessage`. |
+| GET | `/api/v1/creator/conversations/{id}/human-creator-takeover-status` | Status reconciliation. Returns `{ active, started_at, user_last_message_at, remaining_seconds }`. |
+| GET | `/api/v1/creator/conversations/{id}/messages?limit=50&offset=0&order=desc` | Creator-side mirror of the user's `/messages` endpoint, used for polling. Same response shape. |
+
+All require Bearer auth (existing ID token from preferences).
+
+---
+
+## Files changed (10) and added (10)
+
+### Modified
+| File | Change |
+|---|---|
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt` | Added `SYSTEM("system")` to `ConversationMessageRole` enum + handle it in `fromApi`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt` | Added mappers for `HumanCreatorTakeoverStatusDto` and `StartHumanCreatorTakeoverResponseDto` → domain. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt` | Added 5 new endpoint methods to the interface (4 takeover endpoints + 1 creator-side message list). |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt` | Implementation of the 5 new endpoints + 5 new path constants. Follows existing `httpGet`/`httpPost` pattern verbatim. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt` | Added 5 new function signatures. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt` | Pass-through delegation of all 5 functions to the data source. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt` | Registered 4 new use cases. **Switched `ConversationViewModel` from `viewModelOf(::…)` to explicit `viewModel { ConversationViewModel(...) }`** because Koin's `viewModelOf` caps at 22 constructor params and the new constructor has 23. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt` | Added 4 use cases to constructor. Added 5 state fields to `ConversationViewState`. Added 4 public methods (`startHumanCreatorTakeover`, `releaseHumanCreatorTakeover`, `sendAsHumanCreator`, `refreshHumanCreatorTakeoverStatus`). Added private polling job + countdown ticker job. Hooked into `resetState()` and `onCleared()`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt` | Added detection for `role == SYSTEM` in `MessageRow` — routes to `SystemBannerMessage` instead of `MessageContent`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt` | Replaced the `BotAccountPrompt` branch in `bottomAreaState` with `CreatorTakeoverBar`. Added one `LaunchedEffect` that calls `refreshHumanCreatorTakeoverStatus()` when entering a conversation as a bot account. |
+| `shared/features/chat/src/commonMain/composeResources/values/strings.xml` | Added 4 string resources: `takeover_toggle_inactive`, `takeover_toggle_active`, `takeover_timer_label`, `takeover_input_placeholder`. |
+
+### New files
+| File | Purpose |
+|---|---|
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/HumanCreatorTakeoverStatusDto.kt` | DTO for `GET .../human-creator-takeover-status`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/StartHumanCreatorTakeoverResponseDto.kt` | DTO for `POST .../human-creator-takeover`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ReleaseHumanCreatorTakeoverResponseDto.kt` | DTO for `POST .../human-creator-release`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendHumanCreatorMessageRequestDto.kt` | Request body DTO for `POST .../human-creator-messages`. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/HumanCreatorTakeoverStatus.kt` | Domain model exposed to viewmodels. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/StartHumanCreatorTakeoverUseCase.kt` | Standard `SuspendUseCase` wrapper. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/ReleaseHumanCreatorTakeoverUseCase.kt` | Same. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/SendHumanCreatorMessageUseCase.kt` | Same, with `(conversationId, content)` Params. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetHumanCreatorTakeoverStatusUseCase.kt` | Same. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/SystemBannerMessage.kt` | Centered italic banner composable for `role="system"` messages. |
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt` | Toggle + countdown + reused `ChatInputArea`. |
+
+---
+
+## Symmetry notes (the SYMMETRY rule)
+
+Everything follows the existing chat-feature patterns:
+- **DTOs** are simple `@Serializable data class` with `@SerialName` — identical shape to `CreateConversationRequestDto`, `SendMessageRequestDto`, etc.
+- **Use cases** all extend `SuspendUseCase<Param, Result>` with `exceptionType = ExceptionType.CHAT.name` and use `appDispatchers.network` — identical shape to `CreateConversationUseCase`, `MarkConversationAsReadUseCase`.
+- **Data source methods** use the existing `httpGet` / `httpPost` helpers with the same Bearer-auth header pattern.
+- **Path constants** live in the existing private `companion object` block.
+- **Repository delegation** is one-liner pass-throughs (matches the existing pattern).
+- **DI registration** uses `factoryOf(::…)` for use cases, same as every other use case.
+
+The only file that deviates structurally is `ChatModule.kt` — it uses an explicit `viewModel { ConversationViewModel(...) }` block instead of `viewModelOf`. This is forced by Koin's 22-param cap on `viewModelOf`. The block listing is verbose but the alternative is bundling unrelated dependencies into a holder object, which would be worse for symmetry.
+
+---
+
+## Manual test plan on Motorola (`ZN52225232`)
+
+### Setup
+- **Account A (you, Rishi):** human creator who owns at least one AI influencer (e.g., "ChattyBot").
+- **Account B:** a regular user who has at least one ongoing conversation with ChattyBot. (You can use a second device, or sign out/in to swap.)
+- App is the `prod debug` APK already installed.
+
+### Scenario 1 — Regression: existing chat still works (RUN THIS FIRST)
+1. Sign in as Account B (regular user).
+2. Open conversation with ChattyBot. Send "hi". Expect: AI reply arrives as normal, no visible UI change vs. before.
+3. Inbox loads normally, no system banners visible in any existing conversation that has no takeover history.
+
+**Pass criterion:** zero behavior change for the regular user path.
+
+### Scenario 2 — Creator-side takeover happy path
+1. Sign in as Account A.
+2. Switch to ChattyBot profile via the existing profile switcher (this is unchanged — I didn't touch it).
+3. App routes you to Inbox (existing behavior — `DefaultChatHomeComponent.kt:37`).
+4. Tap a conversation. Expect: existing read-only message list, BUT instead of the old "Switch to your human profile to chat" prompt, you now see the **CreatorTakeoverBar** at the bottom: a single button labelled "Take over as ChattyBot" (the bot's display name).
+5. Tap the button. Expect:
+   - Toggle button changes to "Release control" with yellow border, yellow text.
+   - A countdown appears next to it: "2:00" (or whatever remaining_seconds the backend returned).
+   - A text input appears below with placeholder "Reply as ChattyBot…".
+6. Type "hello, real human here" and tap send. Expect: message appears in the message list attributed to ChattyBot (same avatar/name flip as before).
+7. Wait 90s without sending anything. Expect: countdown counts down to ~0:30 then switches to red+larger font.
+8. Wait another 30s. Expect: at 0:00 (next status poll), the toggle auto-flips OFF, input disappears.
+
+### Scenario 3 — Manual release
+1. From step 5 above (takeover ON), tap "Release control".
+2. Expect: button immediately flips back to "Take over as ChattyBot", input disappears, countdown disappears.
+3. A backend system message "ChattyBot has left the chat" gets written, but you won't see it on the creator side until the next message refresh (or screen reopen).
+
+### Scenario 4 — User-side system messages
+1. Switch the Motorola to Account B (or use a second device).
+2. Open the conversation with ChattyBot that you used in Scenario 2.
+3. Expect: a centered italic banner "📣 ChattyBot, the human creator behind ChattyBot, has joined the chat. You're now talking to them directly." (the display name fields end up identical because the backend uses `inf_display_name` for both — see backend note below).
+4. Expect: any messages sent by the creator during takeover appear as normal ChattyBot messages (same avatar, same name on the left).
+5. Expect: a second banner "ChattyBot has left the chat" after the creator releases.
+
+### Scenario 5 — Two-device reconciliation
+1. Take over from device A.
+2. Open the same conversation on device B (as the same creator). Expect: the CreatorTakeoverBar already shows the ON state with the remaining timer.
+3. Release from device B. Expect: device A's next poll (within 6 seconds) flips its toggle OFF.
+
+### Scenario 6 — Network failure on toggle
+1. Turn airplane mode ON.
+2. Tap "Take over as ChattyBot". Expect: button shows "starting" briefly then reverts to OFF. No crash. No partial state.
+
+---
+
+## Known limitations / things to improve later
+
+1. **`refreshHistory()` every 3 seconds may cause a brief LazyColumn refresh flicker.** The existing `refreshHistory()` mechanism resets the paging source, which is heavier than strictly necessary. If you see flicker in testing, the targeted fix would be to fetch new messages directly via `chatRepository.getCreatorConversationMessagesPage(...)` and merge into the existing overlay (similar to how `systemOverlayMessagesFlow` works). I deliberately did NOT do this to keep the diff smaller and stick to one mechanism.
+
+2. **Backend display-name quirk.** The backend uses `inf_display_name` for both the human creator and the bot in the join banner (see `app/routes/creator_takeover.py:57-62`). The banner reads "[BotName], the human creator behind [BotName], has joined the chat" — which is a backend bug, not a mobile bug. Worth a separate ticket to use `inf_parent_principal_id`'s display name once that's available.
+
+3. **No optimistic UI for `sendAsHumanCreator`.** Today the creator types, hits send, the network round-trips, then the message shows up after `refreshHistory()` completes. The existing `_overlay.pending` pattern (used in `sendMessage` for regular users) could be reused. Out of scope for v1.
+
+4. **Battery / bandwidth.** Polling at 3s + 6s only happens while the creator is on the conversation screen with takeover ON. Not while browsing inbox. Not while backgrounded. Should be fine for the expected usage pattern (occasional creator stepping in for a few minutes).
+
+5. **Profile switcher untouched.** The existing profile switcher (in `ProfileMainScreen.kt`) is unchanged. The takeover feature relies on `sessionManager.isBotAccount` flipping correctly, which the existing switcher already does.
+
+6. **WebSocket events ignored.** The backend continues to emit `human_creator_takeover_started`, `human_creator_takeover_ended`, and `new_user_message_during_takeover` via WebSocket. Mobile ignores them. When mobile gets a WebSocket layer (likely as part of Phase 2.7 SSE streaming), the polling loop in `ConversationViewModel.startTakeoverPolling()` can be swapped for event subscription — the rest of the takeover code stays unchanged.
+
+---
+
+## Build + install commands
+
+```bash
+cd ~/Claude\ Projects/yral-mobile
+./gradlew :androidApp:assembleDebug --no-configuration-cache
+
+# APK paths:
+#   prod (agent.rishi.yral.com):  androidApp/build/outputs/apk/prod/debug/androidApp-prod-debug.apk
+#   staging:                       androidApp/build/outputs/apk/staging/debug/androidApp-staging-debug.apk
+
+adb install -r androidApp/build/outputs/apk/prod/debug/androidApp-prod-debug.apk
+```
+
+If you hit the Gobley/Rust-NDK error on first build, the NDK needs to be symlinked into the SDK path Gradle looks at:
+```bash
+ln -s ~/android-sdk/ndk ~/Library/Android/sdk/ndk
+mkdir -p ~/.cargo/bin && ln -sf "$(rustup which rustc)" ~/.cargo/bin/rustc && ln -sf "$(rustup which cargo)" ~/.cargo/bin/cargo
+```
+
+---
+
+## Branch state
+
+- Branch: `rishi/test-v2-chat-url`
+- Local commits: just the one-line `CHAT_BASE_URL` change to `agent.rishi.yral.com` from before this work. The takeover code is **uncommitted** in the working tree, ready for you to review and shape into commits as you see fit.
+- Never pushed to origin.
+
+When you're ready to commit, I'd suggest:
+1. One commit for the data layer (DTOs, mappers, ChatDataSource, ChatRemoteDataSource, ChatRepository, ChatRepositoryImpl, use cases, DI).
+2. One commit for the ViewModel changes.
+3. One commit for the UI (`SystemBannerMessage`, `CreatorTakeoverBar`, `ConversationMessagesList`, `ChatConversationScreen`, strings.xml).
+
+Total diff is ~10 modified files, ~10 new files, ~600 lines of strict code.
+
+---
+
+## Bug fix round 1 — 2026-05-28 (after first Motorola test)
+
+Rishi tested the original build and surfaced 3 real bugs. Full RCA + fixes summarized below. **Only one of these is a mobile change; the other two are owned by the backend session** (see `~/Claude Projects/yral-rishi-agent/PROGRESS.md` "OPEN BUGS — Phase 1.10" section for backend details).
+
+### What Rishi observed
+1. Timer counted down even while the creator was actively typing replies — felt like the wrong reference point.
+2. Timer hit 0:00 but creator could still send messages, and the toggle didn't flip OFF immediately.
+3. "Anastasia Ivanova (Hindi) has left the chat" banner appeared **3 times** in a single conversation when viewed from the user side.
+
+### Bug 1 — Timer semantics (owned by backend)
+
+**Root cause:** backend's `remaining_seconds` is computed from `user_last_message_at`, not `creator_last_message_at`. So the timer measured **user silence**, not **creator silence**.
+
+**Decision (Rishi):** Option A — timer represents the **creator's** response window. Resets only on creator messages. If creator goes silent for 2 minutes, AI takes back over.
+
+**Mobile change:** none. Mobile reads whatever `remaining_seconds` the backend returns and treats it as opaque. When backend ships the semantics swap, mobile behavior automatically follows.
+
+### Bug 2 — Timer at 0:00 but creator could still chat (mobile + backend)
+
+**Root cause:** three compounding gaps —
+- Mobile local ticker decremented `remainingSeconds` to 0 but did NOT flip `isHumanCreatorTakeoverActive` to false. That only happened on the next ~6s status poll.
+- Backend auto-release sweep ran every 30 seconds, so server could be 0-30s late to set `takeover_active = FALSE`.
+- During that gap, `POST .../human-creator-messages` accepted sends because `takeover_active` was still TRUE on the server.
+
+**Mobile fix (shipped in this APK):** `ConversationViewModel.startCountdownTicker()` — when the local timer reaches 0, mobile now immediately calls `releaseHumanCreatorTakeover()`. This:
+- Fires `POST .../human-creator-release` to the backend (no waiting for the sweep)
+- Flips local `isHumanCreatorTakeoverActive = false` synchronously, so the input area and timer disappear within ~1 frame
+- Calls `refreshHistory()` so the "left" system banner shows up in the creator's own view too
+
+**Backend fixes (owned by backend session):**
+- Drop sweep interval from 30s → 5s
+- Reject `POST .../human-creator-messages` if `creator_last_message_at` is already older than 2 minutes (defense in depth, in case mobile's release call drops)
+
+### Bug 3 — "X has left the chat" duplicated 3× (owned by backend)
+
+**Root cause A:** `takeover_repo.activate()` uses `user_last_message_at = COALESCE(user_last_message_at, NOW())`. A fresh takeover started right after a previous one (with the user still silent) inherits the stale timestamp → auto-release sweep fires within 30s → writes another "left" message. Each cycle accumulates one more banner.
+
+**Root cause B:** "left" system message is written from TWO backend paths (`creator_takeover.py:107-114` manual release + `main.py:135-142` sweep). Neither is idempotent — both write a fresh row with a unique ID, so mobile-side dedup can't merge them.
+
+**Mobile change:** none. Mobile faithfully renders every `role="system"` message the backend returns. Once backend stops emitting duplicates, the banners stop duplicating.
+
+**Backend fixes (owned by backend session):** see `PROGRESS.md` for the full SQL. Summary:
+- Migration: add `creator_last_message_at` column, set to NOW on every fresh `activate()`
+- `deactivate()` uses `UPDATE ... WHERE active=TRUE RETURNING id` — only write the "left" banner if a row was actually flipped
+- Sweep additionally guards: don't write a "left" if one was already written in the last 10s
+
+### Files changed in this fix round (1 file)
+| File | Change |
+|---|---|
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt` | `startCountdownTicker()` calls `releaseHumanCreatorTakeover()` when `next == 0`. ~6 lines added. |
+
+### Retest plan (after backend ships)
+
+Same three scenarios as the original handoff, but with these new checks:
+
+**Scenario 2 (creator-side takeover) — additions:**
+- Take over and DON'T type anything. Send a message from a second device as the user. Expect: timer keeps counting down regardless of the user message (because Option A — only creator's activity resets it).
+- Take over and immediately type a message. Expect: timer resets to 2:00 the moment your message is sent.
+- Wait until 0:00. Expect: the toggle flips OFF **within 1 second** of 0:00 (was previously 0-36s delay). Input area disappears. The "has left the chat" banner appears in the message list immediately on the next refresh.
+
+**Scenario 3 (user-side system messages) — additions:**
+- Take over → release → take over → release. Open the conversation as the user. Expect: exactly **one** "joined" and **one** "left" per cycle. Total 4 banners across 2 cycles, not more.
+
+**Scenario 6 (network failure on toggle) — unchanged.**
+
+### State of this APK (2026-05-28)
+
+- Mobile fix for Bug 2 is **in the installed APK on `ZN52225232`**.
+- Mobile fix for Bug 1 = nothing to do, fully backend.
+- Mobile fix for Bug 3 = nothing to do, fully backend.
+
+**Do not retest the previously-broken scenarios on this APK until the backend session has shipped its fixes.** The mobile change alone won't fully resolve any of the three bugs — Bug 2 will still show server-side staleness on the user side, Bugs 1 and 3 are entirely backend.
+
+---
+
+## Latency fix round — 2026-05-28 (after round-1 retest)
+
+Rishi reported that creator-side sends were slow: send button greyed correctly, but the message took up to ~1 second to appear on screen. RCA:
+
+- `sendAsHumanCreator` did the POST (~200-500ms), then called `refreshHistory()` which **reset the paging source and fired a second `GET /messages` call** (~200-500ms more). Two back-to-back round trips before the bubble appeared.
+- No optimistic UI — the message was completely invisible until both calls completed. The regular user `sendMessage` flow has had optimistic UI since day one via `_overlay.pending`; I just hadn't carried that pattern over.
+
+**Fix shipped in this APK (one file, ~50 lines changed):**
+
+`ConversationViewModel.sendAsHumanCreator()` now:
+1. Builds a `LocalMessage(role=ASSISTANT, status=SENDING)` immediately and adds it to `_overlay.pending` **before** the network call. This makes the bubble appear within one frame (~16ms).
+2. On POST success: removes the pending entry and adds a `SentMessage` to `_overlay.sent` with the real server-returned `ChatMessage`. No `refreshHistory()` — the next 3s polling tick will hydrate the message into the paged history, and the existing `loadedMessageIds` dedup will remove the overlay copy automatically.
+3. On POST failure: marks the pending message as `LocalMessageStatus.FAILED` (existing red-error styling kicks in automatically).
+
+Same pattern as the regular `sendMessage` flow (see `ConversationViewModel.kt:1042`). Symmetry preserved.
+
+### Expected behavior now
+- **Tap send → bubble visible: ~16ms** (one frame). Was 400-1000ms.
+- **Button stays greyed for the POST round trip** (~200-500ms), then re-enables. Prevents double-sends.
+- **If the POST fails**, the bubble turns red with the existing "Message Failed. Tap to resend" affordance. ⚠️ **Known limitation:** tapping retry currently no-ops for creator messages because the existing `retry()` uses `draftForRetry` which I left null for creator sends. To recover from a failure, the creator has to retype. Acceptable for v1; cleaner fix would be a dedicated `retryCreatorMessage(localId)` path or storing the content for retry.
+
+### Brief duplicate-bubble race (rare, self-correcting)
+If the 3s polling refresh fires *during* a POST's round trip, the paged result could briefly load the real message while the optimistic pending is still in `_overlay.pending`. The user would see their message twice for ~half a second. Self-corrects when the POST completes (pending → sent → dedup'd by loadedMessageIds). Not worth fixing now; would require either pausing polling during an active send, or content/timestamp-based dedup between pending and remote.
+
+### Files changed in this round (1 file)
+| File | Change |
+|---|---|
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt` | `sendAsHumanCreator()` rewritten to use optimistic overlay; removed the `refreshHistory()` call. ~50 lines net. |
+
+---
+
+## Flicker fix — 2026-05-28 (after latency-round retest)
+
+Rishi reported visible flicker during creator sends — the "rare race" I flagged in the latency fix round was actually common enough to be noticeable.
+
+**Root cause:** the polling loop in `startTakeoverPolling()` calls `refreshHistory()` every 3 seconds unconditionally. If that tick fired between the moment the creator pressed send (optimistic pending added) and the moment the POST returned (pending replaced with sent), the paging refresh could pull the real message from the backend in parallel — so for ~½ second the user saw their bubble twice.
+
+**Fix (1 line + comment):** in `startTakeoverPolling()`, skip the `refreshHistory()` call when `isHumanCreatorMessageSending` is true. Once the POST completes (success or failure), the flag flips false and the next polling tick refreshes normally.
+
+```kotlin
+if (!_viewState.value.isHumanCreatorMessageSending) {
+    refreshHistory()
+}
+```
+
+**Trade-off:** if a NEW user message arrives during the same window (creator's POST in flight), the creator won't see it until the next 3s tick AFTER their send completes. So worst-case delay for the creator seeing an incoming user message goes from 3s → ~3.5s. Acceptable. The status poll (every ~6s) still runs unconditionally so timer reconciliation isn't affected.
+
+### Files changed in this round (1 file)
+| File | Change |
+|---|---|
+| `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt` | One-line guard in `startTakeoverPolling()` to skip `refreshHistory()` while a creator-send is in flight. |

--- a/shared/features/chat/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/chat/src/commonMain/composeResources/values/strings.xml
@@ -25,6 +25,12 @@
     <string name="switch_profile">Switch Profile</string>
     <string name="switch_profile_failed">Unable to switch profile. Please try again.</string>
 
+    <!-- Chat as Human (creator takeover) -->
+    <string name="takeover_toggle_inactive">Take over as %1$s</string>
+    <string name="takeover_toggle_active">Release control</string>
+    <string name="takeover_timer_label">%1$s</string>
+    <string name="takeover_input_placeholder">Reply as %1$s…</string>
+
     <!-- Message Bubble -->
     <string name="message_failed_tap_to_resend">Message Failed. Tap to resend</string>
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
@@ -1,14 +1,19 @@
 package com.yral.shared.features.chat.data
 
 import com.yral.shared.features.chat.attachments.ChatAttachment
+import com.yral.shared.features.chat.data.models.ChatMessageDto
 import com.yral.shared.features.chat.data.models.ConversationDto
 import com.yral.shared.features.chat.data.models.ConversationMessagesResponseDto
 import com.yral.shared.features.chat.data.models.ConversationsResponseDto
 import com.yral.shared.features.chat.data.models.DeleteConversationResponseDto
+import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
 import com.yral.shared.features.chat.data.models.InfluencerDto
 import com.yral.shared.features.chat.data.models.InfluencersResponseDto
+import com.yral.shared.features.chat.data.models.ReleaseHumanCreatorTakeoverResponseDto
+import com.yral.shared.features.chat.data.models.SendHumanCreatorMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageResponseDto
+import com.yral.shared.features.chat.data.models.StartHumanCreatorTakeoverResponseDto
 import com.yral.shared.features.chat.data.models.UploadResponseDto
 
 interface ChatDataSource {
@@ -53,4 +58,22 @@ interface ChatDataSource {
     ): UploadResponseDto
 
     suspend fun markConversationAsRead(conversationId: String)
+
+    suspend fun startHumanCreatorTakeover(conversationId: String): StartHumanCreatorTakeoverResponseDto
+
+    suspend fun releaseHumanCreatorTakeover(conversationId: String): ReleaseHumanCreatorTakeoverResponseDto
+
+    suspend fun sendHumanCreatorMessage(
+        conversationId: String,
+        request: SendHumanCreatorMessageRequestDto,
+    ): ChatMessageDto
+
+    suspend fun getHumanCreatorTakeoverStatus(conversationId: String): HumanCreatorTakeoverStatusDto
+
+    suspend fun listCreatorConversationMessages(
+        conversationId: String,
+        limit: Int,
+        offset: Int,
+        order: String = "desc",
+    ): ConversationMessagesResponseDto
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
@@ -4,16 +4,21 @@ import co.touchlab.kermit.Logger
 import com.yral.shared.core.exceptions.YralException
 import com.yral.shared.features.chat.attachments.ChatAttachment
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import com.yral.shared.features.chat.data.models.ChatMessageDto
 import com.yral.shared.features.chat.data.models.ConversationDto
 import com.yral.shared.features.chat.data.models.ConversationMessagesResponseDto
 import com.yral.shared.features.chat.data.models.ConversationsResponseDto
 import com.yral.shared.features.chat.data.models.CreateConversationRequestDto
 import com.yral.shared.features.chat.data.models.DeleteConversationResponseDto
+import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
 import com.yral.shared.features.chat.data.models.InfluencerDto
 import com.yral.shared.features.chat.data.models.InfluencerFeedResponseDto
 import com.yral.shared.features.chat.data.models.InfluencersResponseDto
+import com.yral.shared.features.chat.data.models.ReleaseHumanCreatorTakeoverResponseDto
+import com.yral.shared.features.chat.data.models.SendHumanCreatorMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageResponseDto
+import com.yral.shared.features.chat.data.models.StartHumanCreatorTakeoverResponseDto
 import com.yral.shared.features.chat.data.models.UploadResponseDto
 import com.yral.shared.features.chat.data.models.toInfluencersResponseDto
 import com.yral.shared.http.UPLOAD_FILE_TIME_OUT
@@ -274,6 +279,88 @@ class ChatRemoteDataSource(
         }
     }
 
+    override suspend fun startHumanCreatorTakeover(conversationId: String): StartHumanCreatorTakeoverResponseDto {
+        val idToken = getIdToken()
+        return httpPost(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(CREATOR_CONVERSATIONS_PATH, conversationId, TAKEOVER_PATH)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun releaseHumanCreatorTakeover(conversationId: String): ReleaseHumanCreatorTakeoverResponseDto {
+        val idToken = getIdToken()
+        return httpPost(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(CREATOR_CONVERSATIONS_PATH, conversationId, RELEASE_PATH)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun sendHumanCreatorMessage(
+        conversationId: String,
+        request: SendHumanCreatorMessageRequestDto,
+    ): ChatMessageDto {
+        val idToken = getIdToken()
+        return httpPost(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(CREATOR_CONVERSATIONS_PATH, conversationId, CREATOR_MESSAGES_PATH)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+            setBody(request)
+        }
+    }
+
+    override suspend fun getHumanCreatorTakeoverStatus(conversationId: String): HumanCreatorTakeoverStatusDto {
+        val idToken = getIdToken()
+        return httpGet(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(CREATOR_CONVERSATIONS_PATH, conversationId, TAKEOVER_STATUS_PATH)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun listCreatorConversationMessages(
+        conversationId: String,
+        limit: Int,
+        offset: Int,
+        order: String,
+    ): ConversationMessagesResponseDto {
+        val idToken = getIdToken()
+        return httpGet(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(CREATOR_CONVERSATIONS_PATH, conversationId, MESSAGES_PATH)
+                parameters.append("limit", limit.toString())
+                parameters.append("offset", offset.toString())
+                parameters.append("order", order)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
     private suspend fun getIdToken() =
         preferences.getString(PrefKeys.ID_TOKEN.name)
             ?: throw YralException("Authorisation not found")
@@ -293,5 +380,10 @@ class ChatRemoteDataSource(
         private const val MESSAGES_PATH = "messages"
         private const val READ_PATH = "read"
         private const val UPLOAD_PATH = "api/v1/media/upload"
+        private const val CREATOR_CONVERSATIONS_PATH = "api/v1/creator/conversations"
+        private const val TAKEOVER_PATH = "human-creator-takeover"
+        private const val RELEASE_PATH = "human-creator-release"
+        private const val CREATOR_MESSAGES_PATH = "human-creator-messages"
+        private const val TAKEOVER_STATUS_PATH = "human-creator-takeover-status"
     }
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
@@ -1,14 +1,17 @@
 package com.yral.shared.features.chat.data
 
+import com.yral.shared.features.chat.data.models.SendHumanCreatorMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.toDomain
 import com.yral.shared.features.chat.data.models.toDomainActiveOnly
 import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.ChatMessage
 import com.yral.shared.features.chat.domain.models.ChatMessageType
 import com.yral.shared.features.chat.domain.models.Conversation
 import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResult
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencersPageResult
 import com.yral.shared.features.chat.domain.models.SendMessageDraft
@@ -141,6 +144,43 @@ class ChatRepositoryImpl(
     override suspend fun markConversationAsRead(conversationId: String) {
         dataSource.markConversationAsRead(conversationId)
     }
+
+    override suspend fun startHumanCreatorTakeover(conversationId: String): HumanCreatorTakeoverStatus =
+        dataSource
+            .startHumanCreatorTakeover(conversationId)
+            .toDomain()
+
+    override suspend fun releaseHumanCreatorTakeover(conversationId: String) {
+        dataSource.releaseHumanCreatorTakeover(conversationId)
+    }
+
+    override suspend fun sendHumanCreatorMessage(
+        conversationId: String,
+        content: String,
+    ): ChatMessage =
+        dataSource
+            .sendHumanCreatorMessage(
+                conversationId = conversationId,
+                request = SendHumanCreatorMessageRequestDto(content = content),
+            ).toDomain(conversationIdFallback = conversationId)
+
+    override suspend fun getHumanCreatorTakeoverStatus(conversationId: String): HumanCreatorTakeoverStatus =
+        dataSource
+            .getHumanCreatorTakeoverStatus(conversationId)
+            .toDomain()
+
+    override suspend fun getCreatorConversationMessagesPage(
+        conversationId: String,
+        limit: Int,
+        offset: Int,
+    ): ConversationMessagesPageResult =
+        dataSource
+            .listCreatorConversationMessages(
+                conversationId = conversationId,
+                limit = limit,
+                offset = offset,
+                order = "desc",
+            ).toDomain()
 
     private companion object {
         private const val UNREAD_COUNT_PAGE_SIZE = 100

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/HumanCreatorTakeoverStatusDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/HumanCreatorTakeoverStatusDto.kt
@@ -1,0 +1,16 @@
+package com.yral.shared.features.chat.data.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HumanCreatorTakeoverStatusDto(
+    @SerialName("active")
+    val active: Boolean,
+    @SerialName("started_at")
+    val startedAt: String? = null,
+    @SerialName("user_last_message_at")
+    val userLastMessageAt: String? = null,
+    @SerialName("remaining_seconds")
+    val remainingSeconds: Int,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -12,6 +12,7 @@ import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResul
 import com.yral.shared.features.chat.domain.models.ConversationUser
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencerStatus
 import com.yral.shared.features.chat.domain.models.InfluencersPageResult
@@ -202,4 +203,20 @@ fun SendMessageResponseDto.toDomain(conversationIdFallback: String): SendMessage
     SendMessageResult(
         userMessage = userMessage.toDomain(conversationIdFallback),
         assistantMessage = assistantMessage?.toDomain(conversationIdFallback),
+    )
+
+fun HumanCreatorTakeoverStatusDto.toDomain(): HumanCreatorTakeoverStatus =
+    HumanCreatorTakeoverStatus(
+        active = active,
+        startedAt = startedAt,
+        userLastMessageAt = userLastMessageAt,
+        remainingSeconds = remainingSeconds,
+    )
+
+fun StartHumanCreatorTakeoverResponseDto.toDomain(): HumanCreatorTakeoverStatus =
+    HumanCreatorTakeoverStatus(
+        active = status.equals("active", ignoreCase = true),
+        startedAt = startedAt,
+        userLastMessageAt = userLastMessageAt,
+        remainingSeconds = remainingSeconds,
     )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ReleaseHumanCreatorTakeoverResponseDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ReleaseHumanCreatorTakeoverResponseDto.kt
@@ -1,0 +1,10 @@
+package com.yral.shared.features.chat.data.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReleaseHumanCreatorTakeoverResponseDto(
+    @SerialName("status")
+    val status: String,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendHumanCreatorMessageRequestDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendHumanCreatorMessageRequestDto.kt
@@ -1,0 +1,10 @@
+package com.yral.shared.features.chat.data.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SendHumanCreatorMessageRequestDto(
+    @SerialName("content")
+    val content: String,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/StartHumanCreatorTakeoverResponseDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/StartHumanCreatorTakeoverResponseDto.kt
@@ -1,0 +1,16 @@
+package com.yral.shared.features.chat.data.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class StartHumanCreatorTakeoverResponseDto(
+    @SerialName("status")
+    val status: String,
+    @SerialName("started_at")
+    val startedAt: String? = null,
+    @SerialName("user_last_message_at")
+    val userLastMessageAt: String? = null,
+    @SerialName("remaining_seconds")
+    val remainingSeconds: Int,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
@@ -13,10 +13,14 @@ import com.yral.shared.features.chat.domain.ChatRepository
 import com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.CreateConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.DeleteConversationUseCase
+import com.yral.shared.features.chat.domain.usecases.GetHumanCreatorTakeoverStatusUseCase
 import com.yral.shared.features.chat.domain.usecases.GetInfluencerUseCase
 import com.yral.shared.features.chat.domain.usecases.GrantChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.MarkConversationAsReadUseCase
+import com.yral.shared.features.chat.domain.usecases.ReleaseHumanCreatorTakeoverUseCase
+import com.yral.shared.features.chat.domain.usecases.SendHumanCreatorMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.SendMessageUseCase
+import com.yral.shared.features.chat.domain.usecases.StartHumanCreatorTakeoverUseCase
 import com.yral.shared.features.chat.viewmodel.ChatUnreadRefreshSignal
 import com.yral.shared.features.chat.viewmodel.ChatWallViewModel
 import com.yral.shared.features.chat.viewmodel.ConversationViewModel
@@ -25,6 +29,7 @@ import kotlinx.serialization.json.Json
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
@@ -54,10 +59,40 @@ val chatModule =
         factoryOf(::GetInfluencerUseCase)
         factoryOf(::MarkConversationAsReadUseCase)
         factoryOf(::SendMessageUseCase)
+        factoryOf(::StartHumanCreatorTakeoverUseCase)
+        factoryOf(::ReleaseHumanCreatorTakeoverUseCase)
+        factoryOf(::SendHumanCreatorMessageUseCase)
+        factoryOf(::GetHumanCreatorTakeoverStatusUseCase)
         factoryOf(::ChatTelemetry)
         singleOf(::ChatErrorMapper)
         singleOf(::ChatUnreadRefreshSignal)
         viewModelOf(::ChatWallViewModel)
-        viewModelOf(::ConversationViewModel)
+        viewModel {
+            ConversationViewModel(
+                flagManager = get(),
+                chatRepository = get(),
+                useCaseFailureListener = get(),
+                sendMessageUseCase = get(),
+                createConversationUseCase = get(),
+                deleteConversationUseCase = get(),
+                markConversationAsReadUseCase = get(),
+                shareService = get(),
+                urlBuilder = get(),
+                linkGenerator = get(),
+                crashlyticsManager = get(),
+                sessionManager = get(),
+                chatTelemetry = get(),
+                chatErrorMapper = get(),
+                iapManager = get(),
+                fetchProductsUseCase = get(),
+                checkChatAccessUseCase = get(),
+                grantChatAccessUseCase = get(),
+                chatUnreadRefreshSignal = get(),
+                startHumanCreatorTakeoverUseCase = get(),
+                releaseHumanCreatorTakeoverUseCase = get(),
+                sendHumanCreatorMessageUseCase = get(),
+                getHumanCreatorTakeoverStatusUseCase = get(),
+            )
+        }
         viewModelOf(::InboxViewModel)
     }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
@@ -28,8 +28,8 @@ import com.yral.shared.features.chat.viewmodel.InboxViewModel
 import kotlinx.serialization.json.Json
 import org.koin.core.module.dsl.factoryOf
 import org.koin.core.module.dsl.singleOf
-import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.module.dsl.viewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
@@ -1,9 +1,11 @@
 package com.yral.shared.features.chat.domain
 
+import com.yral.shared.features.chat.domain.models.ChatMessage
 import com.yral.shared.features.chat.domain.models.Conversation
 import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResult
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencersPageResult
 import com.yral.shared.features.chat.domain.models.SendMessageDraft
@@ -47,4 +49,21 @@ interface ChatRepository {
     ): SendMessageResult
 
     suspend fun markConversationAsRead(conversationId: String)
+
+    suspend fun startHumanCreatorTakeover(conversationId: String): HumanCreatorTakeoverStatus
+
+    suspend fun releaseHumanCreatorTakeover(conversationId: String)
+
+    suspend fun sendHumanCreatorMessage(
+        conversationId: String,
+        content: String,
+    ): ChatMessage
+
+    suspend fun getHumanCreatorTakeoverStatus(conversationId: String): HumanCreatorTakeoverStatus
+
+    suspend fun getCreatorConversationMessagesPage(
+        conversationId: String,
+        limit: Int,
+        offset: Int,
+    ): ConversationMessagesPageResult
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt
@@ -39,6 +39,7 @@ enum class ConversationMessageRole(
 ) {
     USER("user"),
     ASSISTANT("assistant"),
+    SYSTEM("system"),
     ;
 
     companion object {
@@ -46,6 +47,7 @@ enum class ConversationMessageRole(
             when (value.trim().lowercase()) {
                 USER.apiValue -> USER
                 ASSISTANT.apiValue -> ASSISTANT
+                SYSTEM.apiValue -> SYSTEM
                 else -> USER
             }
     }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/HumanCreatorTakeoverStatus.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/HumanCreatorTakeoverStatus.kt
@@ -1,0 +1,8 @@
+package com.yral.shared.features.chat.domain.models
+
+data class HumanCreatorTakeoverStatus(
+    val active: Boolean,
+    val startedAt: String?,
+    val userLastMessageAt: String?,
+    val remainingSeconds: Int,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetHumanCreatorTakeoverStatusUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetHumanCreatorTakeoverStatusUseCase.kt
@@ -1,0 +1,22 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+class GetHumanCreatorTakeoverStatusUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<String, HumanCreatorTakeoverStatus>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: String): HumanCreatorTakeoverStatus =
+        chatRepository.getHumanCreatorTakeoverStatus(conversationId = parameter)
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/ReleaseHumanCreatorTakeoverUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/ReleaseHumanCreatorTakeoverUseCase.kt
@@ -1,0 +1,22 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+class ReleaseHumanCreatorTakeoverUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<String, Unit>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: String) {
+        chatRepository.releaseHumanCreatorTakeover(conversationId = parameter)
+    }
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/SendHumanCreatorMessageUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/SendHumanCreatorMessageUseCase.kt
@@ -1,0 +1,30 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.ChatMessage
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+class SendHumanCreatorMessageUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<SendHumanCreatorMessageUseCase.Params, ChatMessage>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: Params): ChatMessage =
+        chatRepository.sendHumanCreatorMessage(
+            conversationId = parameter.conversationId,
+            content = parameter.content,
+        )
+
+    data class Params(
+        val conversationId: String,
+        val content: String,
+    )
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/StartHumanCreatorTakeoverUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/StartHumanCreatorTakeoverUseCase.kt
@@ -1,0 +1,22 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+class StartHumanCreatorTakeoverUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<String, HumanCreatorTakeoverStatus>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: String): HumanCreatorTakeoverStatus =
+        chatRepository.startHumanCreatorTakeover(conversationId = parameter)
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -189,6 +189,17 @@ fun ChatConversationScreen(
     val screenWidth = LocalWindowInfo.current.containerSize.width
     val density = LocalDensity.current
 
+    // When the user re-enters a conversation, snap the list back to the
+    // newest message (index 0 in reverseLayout). Without this, Compose's
+    // rememberLazyListState() retains the position from the previous visit,
+    // which during an active takeover can land deep in old content and
+    // visually hide the newest messages behind the input box.
+    LaunchedEffect(viewState.conversationId) {
+        if (viewState.conversationId != null) {
+            runCatching { listState.scrollToItem(0) }
+        }
+    }
+
     val imagePickerLauncher =
         rememberChatImagePicker(
             onImagePicked = { attachment -> activeImagePreview = ChatImagePreviewSource.Draft(attachment) },

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -238,6 +238,7 @@ fun ChatConversationScreen(
         screenWidth = screenWidth,
         density = density,
         overlayItems = overlayItems,
+        historyPagingItems = historyPagingItems,
         scrollToLastLine = true,
         lineHeightPx = messageLineHeightPx,
     )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -524,7 +524,8 @@ fun ChatConversationScreen(
                             ConversationBottomAreaState.BotAccountPrompt -> {
                                 if (viewState.isChatAsHumanCreatorEnabled) {
                                     val creatorDisplayName =
-                                        viewState.influencer?.displayName
+                                        viewState.influencer
+                                            ?.displayName
                                             ?.takeIf { it.isNotBlank() }
                                             ?: viewState.influencer?.name.orEmpty()
                                     CreatorTakeoverBar(

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -139,6 +139,12 @@ fun ChatConversationScreen(
 
     LaunchedEffect(Unit) { viewModel.refreshHistory() }
 
+    LaunchedEffect(viewState.isBotAccount, viewState.conversationId) {
+        if (viewState.isBotAccount && viewState.conversationId != null) {
+            viewModel.refreshHumanCreatorTakeoverStatus()
+        }
+    }
+
     LaunchedEffect(Unit) {
         viewModel.influencerSubscriptionToastFlow.collect { event ->
             when (event.status) {
@@ -459,6 +465,7 @@ fun ChatConversationScreen(
                             overlayItems = overlayItems,
                             historyPagingItems = historyPagingItems,
                             isBotAccount = viewState.isBotAccount,
+                            renderSystemBanners = viewState.isChatAsHumanCreatorEnabled,
                             onImageClick = { imageUrl ->
                                 activeImagePreview = ChatImagePreviewSource.Message(imageUrl)
                             },
@@ -503,24 +510,42 @@ fun ChatConversationScreen(
 
                         when (bottomAreaState) {
                             ConversationBottomAreaState.BotAccountPrompt -> {
-                                BotAccountConversationPrompt(
-                                    message = switchProfileMessage,
-                                    buttonText = switchProfileButtonText,
-                                    avatarUrl = viewState.influencer?.avatarUrl,
-                                    isSwitching = isSwitchingProfile,
-                                    onSwitchClick = {
-                                        if (isSwitchingProfile) return@BotAccountConversationPrompt
-                                        isSwitchingProfile = true
-                                        component.switchToMainProfile { switched ->
-                                            isSwitchingProfile = false
-                                            if (!switched) {
-                                                ToastManager.showError(
-                                                    type = ToastType.Small(message = switchProfileFailedMessage),
-                                                )
+                                if (viewState.isChatAsHumanCreatorEnabled) {
+                                    val creatorDisplayName =
+                                        viewState.influencer?.displayName
+                                            ?.takeIf { it.isNotBlank() }
+                                            ?: viewState.influencer?.name.orEmpty()
+                                    CreatorTakeoverBar(
+                                        isActive = viewState.isHumanCreatorTakeoverActive,
+                                        isStarting = viewState.isHumanCreatorTakeoverStarting,
+                                        isEnding = viewState.isHumanCreatorTakeoverEnding,
+                                        isMessageSending = viewState.isHumanCreatorMessageSending,
+                                        remainingSeconds = viewState.humanCreatorTakeoverRemainingSeconds,
+                                        creatorDisplayName = creatorDisplayName,
+                                        onToggleOn = { viewModel.startHumanCreatorTakeover() },
+                                        onToggleOff = { viewModel.releaseHumanCreatorTakeover() },
+                                        onSend = { text -> viewModel.sendAsHumanCreator(text) },
+                                    )
+                                } else {
+                                    BotAccountConversationPrompt(
+                                        message = switchProfileMessage,
+                                        buttonText = switchProfileButtonText,
+                                        avatarUrl = viewState.influencer?.avatarUrl,
+                                        isSwitching = isSwitchingProfile,
+                                        onSwitchClick = {
+                                            if (isSwitchingProfile) return@BotAccountConversationPrompt
+                                            isSwitchingProfile = true
+                                            component.switchToMainProfile { switched ->
+                                                isSwitchingProfile = false
+                                                if (!switched) {
+                                                    ToastManager.showError(
+                                                        type = ToastType.Small(message = switchProfileFailedMessage),
+                                                    )
+                                                }
                                             }
-                                        }
-                                    },
-                                )
+                                        },
+                                    )
+                                }
                             }
 
                             ConversationBottomAreaState.InfluencerSubscription -> {

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -25,6 +25,7 @@ internal fun MessagesList(
     overlayItems: List<ConversationMessageItem>,
     historyPagingItems: LazyPagingItems<ConversationMessageItem>,
     isBotAccount: Boolean = false,
+    renderSystemBanners: Boolean = false,
     onImageClick: (imageUrl: String) -> Unit,
     onRetry: (localId: String) -> Unit,
 ) {
@@ -40,6 +41,7 @@ internal fun MessagesList(
         items(
             items = overlayItems,
         ) { item ->
+            if (item.isSystemMessage() && !renderSystemBanners) return@items
             MessageRow(
                 item = item,
                 isBotAccount = isBotAccount,
@@ -53,6 +55,7 @@ internal fun MessagesList(
         ) { idx ->
             val item = historyPagingItems[idx] ?: return@items
             if (isDuplicateOfOverlay(item, overlayMessageIds)) return@items
+            if (item.isSystemMessage() && !renderSystemBanners) return@items
             MessageRow(
                 item = item,
                 isBotAccount = isBotAccount,
@@ -63,6 +66,12 @@ internal fun MessagesList(
     }
 }
 
+private fun ConversationMessageItem.isSystemMessage(): Boolean =
+    when (this) {
+        is ConversationMessageItem.Remote -> message.role == ConversationMessageRole.SYSTEM
+        is ConversationMessageItem.Local -> message.role == ConversationMessageRole.SYSTEM
+    }
+
 @Composable
 private fun MessageRow(
     item: ConversationMessageItem,
@@ -72,11 +81,19 @@ private fun MessageRow(
 ) {
     val screenWidth = LocalWindowInfo.current.containerSize.width
     val maxWidth = with(LocalDensity.current) { (screenWidth * MESSAGE_MAX_WIDTH_RATIO).toDp() }
-    val roleIsUser =
+    val role =
         when (item) {
-            is ConversationMessageItem.Remote -> item.message.role == ConversationMessageRole.USER
-            is ConversationMessageItem.Local -> item.message.role == ConversationMessageRole.USER
+            is ConversationMessageItem.Remote -> item.message.role
+            is ConversationMessageItem.Local -> item.message.role
         }
+    if (role == ConversationMessageRole.SYSTEM && item is ConversationMessageItem.Remote) {
+        SystemBannerMessage(
+            text = item.message.content.orEmpty(),
+            modifier = Modifier.fillMaxWidth().padding(vertical = MESSAGE_VERTICAL_PADDING_DP),
+        )
+        return
+    }
+    val roleIsUser = role == ConversationMessageRole.USER
     // For bot accounts, roles are flipped: USER messages come from the AI (shown on left),
     // ASSISTANT messages come from the human customer (shown on right).
     val isUser = if (isBotAccount) !roleIsUser else roleIsUser

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationScrollHelpers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationScrollHelpers.kt
@@ -78,6 +78,7 @@ internal fun AutoScrollToAssistantMessage(
     screenWidth: Int,
     density: Density,
     overlayItems: List<ConversationMessageItem>,
+    historyPagingItems: LazyPagingItems<ConversationMessageItem>,
     scrollToLastLine: Boolean = false,
     visibleLines: Int = 0,
     lineHeightPx: Float = 0f,
@@ -138,6 +139,16 @@ internal fun AutoScrollToAssistantMessage(
         val target = scrollTarget ?: return@LaunchedEffect
         if (!readyForAutoScroll && !target.isWaiting) return@LaunchedEffect
         val targetTimeMs = target.message.scrollTimestampMs() ?: return@LaunchedEffect
+        // Primary guard: if the rendered list has an item NEWER than this target,
+        // don't scroll. This catches the case where the user types after an active
+        // takeover (their last action was a send that got no AI reply, so the
+        // newest item is a USER message but findLatestAssistantIndex still returns
+        // an older ASSISTANT). Auto-scrolling to that ASSISTANT would push the
+        // newer USER message off-screen behind the input box.
+        val newestVisibleTimeMs = newestVisibleItemTimeMs(overlayItems, historyPagingItems)
+        if (newestVisibleTimeMs != null && targetTimeMs < newestVisibleTimeMs) return@LaunchedEffect
+        // Secondary guard: don't re-scroll to a target we've already animated to,
+        // and never scroll backward to an older target than the previous one.
         val prev = lastScrolledTimeMs
         if (prev != null && targetTimeMs <= prev) return@LaunchedEffect
         lastScrolledTimeMs = targetTimeMs
@@ -148,6 +159,14 @@ internal fun AutoScrollToAssistantMessage(
             )
         }
     }
+}
+
+private fun newestVisibleItemTimeMs(
+    overlayItems: List<ConversationMessageItem>,
+    historyPagingItems: LazyPagingItems<ConversationMessageItem>,
+): Long? {
+    overlayItems.firstOrNull()?.scrollTimestampMs()?.let { return it }
+    return historyPagingItems.itemSnapshotList.items.firstOrNull()?.scrollTimestampMs()
 }
 
 @OptIn(ExperimentalTime::class)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationScrollHelpers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationScrollHelpers.kt
@@ -5,12 +5,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import com.yral.shared.features.chat.domain.models.ConversationMessageRole
 import com.yral.shared.features.chat.viewmodel.ConversationMessageItem
 import com.yral.shared.features.chat.viewmodel.LocalMessageStatus
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 internal fun ConversationMessageItem.isAssistant() =
     when (this) {
@@ -118,9 +123,24 @@ internal fun AutoScrollToAssistantMessage(
         }
     }
 
+    // Auto-scroll must move forward in time, never backward. The scrollTarget
+    // derivedStateOf re-emits whenever the "latest assistant" reference changes,
+    // and during an active Chat-as-Human takeover the backend's POST /messages
+    // response omits the AI reply (chat.py early-exit). handleSendSuccess then
+    // removes the optimistic ASSISTANT placeholder without replacement, and
+    // findLatestAssistantIndex falls back to a STALE older assistant message.
+    // Without this guard the LaunchedEffect would animate-scroll backward to
+    // that older target, dragging the viewport away from the user's just-sent
+    // message and visually hiding it behind the input area.
+    var lastScrolledTimeMs by remember { mutableStateOf<Long?>(null) }
+
     LaunchedEffect(scrollTarget, readyForAutoScroll) {
         val target = scrollTarget ?: return@LaunchedEffect
         if (!readyForAutoScroll && !target.isWaiting) return@LaunchedEffect
+        val targetTimeMs = target.message.scrollTimestampMs() ?: return@LaunchedEffect
+        val prev = lastScrolledTimeMs
+        if (prev != null && targetTimeMs <= prev) return@LaunchedEffect
+        lastScrolledTimeMs = targetTimeMs
         runCatching {
             listState.animateScrollToItem(
                 index = target.index,
@@ -129,6 +149,25 @@ internal fun AutoScrollToAssistantMessage(
         }
     }
 }
+
+@OptIn(ExperimentalTime::class)
+private fun ConversationMessageItem.scrollTimestampMs(): Long? =
+    when (this) {
+        is ConversationMessageItem.Local -> message.createdAtMs
+        is ConversationMessageItem.Remote -> parseIsoToEpochMs(message.createdAt)
+    }
+
+@OptIn(ExperimentalTime::class)
+private fun parseIsoToEpochMs(timestamp: String): Long? =
+    runCatching {
+        val normalized =
+            if (timestamp.endsWith('Z') || timestamp.matches(Regex(".*[+-]\\d{2}:\\d{2}$"))) {
+                timestamp
+            } else {
+                "${timestamp}Z"
+            }
+        Instant.parse(normalized).toEpochMilliseconds()
+    }.getOrNull()
 
 private fun calculatePendingUserMessagesHeight(
     overlayItems: List<ConversationMessageItem>,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationScrollHelpers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationScrollHelpers.kt
@@ -166,7 +166,9 @@ private fun newestVisibleItemTimeMs(
     historyPagingItems: LazyPagingItems<ConversationMessageItem>,
 ): Long? {
     overlayItems.firstOrNull()?.scrollTimestampMs()?.let { return it }
-    return historyPagingItems.itemSnapshotList.items.firstOrNull()?.scrollTimestampMs()
+    return historyPagingItems.itemSnapshotList.items
+        .firstOrNull()
+        ?.scrollTimestampMs()
 }
 
 @OptIn(ExperimentalTime::class)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt
@@ -1,0 +1,121 @@
+package com.yral.shared.features.chat.ui.conversation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yral.shared.libs.designsystem.theme.YralColors
+import org.jetbrains.compose.resources.stringResource
+import yral_mobile.shared.features.chat.generated.resources.Res
+import yral_mobile.shared.features.chat.generated.resources.takeover_input_placeholder
+import yral_mobile.shared.features.chat.generated.resources.takeover_timer_label
+import yral_mobile.shared.features.chat.generated.resources.takeover_toggle_active
+import yral_mobile.shared.features.chat.generated.resources.takeover_toggle_inactive
+
+private const val URGENT_THRESHOLD_SECONDS = 30
+private const val SECONDS_PER_MINUTE = 60
+
+@Composable
+internal fun CreatorTakeoverBar(
+    isActive: Boolean,
+    isStarting: Boolean,
+    isEnding: Boolean,
+    isMessageSending: Boolean,
+    remainingSeconds: Int,
+    creatorDisplayName: String,
+    onToggleOn: () -> Unit,
+    onToggleOff: () -> Unit,
+    onSend: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var draft by remember { mutableStateOf("") }
+    val toggleEnabled = !isStarting && !isEnding
+    val toggleLabel =
+        if (isActive) {
+            stringResource(Res.string.takeover_toggle_active)
+        } else {
+            stringResource(Res.string.takeover_toggle_inactive, creatorDisplayName)
+        }
+    val timerText = formatRemainingMmSs(remainingSeconds)
+    val isUrgent = remainingSeconds in 1..URGENT_THRESHOLD_SECONDS
+
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = if (isActive) YralColors.Neutral900 else Color.Transparent,
+                        shape = RoundedCornerShape(28.dp),
+                    ).border(
+                        width = 1.dp,
+                        color = if (isActive) YralColors.PrimaryYellow else YralColors.Neutral700,
+                        shape = RoundedCornerShape(28.dp),
+                    ).clickable(enabled = toggleEnabled) {
+                        if (isActive) onToggleOff() else onToggleOn()
+                    }.padding(horizontal = 18.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = toggleLabel,
+                color = if (isActive) YralColors.PrimaryYellow else Color.White,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+            )
+            if (isActive) {
+                Text(
+                    text = stringResource(Res.string.takeover_timer_label, timerText),
+                    color = if (isUrgent) YralColors.Red300 else Color.White.copy(alpha = 0.8f),
+                    fontWeight = if (isUrgent) FontWeight.Bold else FontWeight.Medium,
+                    fontSize = if (isUrgent) 18.sp else 14.sp,
+                )
+            }
+        }
+
+        if (isActive) {
+            Spacer(modifier = Modifier.height(8.dp))
+            ChatInputArea(
+                input = draft,
+                onInputChange = { draft = it },
+                onSendClick = {
+                    val trimmed = draft.trim()
+                    if (trimmed.isNotEmpty() && !isMessageSending) {
+                        onSend(trimmed)
+                        draft = ""
+                    }
+                },
+                showAttachmentMenu = false,
+                placeholder = stringResource(Res.string.takeover_input_placeholder, creatorDisplayName),
+                hasWaitingAssistant = isMessageSending,
+            )
+        }
+    }
+}
+
+private fun formatRemainingMmSs(totalSeconds: Int): String {
+    val safe = totalSeconds.coerceAtLeast(0)
+    val minutes = safe / SECONDS_PER_MINUTE
+    val seconds = safe % SECONDS_PER_MINUTE
+    val secondsStr = if (seconds < 10) "0$seconds" else "$seconds"
+    return "$minutes:$secondsStr"
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt
@@ -33,6 +33,7 @@ import yral_mobile.shared.features.chat.generated.resources.takeover_toggle_inac
 
 private const val URGENT_THRESHOLD_SECONDS = 30
 private const val SECONDS_PER_MINUTE = 60
+private const val TIMER_SECOND_DIGITS = 2
 
 @Composable
 internal fun CreatorTakeoverBar(
@@ -116,6 +117,6 @@ private fun formatRemainingMmSs(totalSeconds: Int): String {
     val safe = totalSeconds.coerceAtLeast(0)
     val minutes = safe / SECONDS_PER_MINUTE
     val seconds = safe % SECONDS_PER_MINUTE
-    val secondsStr = if (seconds < 10) "0$seconds" else "$seconds"
+    val secondsStr = seconds.toString().padStart(TIMER_SECOND_DIGITS, '0')
     return "$minutes:$secondsStr"
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/SystemBannerMessage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/SystemBannerMessage.kt
@@ -1,0 +1,49 @@
+package com.yral.shared.features.chat.ui.conversation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.yral.shared.libs.designsystem.theme.YralColors
+
+@Composable
+internal fun SystemBannerMessage(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .padding(horizontal = 24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = YralColors.Neutral800.copy(alpha = 0.45f),
+                        shape = RoundedCornerShape(12.dp),
+                    ).padding(horizontal = 16.dp, vertical = 10.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = text,
+                color = Color.White.copy(alpha = 0.85f),
+                fontStyle = FontStyle.Italic,
+                fontSize = 13.sp,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -822,6 +822,7 @@ class ConversationViewModel(
                 loginPromptMessageThreshold = current.loginPromptMessageThreshold,
                 subscriptionMandatoryThreshold = current.subscriptionMandatoryThreshold,
                 isSubscriptionEnabled = current.isSubscriptionEnabled,
+                isChatAsHumanCreatorEnabled = current.isChatAsHumanCreatorEnabled,
                 isInfluencerSubscriptionPurchasedAndVerified = false,
                 isInfluencerSubscriptionAvailableToPurchase = current.isInfluencerSubscriptionAvailableToPurchase,
                 isInfluencerSubscriptionPurchaseInProgress = false,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -78,7 +78,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlin.time.Duration.Companion.seconds
 import org.jetbrains.compose.resources.getString
 import yral_mobile.shared.features.chat.generated.resources.Res
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_purchase_failed
@@ -90,6 +89,7 @@ import yral_mobile.shared.libs.designsystem.generated.resources.msg_profile_shar
 import yral_mobile.shared.libs.designsystem.generated.resources.msg_profile_share_desc
 import yral_mobile.shared.libs.designsystem.generated.resources.profile_share_default_name
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import yral_mobile.shared.libs.designsystem.generated.resources.Res as DesignRes
@@ -1178,10 +1178,13 @@ class ConversationViewModel(
     private var takeoverCountdownJob: Job? = null
 
     fun startHumanCreatorTakeover() {
-        if (!_viewState.value.isChatAsHumanCreatorEnabled) return
-        if (!_viewState.value.isBotAccount) return
-        val convId = _viewState.value.conversationId ?: return
-        if (_viewState.value.isHumanCreatorTakeoverActive || _viewState.value.isHumanCreatorTakeoverStarting) return
+        val state = _viewState.value
+        val convId = state.conversationId
+        val featureUnavailable = !state.isChatAsHumanCreatorEnabled || !state.isBotAccount
+        val takeoverUnavailable = state.isHumanCreatorTakeoverActive || state.isHumanCreatorTakeoverStarting
+        if (featureUnavailable || convId == null || takeoverUnavailable) {
+            return
+        }
         _viewState.update { it.copy(isHumanCreatorTakeoverStarting = true) }
         viewModelScope.launch {
             startHumanCreatorTakeoverUseCase(convId)
@@ -1231,11 +1234,14 @@ class ConversationViewModel(
 
     @OptIn(ExperimentalTime::class)
     fun sendAsHumanCreator(content: String) {
-        val convId = _viewState.value.conversationId ?: return
+        val state = _viewState.value
+        val convId = state.conversationId
         val trimmed = content.trim()
-        if (trimmed.isEmpty()) return
-        if (!_viewState.value.isHumanCreatorTakeoverActive) return
-        if (_viewState.value.isHumanCreatorMessageSending) return
+        val messageUnavailable = convId == null || trimmed.isEmpty()
+        val takeoverUnavailable = !state.isHumanCreatorTakeoverActive || state.isHumanCreatorMessageSending
+        if (messageUnavailable || takeoverUnavailable) {
+            return
+        }
         _viewState.update { it.copy(isHumanCreatorMessageSending = true) }
         viewModelScope.launch {
             sendHumanCreatorMessageUseCase(
@@ -1246,7 +1252,9 @@ class ConversationViewModel(
                 // (flicker), and gave the auto-scroll a second target to animate to
                 // (more flicker). Just add the real message to the overlay after the
                 // POST returns. ~200-500ms latency, button greys during the wait.
-                val insertedAtMs = parseTimestampToEpochMs(message.createdAt) ?: Clock.System.now().toEpochMilliseconds()
+                val insertedAtMs =
+                    parseTimestampToEpochMs(message.createdAt)
+                        ?: Clock.System.now().toEpochMilliseconds()
                 _overlay.update { state ->
                     state.copy(sent = state.sent + SentMessage(insertedAtMs = insertedAtMs, message = message))
                 }
@@ -1261,9 +1269,9 @@ class ConversationViewModel(
     }
 
     fun refreshHumanCreatorTakeoverStatus() {
-        if (!_viewState.value.isChatAsHumanCreatorEnabled) return
-        if (!_viewState.value.isBotAccount) return
-        val convId = _viewState.value.conversationId ?: return
+        val state = _viewState.value
+        val convId = state.conversationId
+        if (!state.isChatAsHumanCreatorEnabled || !state.isBotAccount || convId == null) return
         viewModelScope.launch {
             getHumanCreatorTakeoverStatusUseCase(convId)
                 .onSuccess { status ->
@@ -1331,7 +1339,10 @@ class ConversationViewModel(
             )
         }.onSuccess { result ->
             val loadedIds = loadedMessageIds.value
-            val sentIds = _overlay.value.sent.map { it.message.id }.toSet()
+            val sentIds =
+                _overlay.value.sent
+                    .map { it.message.id }
+                    .toSet()
             val newSentMessages =
                 result.messages
                     .filterNot { msg -> msg.id in loadedIds || msg.id in sentIds }
@@ -1415,6 +1426,7 @@ class ConversationViewModel(
         private const val MESSAGES_STOP_TIMEOUT_MS = 5_000L
         private const val FALLBACK_ACCESS_DURATION_MS = 24L * 60 * 60 * 1000
         private val TAKEOVER_MESSAGES_POLL_INTERVAL = 3.seconds
+
         // Status poll runs every Nth iteration of message poll: 3s × 2 ≈ 6s ≈ ~5s spec.
         private const val TAKEOVER_STATUS_POLL_EVERY_N = 2
         private const val TAKEOVER_POLL_PAGE_SIZE = 20

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -37,10 +37,14 @@ import com.yral.shared.features.chat.domain.models.SendMessageResult
 import com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.CreateConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.DeleteConversationUseCase
+import com.yral.shared.features.chat.domain.usecases.GetHumanCreatorTakeoverStatusUseCase
 import com.yral.shared.features.chat.domain.usecases.GrantChatAccessParams
 import com.yral.shared.features.chat.domain.usecases.GrantChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.MarkConversationAsReadUseCase
+import com.yral.shared.features.chat.domain.usecases.ReleaseHumanCreatorTakeoverUseCase
+import com.yral.shared.features.chat.domain.usecases.SendHumanCreatorMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.SendMessageUseCase
+import com.yral.shared.features.chat.domain.usecases.StartHumanCreatorTakeoverUseCase
 import com.yral.shared.features.subscriptions.domain.FetchProductsUseCase
 import com.yral.shared.iap.IAPManager
 import com.yral.shared.iap.core.IAPError
@@ -58,7 +62,9 @@ import com.yral.shared.libs.sharing.ShareService
 import com.yral.shared.rust.service.utils.getUserInfoServiceCanister
 import com.yral.shared.rust.service.utils.propicFromPrincipal
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -72,6 +78,7 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
 import org.jetbrains.compose.resources.getString
 import yral_mobile.shared.features.chat.generated.resources.Res
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_purchase_failed
@@ -108,6 +115,10 @@ class ConversationViewModel(
     private val checkChatAccessUseCase: CheckChatAccessUseCase,
     private val grantChatAccessUseCase: GrantChatAccessUseCase,
     private val chatUnreadRefreshSignal: ChatUnreadRefreshSignal,
+    private val startHumanCreatorTakeoverUseCase: StartHumanCreatorTakeoverUseCase,
+    private val releaseHumanCreatorTakeoverUseCase: ReleaseHumanCreatorTakeoverUseCase,
+    private val sendHumanCreatorMessageUseCase: SendHumanCreatorMessageUseCase,
+    private val getHumanCreatorTakeoverStatusUseCase: GetHumanCreatorTakeoverStatusUseCase,
 ) : ViewModel() {
     /**
      * Message ordering:
@@ -121,6 +132,7 @@ class ConversationViewModel(
                 loginPromptMessageThreshold = flagManager.get(ChatFeatureFlags.Chat.LoginPromptMessageThreshold),
                 subscriptionMandatoryThreshold = flagManager.get(ChatFeatureFlags.Chat.SubscriptionMandatoryThreshold),
                 isSubscriptionEnabled = flagManager.isEnabled(AppFeatureFlags.Common.EnableSubscription),
+                isChatAsHumanCreatorEnabled = flagManager.get(ChatFeatureFlags.Chat.ChatAsHumanCreatorEnabled),
             ),
         )
     val viewState: StateFlow<ConversationViewState> = _viewState.asStateFlow()
@@ -822,6 +834,8 @@ class ConversationViewModel(
         loadedMessageIds.value = emptySet()
         initialOffset.value = null
         historyRefreshTrigger.value = 0
+        stopTakeoverPolling()
+        stopCountdownTicker()
     }
 
     private fun createConversation(influencerId: String) {
@@ -1157,6 +1171,221 @@ class ConversationViewModel(
         }
     }
 
+    // ── Human Creator Takeover (Chat as Human) ──────────────────────────────
+    // Polling-based. No WebSocket dependency. See PLAN-CHAT-AS-HUMAN.md.
+    private var takeoverPollingJob: Job? = null
+    private var takeoverCountdownJob: Job? = null
+
+    fun startHumanCreatorTakeover() {
+        if (!_viewState.value.isChatAsHumanCreatorEnabled) return
+        if (!_viewState.value.isBotAccount) return
+        val convId = _viewState.value.conversationId ?: return
+        if (_viewState.value.isHumanCreatorTakeoverActive || _viewState.value.isHumanCreatorTakeoverStarting) return
+        _viewState.update { it.copy(isHumanCreatorTakeoverStarting = true) }
+        viewModelScope.launch {
+            startHumanCreatorTakeoverUseCase(convId)
+                .onSuccess { status ->
+                    applyTakeoverStatus(status.active, status.remainingSeconds)
+                    _viewState.update { it.copy(isHumanCreatorTakeoverStarting = false) }
+                    if (status.active) {
+                        // Pull the "X has joined the chat" banner into the overlay
+                        // immediately. Otherwise it doesn't show until the first poll
+                        // tick ~3s later, and the creator can start typing before the
+                        // banner appears — confusing UX.
+                        pollLatestMessagesIntoOverlay(convId)
+                        startTakeoverPolling(convId)
+                    }
+                }.onFailure { error ->
+                    Logger.w(ConversationViewModel::class.simpleName!!, error) {
+                        "Failed to start human creator takeover: $convId"
+                    }
+                    _viewState.update { it.copy(isHumanCreatorTakeoverStarting = false) }
+                }
+        }
+    }
+
+    fun releaseHumanCreatorTakeover() {
+        val convId = _viewState.value.conversationId ?: return
+        if (!_viewState.value.isHumanCreatorTakeoverActive) return
+        _viewState.update { it.copy(isHumanCreatorTakeoverEnding = true) }
+        stopTakeoverPolling()
+        viewModelScope.launch {
+            releaseHumanCreatorTakeoverUseCase(convId)
+                .onSuccess {
+                    applyTakeoverStatus(active = false, remainingSeconds = 0)
+                    _viewState.update { it.copy(isHumanCreatorTakeoverEnding = false) }
+                    // Pull the "X has left the chat" system banner into the overlay
+                    // without flickering the whole LazyColumn.
+                    pollLatestMessagesIntoOverlay(convId)
+                }.onFailure { error ->
+                    Logger.w(ConversationViewModel::class.simpleName!!, error) {
+                        "Failed to release human creator takeover: $convId"
+                    }
+                    // Local intent is to release — flip OFF anyway. Server will auto-release after 2 min.
+                    applyTakeoverStatus(active = false, remainingSeconds = 0)
+                    _viewState.update { it.copy(isHumanCreatorTakeoverEnding = false) }
+                }
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    fun sendAsHumanCreator(content: String) {
+        val convId = _viewState.value.conversationId ?: return
+        val trimmed = content.trim()
+        if (trimmed.isEmpty()) return
+        if (!_viewState.value.isHumanCreatorTakeoverActive) return
+        if (_viewState.value.isHumanCreatorMessageSending) return
+        _viewState.update { it.copy(isHumanCreatorMessageSending = true) }
+        viewModelScope.launch {
+            sendHumanCreatorMessageUseCase(
+                SendHumanCreatorMessageUseCase.Params(conversationId = convId, content = trimmed),
+            ).onSuccess { message ->
+                // No optimistic UI here. Optimistic pending → sent caused a Local→Remote
+                // swap that compose's items() rendered as a subtree teardown+rebuild
+                // (flicker), and gave the auto-scroll a second target to animate to
+                // (more flicker). Just add the real message to the overlay after the
+                // POST returns. ~200-500ms latency, button greys during the wait.
+                val insertedAtMs = parseTimestampToEpochMs(message.createdAt) ?: Clock.System.now().toEpochMilliseconds()
+                _overlay.update { state ->
+                    state.copy(sent = state.sent + SentMessage(insertedAtMs = insertedAtMs, message = message))
+                }
+                _viewState.update { it.copy(isHumanCreatorMessageSending = false) }
+            }.onFailure { error ->
+                Logger.w(ConversationViewModel::class.simpleName!!, error) {
+                    "Failed to send human creator message: $convId"
+                }
+                _viewState.update { it.copy(isHumanCreatorMessageSending = false) }
+            }
+        }
+    }
+
+    fun refreshHumanCreatorTakeoverStatus() {
+        if (!_viewState.value.isChatAsHumanCreatorEnabled) return
+        if (!_viewState.value.isBotAccount) return
+        val convId = _viewState.value.conversationId ?: return
+        viewModelScope.launch {
+            getHumanCreatorTakeoverStatusUseCase(convId)
+                .onSuccess { status ->
+                    applyTakeoverStatus(status.active, status.remainingSeconds)
+                    if (status.active && takeoverPollingJob?.isActive != true) {
+                        startTakeoverPolling(convId)
+                    } else if (!status.active) {
+                        stopTakeoverPolling()
+                    }
+                }.onFailure { error ->
+                    Logger.w(ConversationViewModel::class.simpleName!!, error) {
+                        "Failed to fetch takeover status: $convId"
+                    }
+                }
+        }
+    }
+
+    private fun applyTakeoverStatus(
+        active: Boolean,
+        remainingSeconds: Int,
+    ) {
+        _viewState.update {
+            it.copy(
+                isHumanCreatorTakeoverActive = active,
+                humanCreatorTakeoverRemainingSeconds = if (active) remainingSeconds.coerceAtLeast(0) else 0,
+            )
+        }
+        if (active) startCountdownTicker() else stopCountdownTicker()
+    }
+
+    private fun startTakeoverPolling(conversationId: String) {
+        stopTakeoverPolling()
+        takeoverPollingJob =
+            viewModelScope.launch {
+                var iter = 0
+                while (true) {
+                    delay(TAKEOVER_MESSAGES_POLL_INTERVAL)
+                    iter += 1
+                    // Every 3s: fetch latest messages and merge new ones into the
+                    // overlay. DO NOT call refreshHistory() — that resets the paging
+                    // source, wipes loadedMessageIds, and rebuilds the entire LazyColumn
+                    // every tick. That's what caused the flickering chat screen.
+                    if (!_viewState.value.isHumanCreatorMessageSending) {
+                        pollLatestMessagesIntoOverlay(conversationId)
+                    }
+                    // Every 5s (~every other iteration of 3s, but use modulo on time):
+                    if (iter % TAKEOVER_STATUS_POLL_EVERY_N == 0) {
+                        getHumanCreatorTakeoverStatusUseCase(conversationId)
+                            .onSuccess { status ->
+                                applyTakeoverStatus(status.active, status.remainingSeconds)
+                                if (!status.active) return@launch
+                            }
+                    }
+                }
+            }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private suspend fun pollLatestMessagesIntoOverlay(conversationId: String) {
+        runSuspendCatching {
+            chatRepository.getCreatorConversationMessagesPage(
+                conversationId = conversationId,
+                limit = TAKEOVER_POLL_PAGE_SIZE,
+                offset = 0,
+            )
+        }.onSuccess { result ->
+            val loadedIds = loadedMessageIds.value
+            val sentIds = _overlay.value.sent.map { it.message.id }.toSet()
+            val newSentMessages =
+                result.messages
+                    .filterNot { msg -> msg.id in loadedIds || msg.id in sentIds }
+                    .mapNotNull { msg ->
+                        val insertedAtMs = parseTimestampToEpochMs(msg.createdAt) ?: return@mapNotNull null
+                        SentMessage(insertedAtMs = insertedAtMs, message = msg)
+                    }
+            if (newSentMessages.isNotEmpty()) {
+                _overlay.update { it.copy(sent = it.sent + newSentMessages) }
+            }
+        }.onFailure { error ->
+            Logger.w(ConversationViewModel::class.simpleName!!, error) {
+                "pollLatestMessagesIntoOverlay failed: $conversationId"
+            }
+        }
+    }
+
+    private fun stopTakeoverPolling() {
+        takeoverPollingJob?.cancel()
+        takeoverPollingJob = null
+    }
+
+    private fun startCountdownTicker() {
+        if (takeoverCountdownJob?.isActive == true) return
+        takeoverCountdownJob =
+            viewModelScope.launch {
+                while (true) {
+                    delay(1.seconds)
+                    val current = _viewState.value
+                    if (!current.isHumanCreatorTakeoverActive) return@launch
+                    val next = (current.humanCreatorTakeoverRemainingSeconds - 1).coerceAtLeast(0)
+                    _viewState.update { it.copy(humanCreatorTakeoverRemainingSeconds = next) }
+                    if (next == 0) {
+                        // Local countdown expired. Don't wait for the server-side sweep —
+                        // proactively release so the UI flips off instantly AND the backend
+                        // writes the "left" system message before any other path can.
+                        releaseHumanCreatorTakeover()
+                        return@launch
+                    }
+                }
+            }
+    }
+
+    private fun stopCountdownTicker() {
+        takeoverCountdownJob?.cancel()
+        takeoverCountdownJob = null
+    }
+
+    override fun onCleared() {
+        stopTakeoverPolling()
+        stopCountdownTicker()
+        super.onCleared()
+    }
+    // ────────────────────────────────────────────────────────────────────────
+
     private fun consumePurchaseInBackground(purchaseToken: String) {
         viewModelScope.launch {
             iapManager
@@ -1184,6 +1413,10 @@ class ConversationViewModel(
         private const val PREFETCH_DISTANCE = 5
         private const val MESSAGES_STOP_TIMEOUT_MS = 5_000L
         private const val FALLBACK_ACCESS_DURATION_MS = 24L * 60 * 60 * 1000
+        private val TAKEOVER_MESSAGES_POLL_INTERVAL = 3.seconds
+        // Status poll runs every Nth iteration of message poll: 3s × 2 ≈ 6s ≈ ~5s spec.
+        private const val TAKEOVER_STATUS_POLL_EVERY_N = 2
+        private const val TAKEOVER_POLL_PAGE_SIZE = 20
     }
 }
 
@@ -1215,6 +1448,12 @@ data class ConversationViewState(
     val totalHistoryMessageCount: Int = 0,
     val chatAccessExpiresAtMs: Long? = null,
     val isChatAccessLoading: Boolean = false,
+    val isChatAsHumanCreatorEnabled: Boolean = false,
+    val isHumanCreatorTakeoverActive: Boolean = false,
+    val isHumanCreatorTakeoverStarting: Boolean = false,
+    val isHumanCreatorTakeoverEnding: Boolean = false,
+    val isHumanCreatorMessageSending: Boolean = false,
+    val humanCreatorTakeoverRemainingSeconds: Int = 0,
 )
 
 sealed class ConversationMessageItem {

--- a/shared/features/chat/src/commonTest/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImplUnreadCountTest.kt
+++ b/shared/features/chat/src/commonTest/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImplUnreadCountTest.kt
@@ -1,14 +1,20 @@
 package com.yral.shared.features.chat.data
 
 import com.yral.shared.features.chat.attachments.ChatAttachment
+import com.yral.shared.features.chat.data.models.ChatMessageDto
 import com.yral.shared.features.chat.data.models.ConversationDto
 import com.yral.shared.features.chat.data.models.ConversationInfluencerDto
+import com.yral.shared.features.chat.data.models.ConversationMessagesResponseDto
 import com.yral.shared.features.chat.data.models.ConversationsResponseDto
 import com.yral.shared.features.chat.data.models.DeleteConversationResponseDto
+import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
 import com.yral.shared.features.chat.data.models.InfluencerDto
 import com.yral.shared.features.chat.data.models.InfluencersResponseDto
+import com.yral.shared.features.chat.data.models.ReleaseHumanCreatorTakeoverResponseDto
+import com.yral.shared.features.chat.data.models.SendHumanCreatorMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageResponseDto
+import com.yral.shared.features.chat.data.models.StartHumanCreatorTakeoverResponseDto
 import com.yral.shared.features.chat.data.models.UploadResponseDto
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -142,5 +148,23 @@ class ChatRepositoryImplUnreadCountTest {
         ): UploadResponseDto = error("unused")
 
         override suspend fun markConversationAsRead(conversationId: String) = error("unused")
+
+        override suspend fun startHumanCreatorTakeover(conversationId: String): StartHumanCreatorTakeoverResponseDto = error("unused")
+
+        override suspend fun releaseHumanCreatorTakeover(conversationId: String): ReleaseHumanCreatorTakeoverResponseDto = error("unused")
+
+        override suspend fun sendHumanCreatorMessage(
+            conversationId: String,
+            request: SendHumanCreatorMessageRequestDto,
+        ): ChatMessageDto = error("unused")
+
+        override suspend fun getHumanCreatorTakeoverStatus(conversationId: String): HumanCreatorTakeoverStatusDto = error("unused")
+
+        override suspend fun listCreatorConversationMessages(
+            conversationId: String,
+            limit: Int,
+            offset: Int,
+            order: String,
+        ): ConversationMessagesResponseDto = error("unused")
     }
 }

--- a/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
+++ b/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
@@ -42,5 +42,14 @@ object ChatFeatureFlags {
                 description = "Maximum number of bot usernames to show before '+N More'",
                 defaultValue = 2,
             )
+        val ChatAsHumanCreatorEnabled: FeatureFlag<Boolean> =
+            boolean(
+                keySuffix = "chatAsHumanCreatorEnabled",
+                name = "Chat as Human Creator (takeover)",
+                description = "When ON, exposes the Take Over toggle inside a creator's inbox conversation view " +
+                    "and renders user-side join/leave system banners. When OFF, the creator sees the legacy " +
+                    "'switch to your human profile' prompt and system banners are not rendered.",
+                defaultValue = false,
+            )
     }
 }


### PR DESCRIPTION
## Summary

Adds Chat as Human Creator feature behind feature flag (`chatAsHumanCreatorEnabled`, default OFF). This feature is part of the upcoming Agent V2 chat service (`agent.rishi.yral.com`) currently in development. Backend endpoints exist at the V2 service only — feature flag stays OFF until URL cutover from `chat-ai.rishi.yral.com` to `agent.rishi.yral.com`.

UI changes:
1. Take Over toggle in the AI influencer's inbox conversation view
2. Timer countdown for auto-release
3. Creator-side text input during takeover
4. User-side system messages when creator joins/leaves

No impact on existing user → AI chat flow. When the flag is OFF, the legacy `BotAccountConversationPrompt` (switch-to-human-profile prompt) remains in place and `role=system` messages are not rendered.

Detailed handoff doc at [HANDOFF-CHAT-AS-HUMAN.md](./HANDOFF-CHAT-AS-HUMAN.md).

## Test plan

- [ ] Build prod debug APK; install on Android device
- [ ] Verify with flag OFF (default): user-to-AI chat flow is unchanged; creator opening a bot's inbox conversation sees the existing "Switch to your human profile" prompt; no system banners in any conversation
- [ ] After backend cutover, flip flag ON via Firebase Remote Config and verify:
  - Toggle appears in creator's conversation view
  - Tap toggle → countdown starts at 2:00, input area appears
  - Type + send → message arrives within ~200-500ms, button greys during the POST
  - User-side view shows centered italic "joined the chat" banner; subsequent creator messages render as normal bot messages; "left the chat" banner on release
  - Wait 2 min without sending → toggle auto-flips OFF at 0:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)