### PR TITLE
feat(chat): H2H (Human-to-Human) chat — dormant behind feature flag

### DIFF
--- a/H2H-IMPLEMENTATION-PLAN.md
+++ b/H2H-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,290 @@
+# Human-to-Human (H2H) chat — implementation plan
+
+**Branch:** `rishi/h2h-chat`, branched off `origin/main` at 05229d97.
+**Status:** Plan only. No code. Awaiting Rishi approval before implementation.
+**Companion docs:**
+- Discipline: [`MOBILE-EXPERT-LESSONS.md`](./MOBILE-EXPERT-LESSONS.md) on `rishi/sse-streaming` (will arrive on main when PR [#1173](https://github.com/dolr-ai/yral-mobile/pull/1173) merges). Read P1, P2, P4 before touching code on this branch.
+- SSE work: PR [#1173](https://github.com/dolr-ai/yral-mobile/pull/1173) is dormant-by-default and shares the chat module. Section 12 below covers rebase/merge coordination.
+
+## 1. What this PR does (product)
+
+Adds Human-to-Human direct messaging to the mobile app, behind `ChatFeatureFlags.Chat.H2hChatEnabled` (default OFF). When the flag is on:
+
+- Every **other-user profile** (not bot profile) shows a "Send Message" button.
+- Tapping it creates (or opens) a 1:1 H2H conversation and routes to the chat screen.
+- The chat screen renders the same way as AI chat — same bubbles, same input, same scroll — minus AI-specific affordances (no streaming cursor, no "Try Again" retry on errors).
+- H2H conversations appear in the same inbox list as AI conversations (Instagram-DM style; one unified list).
+
+## 2. What's already there (don't re-invent)
+
+The Day 8 backend (PR #158) was paired with anticipatory mobile scaffolding. Specifically:
+
+- `Conversation.conversationUser: ConversationUser?` already exists ([`shared/features/chat/.../domain/models/Conversation.kt`](shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt)). When non-null, it carries `principalId`, `username`, `profilePictureUrl`.
+- `ConversationDto.user: ConversationUserDto?` and the mapper that materializes the domain `ConversationUser` already exist ([`data/models/ConversationDto.kt`](shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ConversationDto.kt) and [`Mappers.kt`](shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt)).
+- The inbox `ConversationListItem` already prefers `conversationUser.profilePictureUrl` and `conversationUser.username` over the influencer fields when both are present ([`ui/inbox/ConversationListItem.kt`](shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/ConversationListItem.kt)).
+- Navigation routes via `OpenConversationParams` + a Decompose `StackNavigation<Config>` in `DefaultChatComponent` ([`nav/DefaultChatComponent.kt`](shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/nav/DefaultChatComponent.kt)).
+- The inbox query passes `influencerId = null` to its paging source, so it lists **all** conversations for the user, not just AI ones ([`InboxViewModel.kt`](shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/InboxViewModel.kt)).
+
+What does NOT exist yet:
+- No `conversation_type` field anywhere in DTOs or domain — the backend now exposes `"human_chat"` and we have to deserialize it.
+- No "Send Message" button on user profile screens.
+- No create-H2H-conversation use case (`POST /api/v1/chat/human/conversations`).
+- No H2H send-message path (`POST /api/v1/chat/human/conversations/{id}/messages`).
+- No `H2hChatEnabled` feature flag.
+- No H2H awareness in `ConversationViewModel` (subscription / welcome / influencer-specific machinery runs unconditionally today).
+
+## 3. Architecture decision — reuse vs. parallel ViewModel
+
+**Decision: reuse `ConversationViewModel` with branches off a new `ConversationKind` field.** A parallel `H2HConversationViewModel` would duplicate the overlay/paging/send queue/optimistic-Local infrastructure — none of which is AI-specific — and would split future bug-fix surface area in half.
+
+The H2H branches are mostly skip-conditions:
+
+- Don't fetch the influencer.
+- Don't load subscription products / IAP state / welcome message.
+- Don't run takeover polling.
+- Use `sendMessageUseCase`'s H2H sibling instead of the AI one.
+- Read participant info from `conversationUser` instead of `influencer`.
+
+`ConversationKind` is added as a sealed type so the compiler enforces exhaustive handling at branch points:
+
+```kotlin
+sealed interface ConversationKind {
+    data object Ai : ConversationKind          // influencer != null, conversationUser == null
+    data class Human(                          // conversationUser != null, influencer == null
+        val participantPrincipalId: String,
+    ) : ConversationKind
+}
+```
+
+`ConversationViewState` carries `conversationKind: ConversationKind`, derived from the loaded `Conversation` (presence of `conversationUser` vs `influencer`, cross-checked against the new `conversationType` field — see §4).
+
+## 4. Backend wire integration
+
+### 4.1 Endpoints (deployed at `chat-ai.rishi.yral.com` per Day 8, accessed via the existing `CHAT_BASE_URL`)
+
+| Method | Path | Body | Notes |
+|---|---|---|---|
+| `POST` | `/api/v1/chat/human/conversations` | `{ "participant_id": "<other principal_id>" }` | Returns `Conversation` JSON. Idempotent — if a conversation between these two users already exists, returns it instead of creating a duplicate. |
+| `GET` | `/api/v1/chat/human/conversations` | — | Lists H2H conversations for the current user. **We may not need this directly** — the existing combined inbox `GET /conversations` already surfaces H2H conversations once we add `conversation_type` parsing. Confirm with backend whether the combined endpoint is canonical. |
+| `POST` | `/api/v1/chat/human/conversations/{id}/messages` | Same shape as `SendMessageRequestDto` minus `is_streaming` and `is_safety_fallback` | Returns `SendMessageResponseDto` shape. |
+
+### 4.2 DTO changes
+
+- `ConversationDto`: add `@SerialName("conversation_type") val conversationType: String? = null`. Default-null-handle so older inbox responses (pre-Day-8) don't crash. Domain `Conversation` gains `conversationType: String?` carried through.
+- `Mappers.kt`: `ConversationDto.toDomain()` already maps `user → conversationUser`. Extend it to carry `conversationType`. **Critical**: when `conversationType == "human_chat"`, `influencer` may be `null` in the DTO. Today the mapper *throws* if `influencer` is missing — that path needs to be relaxed conditionally on the type.
+
+### 4.3 Use cases (new)
+
+- `CreateHumanConversationUseCase` — wraps `POST /api/v1/chat/human/conversations`. Returns the domain `Conversation`. Both "created" (201) and "already exists" (200) are success cases.
+- `SendHumanMessageUseCase` — wraps `POST /api/v1/chat/human/conversations/{id}/messages`. Same domain return type as the existing `SendMessageUseCase` (`SendMessageResult`).
+
+The existing `SendMessageUseCase` stays AI-only. `ConversationViewModel`'s send routing picks one based on `viewState.conversationKind`.
+
+### 4.4 Repository
+
+Extend `ChatRepository` (interface) with the two new methods. The implementation (`ChatRepositoryImpl`) gets new methods on `ChatDataSource` and `ChatRemoteDataSource` for the H2H paths. The H2H paths are URL-only differences from the AI paths — no body-shape changes other than dropping the streaming-related fields.
+
+## 5. ViewModel changes (`ConversationViewModel`)
+
+### 5.1 State carry
+
+Add to `ConversationViewState`:
+
+```kotlin
+val conversationKind: ConversationKind = ConversationKind.Ai,
+val participantUser: ConversationUser? = null,   // populated for Human conversations
+val isH2hChatEnabled: Boolean = false,            // feature flag, gating UI affordances
+```
+
+`conversationKind` is set in `initializeFromInbox(...)` and `initializeForChatWall(...)` based on the loaded conversation. `participantUser` mirrors `Conversation.conversationUser` for H2H, otherwise null. `isH2hChatEnabled` is read from `FeatureFlagManager` in the VM constructor, same pattern as `isSseStreamingEnabled` / `isChatAsHumanCreatorEnabled`.
+
+### 5.2 Send routing
+
+```kotlin
+private fun routeSendMessage(draft: SendMessageDraft) = when (val k = viewState.value.conversationKind) {
+    ConversationKind.Ai -> sendMessageUseCase(...)             // existing path
+    is ConversationKind.Human -> sendHumanMessageUseCase(...)  // new path
+}
+```
+
+The optimistic Local + overlay + paging + retry-on-failure infrastructure is shared (and stays in place).
+
+### 5.3 Skip branches for H2H
+
+Conditional `if (kind is ConversationKind.Human) return` early-outs in:
+
+- `loadInfluencer(...)` / influencer-fetch paths
+- `loadSubscriptionProducts(...)` / IAP machinery
+- Welcome-message setup
+- Takeover polling startup
+
+Telemetry events get a `conversationKind` parameter or are skipped for H2H if they're influencer-specific.
+
+### 5.4 Retry affordance
+
+**Spec note (open question for Rishi):** the spec says "no AI-specific affordances (no 'Try Again' on errors, no streaming cursor)". Today, the legacy non-streaming send path DOES render a retry button on failed user messages — that's a non-AI feature shared with AI chat. Strict reading of the spec is that H2H gets no retry at all; failed messages stay failed and the user retypes. **Open question §11.1.**
+
+## 6. UI changes
+
+### 6.1 Profile screen — "Send Message" button
+
+Location: `ProfileMainScreen.kt`. Add a CTA in the profile header area, alongside Follow/Unfollow. Gated by `isH2hChatEnabled` (flag off → button hidden entirely, no surprise UX exposure).
+
+On tap:
+
+1. Set local "creating" loading state on the button.
+2. Call `createHumanConversationUseCase(participantPrincipalId = profileOwner.principalId)`.
+3. On success → `component.openConversation(OpenConversationParams(conversationId = created.id, participantPrincipalId = profileOwner.principalId, ...participant display fields))`.
+4. On failure → toast with the mapped error string; keep the user on the profile screen.
+
+The followers/following list rows (`FollowersBottomSheet.FollowerRow`) intentionally do NOT get the button in v1 — keep entry single-source-of-truth.
+
+### 6.2 `OpenConversationParams` extension
+
+Today's params carry `influencerId, conversationId, userId, username, displayName, avatarUrl, ...`. Add:
+
+```kotlin
+val participantPrincipalId: String? = null,
+val conversationKindHint: ConversationKind? = null,   // optional; the VM will re-derive after load anyway
+```
+
+`conversationKindHint` is just an optimization so the screen can render the right empty-state ("Start a chat with Alice") before the network load returns the canonical `Conversation`.
+
+### 6.3 Chat screen — header
+
+`ChatConversationScreen` currently renders the influencer's avatar + name in the header. For H2H, render `participantUser.profilePictureUrl` / `participantUser.username` (with a username fallback if `username == null`). Decision happens off `viewState.conversationKind` — one `when` at the header composable's top.
+
+### 6.4 Chat screen — bubble rendering
+
+The existing `MessageRow.isUser` derives from `role == ConversationMessageRole.USER`. The backend's H2H message DTO uses the same `role` field but maps `sender_id == current_user_principal_id → USER` and the other participant → ASSISTANT. **Confirm with backend** that this convention holds — open question §11.2.
+
+Assuming it does: no changes to `ConversationMessageBubble.kt`. Both H2H sides render exactly as today's user-vs-assistant split (pink-right vs gray-left). The streaming cursor only renders when `isStreaming = true`, which is never true for H2H (the H2H send path doesn't go through SSE).
+
+### 6.5 Chat screen — input
+
+No change. `ChatInputArea` is type-agnostic. The `hasWaitingAssistant` flag still gates send-button-disabled-during-reply behavior (Phase 7-final from the SSE PR's send-button gating); for H2H this means "disabled during in-flight non-streaming send", which already matches production semantics.
+
+### 6.6 Chat screen — disabled affordances for H2H
+
+When `conversationKind is Human`:
+- Don't render the subscription/IAP overlay or paywall card.
+- Don't render the takeover bar (already only renders when `isBotAccount` is true).
+- Don't render the welcome / first-message overlay.
+- Don't render the streaming cursor (automatic — no streaming path).
+
+These are all early-return composables today; we add a `conversationKind is Human` short-circuit at each.
+
+### 6.7 Inbox
+
+No change. `ConversationListItem` already renders dual-avatar correctly. The list query already surfaces all conversations.
+
+**One gotcha:** if `H2hChatEnabled` is OFF but a user has H2H conversations from a prior session (impossible today since the feature is new, but defensive), we'd surface them in the list with no way to open them safely. **Decision:** when `isH2hChatEnabled = false`, filter H2H items out of the inbox list at the screen layer. Cheap and keeps dormancy total.
+
+## 7. Feature flag
+
+Add to `ChatFeatureFlags.Chat`:
+
+```kotlin
+val H2hChatEnabled: FeatureFlag<Boolean> =
+    boolean(
+        keySuffix = "h2hChatEnabled",
+        name = "Human-to-Human chat",
+        description = "Enables direct messaging between users via " +
+            "POST /api/v1/chat/human/conversations. Off until backend + " +
+            "feature go-live.",
+        defaultValue = false,
+    )
+```
+
+Wire `flagManager.get(ChatFeatureFlags.Chat.H2hChatEnabled)` into `ConversationViewState.isH2hChatEnabled`, and into the profile screen's ViewModel state for button visibility.
+
+## 8. Edge cases
+
+| Case | Behavior |
+|---|---|
+| Backend returns existing conversation (200) | Treat as success. Same navigation. |
+| Invalid `participant_id` (backend 4xx) | Toast with mapped error; user stays on profile screen. |
+| Current user has blocked the participant (if/when block feature ships) | Out of scope. No block feature exists today. Document as a Phase-2 follow-up. |
+| Participant's profile becomes deleted while chat is open | Same behavior as a deleted-influencer AI chat today (need to verify what that is — open question §11.3). |
+| User taps "Send Message" while offline | The POST will fail; current `ChatErrorMapper` produces a generic network error → toast. Acceptable for v1. |
+| H2H conversation in inbox while `H2hChatEnabled = false` | Filter out at inbox-screen layer (see §6.7). |
+| Stale current-user principal_id (e.g. user logged out mid-session) | `SessionManager.userPrincipal` is observed; on logout, the inbox + chat screens get torn down by Decompose, so no zombie state. Same as today. |
+| Race: two devices create conversations with same pair simultaneously | Backend should be the de-dup point (return existing). If it doesn't, mobile gets two conversations for the same pair, both valid. Document as backend invariant — open question §11.4. |
+| H2H message fails to send | LocalMessage moves to `FAILED` state. Per spec interpretation, no retry button. User has to copy-paste and resend. (Open question §11.1.) |
+
+## 9. Files to add (estimated 6)
+
+```
+shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/
+  domain/models/ConversationKind.kt
+  domain/usecases/CreateHumanConversationUseCase.kt
+  domain/usecases/SendHumanMessageUseCase.kt
+  data/models/CreateHumanConversationRequestDto.kt
+  data/models/SendHumanMessageRequestDto.kt              # if shape differs from existing SendMessageRequestDto
+```
+
+`SendHumanMessageRequestDto` is only needed if the H2H wire shape diverges — if the existing DTO works with default-null `is_streaming` / `is_safety_fallback`, we reuse it and drop this file.
+
+## 10. Files to modify (estimated 9)
+
+| File | One-line rationale |
+|---|---|
+| `data/models/ConversationDto.kt` | Add `conversation_type` field (nullable). |
+| `data/models/Mappers.kt` | Carry `conversationType` through to domain; allow null `influencer` when `conversationType == "human_chat"`. |
+| `domain/models/Conversation.kt` | Add `conversationType: String?` carried from DTO. |
+| `domain/ChatRepository.kt` + `data/ChatRepositoryImpl.kt` | New `createHumanConversation(participantId)` + `sendHumanMessage(conversationId, draft)` methods. |
+| `data/ChatRemoteDataSource.kt` (interface and impl) | New H2H endpoint paths. |
+| `di/ChatModule.kt` | Register the two new use cases. |
+| `viewmodel/ConversationViewState.kt` | Add `conversationKind`, `participantUser`, `isH2hChatEnabled`. |
+| `viewmodel/ConversationViewModel.kt` | Send routing + skip branches for H2H + initialize `conversationKind` from loaded conversation. |
+| `nav/conversation/OpenConversationParams.kt` | Add `participantPrincipalId`, `conversationKindHint`. |
+| `ui/conversation/ChatConversationScreen.kt` | Header branch on `conversationKind`; skip subscription/welcome/takeover overlays for Human. |
+| `ui/inbox/InboxScreen.kt` (or its VM) | Inbox filter when `H2hChatEnabled = false`. |
+| `shared/features/profile/.../ProfileMainScreen.kt` | New "Send Message" button + tap handler. |
+| `shared/libs/feature-flag/.../ChatFeatureFlags.kt` | New `H2hChatEnabled` flag. |
+
+Two of these files (`ConversationViewModel.kt`, `ChatConversationScreen.kt`) are also heavily modified on the SSE branch — see §12 for rebase coordination.
+
+## 11. Open questions for Rishi (answer before coding)
+
+1. **Retry on H2H send failure** — strict spec reading is "no Try Again button at all." Confirm: failed H2H messages stay as red FAILED bubbles with no retry affordance, and the user must re-type from scratch? Or keep the retry button (it's not technically AI-specific)?
+2. **Backend message-side role convention** — does the H2H message DTO use `role: "user" | "assistant"` mapped to current-user-vs-other, or does it use `sender_principal_id` and require mobile to derive the role by comparing to `SessionManager.userPrincipal`? Need the exact wire format before §6.4 lands.
+3. **Deleted-participant behavior** — what does the AI chat show today when an influencer is deleted? H2H should match.
+4. **De-dup invariant** — is the backend guaranteed to return the existing conversation on POST when a pair already has one? Or do we need client-side de-dup as a defense?
+5. **Inbox sort order** — H2H and AI conversations are interleaved by last-message timestamp, same as the existing inbox sort? Confirming the unified sort is desired.
+6. **Send button location on profile** — header area next to Follow/Unfollow, or sticky bottom CTA, or both? Sketch / mock needed.
+7. **First-time-empty-state** — when a fresh H2H conversation has no messages, what does the chat screen show? Empty + input bar, or a "Say hi to Alice!" prompt? AI chat has the welcome-bubble for empty state; H2H needs its own design.
+8. **Should "Send Message" appear on bot/influencer profiles too?** Spec says "NOT bot profile" — confirming. Bot profiles already route to the existing AI chat flow on tap; the Send Message button would be ambiguous there.
+
+## 12. Coordination with SSE PR #1173
+
+The SSE PR modifies `ConversationViewModel.kt`, `ChatConversationScreen.kt`, `ChatRepository.kt`, `ChatModule.kt`, and adds `MOBILE-EXPERT-LESSONS.md`. This H2H plan touches the same first four. Two possible merge orders:
+
+**Order A: SSE merges first, then H2H rebases.** Simpler. The lessons file and the SSE additions land on main; H2H rebases and resolves the four-file conflicts. Most of the H2H changes are in different sections of those files (header rendering vs streaming buffer state), so conflicts should be mechanical.
+
+**Order B: H2H merges first, then SSE rebases.** SSE PR has to absorb H2H's changes. Bigger conflict surface for SSE (the `conversationKind` branches affect routing throughout the VM). Not recommended.
+
+**Recommendation:** wait for SSE PR to merge before opening H2H PR. This branch can land its first commit immediately (no merge-state dependency for the planning + DTO/flag work), but the chat-screen and VM changes should land after the rebase to minimize re-review for Sarvesh.
+
+## 13. Test plan (manual, on Motorola)
+
+When implementation lands. Mirror the §11 style from the SSE plan:
+
+- **H1 Functional happy path** — Profile of another user → tap Send Message → loading → chat screen opens → send "hi" → message lands. Other user (via test rig or second device) sees the message in their inbox.
+- **H2 Idempotency** — Tap Send Message twice on same profile in quick succession → only one conversation gets created (backend returns existing on second tap) → both taps land on the same chat screen.
+- **H3 Inbox visibility** — H2H conversation shows in the unified inbox with the other user's avatar + username. Tapping the row opens the chat.
+- **H4 Flag-off dormancy** — With `H2hChatEnabled = false`, no Send Message button visible on any profile; existing H2H conversations don't appear in inbox.
+- **H5 Carve-outs** — Bot profiles do NOT show the Send Message button. Active takeover on the user's own bot doesn't interact with H2H state.
+- **H6 Error path** — Send message while offline → message goes to FAILED state. Verify the "Try Again" behavior matches whichever way §11.1 is answered.
+- **H7 AI regression** — Open an existing AI conversation → verify subscription card, welcome message, retry buttons, and (when SSE is merged) streaming behavior all still work. The `conversationKind` branches must not leak into the AI path.
+- **H8 Cross-screen** — Inbox + Wall + own profile + media upload flows unaffected by H2H changes.
+
+## 14. Estimated scope
+
+- **Code lines added**: ~300-500 in shared/features/chat, ~50 in profile/, ~10 in feature-flag.
+- **Sessions**: 2-3 (one for backend/DTO/repository/use-cases, one for VM + chat screen branches, one for profile button + inbox filter + flag + Motorola test pass).
+- **PR size**: estimated ~600 lines diff. Well below the "request a senior review on size" threshold.
+
+---
+
+**Next step:** Rishi reviews this plan, answers the §11 open questions, signs off on the architectural decision in §3 (reuse vs. parallel VM). Then implementation begins.

--- a/MOBILE-EXPERT-LESSONS.md
+++ b/MOBILE-EXPERT-LESSONS.md
@@ -1,0 +1,72 @@
+# Mobile Expert — Hard-Won Lessons
+
+**Append-only.** Each new lesson learned the expensive way (false-conclusion turns, wasted builds, regressions caught by Rishi) gets added at the bottom with the date and the bug-trail context that made it expensive. Existing entries are NEVER rewritten — that erases the cost lesson.
+
+**Read this file before starting any mobile work in a fresh session.** The five lessons below cost a multi-hour debugging arc that should not be repeated.
+
+---
+
+## P1 — Multi-flavor Android install hazard
+
+This project has two debug flavors with two different package IDs:
+- `com.yral.android.app` ← **prod-debug** (Rishi tests this)
+- `com.yral.android` ← staging-debug (separate app icon)
+
+For multiple turns I ran `:androidApp:installStagingDebug`, the install succeeded, but the staging APK landed as a separate app that Rishi never opened. He was testing prod-debug the whole time, which had no probe code in it. **Always run `installProdDebug` for this project, OR confirm which app icon Rishi is opening before drawing conclusions from his observations.** Verify after install by pulling `pm path com.yral.android.app` and grepping the dex for an expected new string.
+
+## P2 — Gradle build cache silently served stale artifacts
+
+Edits hit disk, but `:shared:features:chat:compileDebugKotlinAndroid` came back as `UP-TO-DATE` and later `FROM-CACHE`, so the new code never reached the APK. Causes: (a) Gradle uses content hashes, not mtimes — `touch` does nothing. (b) The build cache has cross-build entries it'll match against. **For any diagnostic build where you must be sure the new code is in the output, use `:shared:features:chat:clean` AND `--no-build-cache --rerun-tasks`.** Confirm with the next point below.
+
+## P3 — macOS `strings` fails silently on JVM `.class` files
+
+Xcode's `strings` errors with "fat file truncated or malformed" and returns 0 lines, which looks identical to "string not present." **For verifying compiled artifacts, use `LC_ALL=C grep -a "marker" file.class` or `unzip -p apk.apk "classes*.dex" | LC_ALL=C grep -ao "marker"`.** This wasted multiple turns where I thought my edits weren't compiled.
+
+## P4 — Claims-vs-code drift
+
+Twice in this session I stated things about the code that the code didn't actually do (claimed cursor wasn't in the content string; claimed Text path was used during streaming for all content). Codex consultant caught both by reading the file. **Re-read the actual code before making any claim about it; if a comment in the code disagrees with what the code does, the comment is wrong, not the code.** The misleading comment in `ConversationMessagesList.kt` was authored by Phase 5b me, and Codex was reading it as authoritative.
+
+## P5 — Don't theorize past validation
+
+I was three rounds deep into "it's a path swap at first token" theories before the probe confirmed the actual cause was Markdown library re-render. Run the probe first.
+
+---
+
+## Phase 5b ↔ 5c contract — invariants to never violate
+
+If a future session touches `RegularBubble`, `MessagesList`, or `startStreamingAssistantReply`:
+
+- **Path lock**: `markdownLockedOverride` pins Markdown vs Text per stream. NEVER let the path switch mid-stream or at done. The `useMarkdown` branch in `RegularBubble` must always honor an explicit override before falling back to `shouldRenderAsMarkdown(content)`.
+- **Cursor isolation**: the streaming cursor MUST be a sibling composable, never appended to the content string the renderer parses. If you change cursor presentation (e.g., move from "below the text" to "bottom-end overlay"), keep the input-string isolation property.
+- **Coalesce window**: 250ms is the shipped value. Don't tune without re-measuring on a Motorola with realistic Gemini token cadence (the diagnostic logs in the conversation show typical batch sizes 80-180 chars, 3-5 batches per reply).
+- **Flush ordering**: `flushJob?.cancelAndJoin()` MUST run before any code that removes the streaming Local (Done, Failed). Otherwise a lingering 250ms flush will append text after the Local has been replaced by the Remote.
+
+## Verified root cause of SSE streaming flicker
+
+**Per-batch mid-stream flicker** = `com.mikepenz:multiplatform-markdown-renderer:0.38.0` re-parses the entire content string on every recomposition. With tokens arriving 3-5 times per reply, the user sees the bubble "refresh" once per network token batch. This was *verified* by a diagnostic probe that forced Text-path during streaming — flicker disappeared, then reappeared once at `done` (the intentional Text→Markdown swap inside the probe).
+
+**Amplifier**: the cursor "▌" was being appended to the string passed to `Markdown(content = ...)`. Every token batch grew the string by `(new token text + 1 trailing cursor char that shifted position)`. Eliminating the trailing cursor character from the parser's input reduces the per-batch re-parse delta.
+
+**Mitigation** = path-lock (Phase 5b, already shipped) + cursor isolation (this session) + 250ms coalescing (this session). Together they reduce streaming bubble re-parses from N (per network token) to roughly N/3 (per coalesced window), with no Markdown/Text path swap anywhere in the stream lifecycle.
+
+---
+
+## P6 — The wire is wired ≠ the wire carries data
+
+**The mistake:** wiring an endpoint, a DTO, a mapper, and a list view all compile and pass. The Explore agent reports back: "the source merely passes `influencerId=null` to list all conversations." The code looks correct at every interface boundary. You ship. The H2H "Send Message" works, but the new conversation never shows up in the inbox.
+
+The root cause was visible only by reading the SQL inside the repository function — an `INNER JOIN ai_influencers` that silently dropped every row where `influencer_id` was NULL. None of the surface-level checks could see it: the function signature said "list all conversations for the user," the mapper handled the case where `influencer` was null, the UI had dual-avatar logic for H2H rows. Every layer told the truth about its own interface. The data flowing between them was filtered upstream by a `JOIN` clause that the interface didn't expose.
+
+**Why this is its own lesson and not just a restatement of P4:** P4 is "the code may disagree with the comment — trust the code." P6 is the next layer down: the code at the interface boundary may also disagree with the *deeper* code that produces the data the interface returns. A function called `list_by_user(user_id)` whose name and signature say "all conversations for user" can still silently drop H2H rows because of how the SQL is written. The compile passes. The types match. The function name is honest about *what it intends to return*. The implementation differs from the intent and nobody catches it because nobody reads three layers down.
+
+**Defense:**
+
+1. **Read the SQL, not the function name.** When a function returns rows from a database, the source of truth is the `SELECT ... FROM ... JOIN ... WHERE ...` block, not the function's docstring. Open the repository file. Read the actual query. Trace each `JOIN` and `WHERE` clause against the data shape you expect to see.
+
+2. **Trace the actual response shape through to the UI render.** Not just the type system — the *values*. For each field the UI displays, follow it: API JSON → DTO field → mapper → domain field → state → composable. If any layer drops the field (or substitutes a default) the layer below will silently render the default and you won't know why.
+
+3. **Run the test plan you wrote — don't skip.** When I write `§H3: H2H conversation shows in the unified inbox with the other user's avatar` in my own plan, that's a test that exists to catch exactly this class of bug. Skipping it because "the data layer compiles" is the same as not writing it. Either delete the test from the plan or run it.
+
+4. **Don't trust Explore agent summaries about data flow.** The agent's job is to map call sites; the agent does NOT verify that the data those call sites carry matches what the call site implies. "Backend query is not hardcoded to AI" was a summary derived from the *call signature*, not the SQL. If a summary makes a claim about data behavior (what rows come back, what fields populate), verify by reading the implementation — never inherit the claim.
+
+**Bug-trail context, 2026-05-30:** Day-9 of the H2H build. I shipped 7 commits across two sessions that wired the H2H create endpoint, the send endpoint, the typed sender_id propagation, and a chat-screen functional flow. End-to-end H2H send worked. Rishi tested by messaging `abledearcorgi` — message sent, conversation created in the database, sender on the receiving end gets a WebSocket push. But the conversation never appeared in Rishi's inbox. My H2H-IMPLEMENTATION-PLAN.md §4.1 had stated "the existing combined inbox `GET /conversations` already surfaces H2H conversations once we add `conversation_type` parsing" with a note "Confirm with backend whether the combined endpoint is canonical." I never confirmed. The SQL in `conversation_repo.list_by_user` did an `INNER JOIN ai_influencers`, which excluded every H2H row. Caught only when Rishi tested the inbox visibility I had originally written down as test case §H3 and never executed.

--- a/MOBILE-EXPERT-LESSONS.md
+++ b/MOBILE-EXPERT-LESSONS.md
@@ -70,3 +70,27 @@ The root cause was visible only by reading the SQL inside the repository functio
 4. **Don't trust Explore agent summaries about data flow.** The agent's job is to map call sites; the agent does NOT verify that the data those call sites carry matches what the call site implies. "Backend query is not hardcoded to AI" was a summary derived from the *call signature*, not the SQL. If a summary makes a claim about data behavior (what rows come back, what fields populate), verify by reading the implementation — never inherit the claim.
 
 **Bug-trail context, 2026-05-30:** Day-9 of the H2H build. I shipped 7 commits across two sessions that wired the H2H create endpoint, the send endpoint, the typed sender_id propagation, and a chat-screen functional flow. End-to-end H2H send worked. Rishi tested by messaging `abledearcorgi` — message sent, conversation created in the database, sender on the receiving end gets a WebSocket push. But the conversation never appeared in Rishi's inbox. My H2H-IMPLEMENTATION-PLAN.md §4.1 had stated "the existing combined inbox `GET /conversations` already surfaces H2H conversations once we add `conversation_type` parsing" with a note "Confirm with backend whether the combined endpoint is canonical." I never confirmed. The SQL in `conversation_repo.list_by_user` did an `INNER JOIN ai_influencers`, which excluded every H2H row. Caught only when Rishi tested the inbox visibility I had originally written down as test case §H3 and never executed.
+
+---
+
+## P7 — Permissive deserialization defaults are load-bearing during backend evolution
+
+**The catch:** when backend PR #228 added an `is_online` field to the AI `influencer` block in the unified inbox response, mobile shipped without any DTO change for that field. The new field did not crash anything because `JsonHelper.kt` configures the Json instance with `ignoreUnknownKeys = true` and `isLenient = true`. Mobile silently dropped the new field, the inbox rendered as before, and nobody noticed until I did the post-deploy code-read pass and explicitly accounted for it.
+
+This is good behavior, not luck — but it depends on a single Json-instance config line at the boundary, and the *value* of that line is invisible to every layer above it. The DTO doesn't know it's missing a field. The mapper doesn't know. The composable doesn't know. The compiler can't help. The only signal that this safety net exists is the absence of the bug.
+
+**The lesson:** permissive deserialization defaults are load-bearing infrastructure during periods when the backend is evolving. If the team ever tightens these defaults — to catch typos, enforce schema strictness, or surface unexpected fields — that change is not a routine config tweak. It is equivalent to a coordinated backend-frontend release: every DTO must be audited against the *current* backend response shape, on the *current* deployed branch, before the strict config can ship without breaking the inbox.
+
+**Concrete properties of the safety net we currently rely on:**
+
+1. `Json { isLenient = true; ignoreUnknownKeys = true }` at `shared/libs/http/src/commonMain/kotlin/com/yral/shared/http/JsonHelper.kt:6-8`. This is the single point where unknown-key tolerance is configured.
+2. Every DTO consumed by this `Json` instance inherits that tolerance. Removing the config line silently flips every DTO from forward-compatible to strict.
+3. Backend ships new fields routinely (`is_online` is one of several this quarter). Each one is a silent "test" of the tolerance.
+
+**Defense if you ever touch JsonHelper.kt:**
+
+1. **Don't remove `ignoreUnknownKeys = true` without a coordinated audit.** Open every `@Serializable data class` consumed by this Json instance. For each, fetch the current backend response on the staging/dev branch and diff field-by-field. Add fields the backend now sends but the DTO doesn't model.
+2. **If you want stricter behavior on a specific DTO, prefer field-level annotations (`@Required`, default values, sealed type validation) over flipping the global config.** Global strict-mode breaks every DTO at once; field-level enforcement breaks only the contract you're tightening.
+3. **Treat unknown-key warnings, if you add a custom serializer that surfaces them, as a forward-compat signal not a bug — log them, don't throw.** The backend is allowed to ship new fields; mobile catches up at the next DTO update window.
+
+**Bug-trail context, 2026-05-30:** while doing the code-read pass for the post-PR-#228 inbox retest, I noticed that `ConversationInfluencerDto` does not model `is_online` even though the backend now sends it. The reason the AI rows still parse is `JsonHelper.kt:8`'s `ignoreUnknownKeys = true`. The lesson was visible only because I explicitly went looking for "what does the new field do to my parser?" — a question that comes from P4/P6 discipline, not from the type system or the test suite.

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/DefaultRootComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/DefaultRootComponent.kt
@@ -419,7 +419,10 @@ class DefaultRootComponent(
                     }
                 }
             if (existingIndex != -1) {
-                stack.take(existingIndex + 1)
+                // H2H repro: matching a stale frame by conversationId was
+                // dropping new params like participantPrincipalId. Replace
+                // the matched frame so the chat screen re-initializes.
+                stack.take(existingIndex) + Config.Conversation(params = params)
             } else {
                 stack + Config.Conversation(params = params)
             }

--- a/shared/data/src/commonMain/kotlin/com/yral/shared/data/domain/models/OpenConversationParams.kt
+++ b/shared/data/src/commonMain/kotlin/com/yral/shared/data/domain/models/OpenConversationParams.kt
@@ -13,6 +13,13 @@ data class OpenConversationParams(
     val displayName: String? = null,
     val avatarUrl: String? = null,
     val autoTriggerPurchase: Boolean = false,
+    // H2H: the other-user's principal_id, populated when this navigation
+    // comes from a "Send Message" tap on a user profile. Null for AI
+    // chats. The chat screen also derives the H2H vs AI mode from the
+    // loaded Conversation.conversationType, so this field is a UX hint
+    // (for empty-state rendering before the network load completes)
+    // rather than the canonical signal.
+    val participantPrincipalId: String? = null,
 )
 
 @Serializable

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
@@ -31,6 +31,26 @@ interface ChatDataSource {
 
     suspend fun createConversation(influencerId: String): ConversationDto
 
+    /**
+     * H2H: idempotent create-or-fetch of a 1:1 human conversation with
+     * [participantId]. POST /api/v1/chat/human/conversations.
+     */
+    suspend fun createHumanConversation(participantId: String): ConversationDto
+
+    /**
+     * H2H: post a message to the human conversation [conversationId].
+     * POST /api/v1/chat/human/conversations/{id}/messages.
+     *
+     * Reuses [SendMessageRequestDto] — the backend ignores
+     * `is_streaming` / `is_safety_fallback` for H2H, and the existing
+     * non-null body fields (content, message_type, media_urls, audio_url,
+     * audio_duration_seconds) are identical between AI and H2H sends.
+     */
+    suspend fun sendHumanMessage(
+        conversationId: String,
+        request: SendMessageRequestDto,
+    ): SendMessageResponseDto
+
     suspend fun listConversations(
         limit: Int,
         offset: Int,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
@@ -9,6 +9,7 @@ import com.yral.shared.features.chat.data.models.ConversationDto
 import com.yral.shared.features.chat.data.models.ConversationMessagesResponseDto
 import com.yral.shared.features.chat.data.models.ConversationsResponseDto
 import com.yral.shared.features.chat.data.models.CreateConversationRequestDto
+import com.yral.shared.features.chat.data.models.CreateHumanConversationRequestDto
 import com.yral.shared.features.chat.data.models.DeleteConversationResponseDto
 import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
 import com.yral.shared.features.chat.data.models.InfluencerDto
@@ -117,6 +118,43 @@ class ChatRemoteDataSource(
                 ),
             )
             headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun createHumanConversation(participantId: String): ConversationDto {
+        val idToken = getIdToken()
+        return httpPost(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(HUMAN_CONVERSATIONS_PATH)
+            }
+            setBody(
+                CreateHumanConversationRequestDto(
+                    participantId = participantId,
+                ),
+            )
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun sendHumanMessage(
+        conversationId: String,
+        request: SendMessageRequestDto,
+    ): SendMessageResponseDto {
+        val idToken = getIdToken()
+        return httpPost(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(HUMAN_CONVERSATIONS_PATH, conversationId, MESSAGES_PATH)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+            setBody(request)
         }
     }
 
@@ -376,6 +414,7 @@ class ChatRemoteDataSource(
         private const val INFLUENCERS_PATH = "api/v1/influencers"
         private const val INFLUENCER_FEED_PATH = "api/v1/influencer-feed"
         private const val CONVERSATIONS_PATH = "api/v1/chat/conversations"
+        private const val HUMAN_CONVERSATIONS_PATH = "api/v1/chat/human/conversations"
         private const val CONVERSATIONS_LIST_PATH = "api/v2/chat/conversations"
         private const val MESSAGES_PATH = "messages"
         private const val READ_PATH = "read"

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
@@ -71,6 +71,56 @@ class ChatRepositoryImpl(
             .createConversation(influencerId)
             .toDomain()
 
+    override suspend fun createHumanConversation(participantId: String): Conversation =
+        dataSource
+            .createHumanConversation(participantId)
+            .toDomain()
+
+    override suspend fun sendHumanMessage(
+        conversationId: String,
+        draft: SendMessageDraft,
+    ): SendMessageResult {
+        // H2H send shares the attachment-upload + request-shape pipeline
+        // with the AI path. The wire endpoint differs (POST .../human/...)
+        // but the body fields are identical — backend ignores the
+        // streaming-only fields for H2H.
+        val mediaUrls =
+            if (draft.mediaAttachments.isNotEmpty()) {
+                draft.mediaAttachments.map { attachment ->
+                    dataSource
+                        .uploadAttachment(
+                            attachment = attachment,
+                            type = ChatMessageType.IMAGE.apiValue,
+                        ).storageKey
+                }
+            } else {
+                null
+            }
+
+        val audioUrl =
+            draft.audioAttachment?.let { attachment ->
+                dataSource
+                    .uploadAttachment(
+                        attachment = attachment,
+                        type = ChatMessageType.AUDIO.apiValue,
+                    ).storageKey
+            }
+
+        val response =
+            dataSource.sendHumanMessage(
+                conversationId = conversationId,
+                request =
+                    SendMessageRequestDto(
+                        content = draft.content,
+                        messageType = draft.messageType.apiValue,
+                        mediaUrls = mediaUrls,
+                        audioUrl = audioUrl,
+                        audioDurationSeconds = draft.audioDurationSeconds,
+                    ),
+            )
+        return response.toDomain(conversationIdFallback = conversationId)
+    }
+
     override suspend fun getConversationsPage(
         limit: Int,
         offset: Int,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
@@ -25,4 +25,12 @@ data class ChatMessageDto(
     val tokenCount: Int? = null,
     @SerialName("created_at")
     val createdAt: String,
+    // H2H: the principal_id of whichever user inserted the row. The backend
+    // stores every H2H message with role="user", so role alone can't tell us
+    // which side sent it — sender_id is what the mobile client compares
+    // against SessionManager.userPrincipal to render bubble alignment.
+    // Defaults to null so legacy (pre-backend-patch) wire payloads and the
+    // AI path (where role is authoritative) parse without breaking.
+    @SerialName("sender_id")
+    val senderId: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ConversationDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ConversationDto.kt
@@ -15,6 +15,12 @@ data class ConversationDto(
     val influencer: ConversationInfluencerDto? = null,
     @SerialName("user")
     val user: ConversationUserDto? = null,
+    // H2H plumbing: backend exposes "human_chat" here for direct-message
+    // conversations and "ai_chat" (or null on pre-Day-8 rows) for the
+    // existing influencer-backed chats. Mappers branch on this to decide
+    // whether `influencer` may legally be null in the domain.
+    @SerialName("conversation_type")
+    val conversationType: String? = null,
     @SerialName("created_at")
     val createdAt: String,
     @SerialName("updated_at")

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/CreateHumanConversationRequestDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/CreateHumanConversationRequestDto.kt
@@ -1,0 +1,18 @@
+package com.yral.shared.features.chat.data.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Body for `POST /api/v1/chat/human/conversations`.
+ *
+ * The endpoint is idempotent — if an H2H conversation between the
+ * authenticated user and [participantId] already exists, the backend
+ * returns the existing one rather than creating a duplicate. So callers
+ * can treat both 200 and 201 responses as success.
+ */
+@Serializable
+data class CreateHumanConversationRequestDto(
+    @SerialName("participant_id")
+    val participantId: String,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -176,6 +176,7 @@ fun ChatMessageDto.toDomain(conversationIdFallback: String? = null): ChatMessage
         audioDurationSeconds = audioDurationSeconds,
         tokenCount = tokenCount,
         createdAt = createdAt,
+        senderId = senderId,
     )
 }
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -12,6 +12,7 @@ import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResul
 import com.yral.shared.features.chat.domain.models.ConversationUser
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.HUMAN_CHAT_CONVERSATION_TYPE
 import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencerStatus
@@ -106,7 +107,7 @@ fun ConversationDto.toDomain(): Conversation {
     // conversations must — keep the original invariant in place for them
     // so a backend bug that drops the influencer doesn't silently
     // degrade the AI chat experience.
-    if (resolvedInfluencer == null && conversationType != HUMAN_CHAT_TYPE) {
+    if (resolvedInfluencer == null && conversationType != HUMAN_CHAT_CONVERSATION_TYPE) {
         throw YralException("Conversation requires a valid influencer")
     }
     return Conversation(
@@ -143,8 +144,6 @@ fun ConversationDto.toDomain(): Conversation {
         conversationType = conversationType,
     )
 }
-
-private const val HUMAN_CHAT_TYPE = "human_chat"
 
 fun ConversationsResponseDto.toDomain(): ConversationsPageResult {
     val rawCount = conversations.size

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -80,31 +80,39 @@ fun InfluencersResponseDto.toDomainActiveOnly(): InfluencersPageResult {
     )
 }
 
-fun ConversationDto.toDomain(): Conversation =
-    Conversation(
+fun ConversationDto.toDomain(): Conversation {
+    val resolvedInfluencer: ConversationInfluencer? =
+        influencer?.let {
+            ConversationInfluencer(
+                id = it.id,
+                name = it.name,
+                displayName = it.displayName,
+                avatarUrl =
+                    it.avatarUrl
+                        .takeIf { url -> url.isNotEmpty() }
+                        ?: propicFromPrincipal(it.id),
+                category = it.category.orEmpty(),
+                suggestedMessages = it.suggestedMessages.orEmpty(),
+            )
+        } ?: influencerId?.let { influencerId ->
+            ConversationInfluencer(
+                id = influencerId,
+                name = "",
+                displayName = "",
+                avatarUrl = "",
+            )
+        }
+    // H2H conversations legitimately carry no influencer. AI / takeover
+    // conversations must — keep the original invariant in place for them
+    // so a backend bug that drops the influencer doesn't silently
+    // degrade the AI chat experience.
+    if (resolvedInfluencer == null && conversationType != HUMAN_CHAT_TYPE) {
+        throw YralException("Conversation requires a valid influencer")
+    }
+    return Conversation(
         id = id,
         userId = userId,
-        influencer =
-            influencer?.let {
-                ConversationInfluencer(
-                    id = it.id,
-                    name = it.name,
-                    displayName = it.displayName,
-                    avatarUrl =
-                        it.avatarUrl
-                            .takeIf { url -> url.isNotEmpty() }
-                            ?: propicFromPrincipal(it.id),
-                    category = it.category.orEmpty(),
-                    suggestedMessages = it.suggestedMessages.orEmpty(),
-                )
-            } ?: influencerId?.let { influencerId ->
-                ConversationInfluencer(
-                    id = influencerId,
-                    name = "",
-                    displayName = "",
-                    avatarUrl = "",
-                )
-            } ?: throw YralException("Conversation requires a valid influencer"),
+        influencer = resolvedInfluencer,
         conversationUser =
             user?.let {
                 ConversationUser(
@@ -132,7 +140,11 @@ fun ConversationDto.toDomain(): Conversation =
             },
         recentMessages = recentMessages?.map { it.toDomain(conversationIdFallback = id) } ?: emptyList(),
         unreadCount = unreadCount,
+        conversationType = conversationType,
     )
+}
+
+private const val HUMAN_CHAT_TYPE = "human_chat"
 
 fun ConversationsResponseDto.toDomain(): ConversationsPageResult {
     val rawCount = conversations.size

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
@@ -91,6 +91,7 @@ val chatModule =
                 chatRepository = get(),
                 useCaseFailureListener = get(),
                 sendMessageUseCase = get(),
+                sendHumanMessageUseCase = get(),
                 createConversationUseCase = get(),
                 deleteConversationUseCase = get(),
                 markConversationAsReadUseCase = get(),

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
@@ -14,6 +14,7 @@ import com.yral.shared.features.chat.domain.ChatErrorMapper
 import com.yral.shared.features.chat.domain.ChatRepository
 import com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.CreateConversationUseCase
+import com.yral.shared.features.chat.domain.usecases.CreateHumanConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.DeleteConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.GetHumanCreatorTakeoverStatusUseCase
 import com.yral.shared.features.chat.domain.usecases.GetInfluencerUseCase
@@ -21,6 +22,7 @@ import com.yral.shared.features.chat.domain.usecases.GrantChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.MarkConversationAsReadUseCase
 import com.yral.shared.features.chat.domain.usecases.ReleaseHumanCreatorTakeoverUseCase
 import com.yral.shared.features.chat.domain.usecases.SendHumanCreatorMessageUseCase
+import com.yral.shared.features.chat.domain.usecases.SendHumanMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.SendMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.StartHumanCreatorTakeoverUseCase
 import com.yral.shared.features.chat.viewmodel.ChatUnreadRefreshSignal
@@ -65,10 +67,12 @@ val chatModule =
         factoryOf(::CheckChatAccessUseCase)
         factoryOf(::GrantChatAccessUseCase)
         factoryOf(::CreateConversationUseCase)
+        factoryOf(::CreateHumanConversationUseCase)
         factoryOf(::DeleteConversationUseCase)
         factoryOf(::GetInfluencerUseCase)
         factoryOf(::MarkConversationAsReadUseCase)
         factoryOf(::SendMessageUseCase)
+        factoryOf(::SendHumanMessageUseCase)
         factoryOf(::StartHumanCreatorTakeoverUseCase)
         factoryOf(::ReleaseHumanCreatorTakeoverUseCase)
         factoryOf(::SendHumanCreatorMessageUseCase)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
@@ -30,6 +30,26 @@ interface ChatRepository {
 
     suspend fun createConversation(influencerId: String): Conversation
 
+    /**
+     * H2H: idempotent create-or-fetch of a 1:1 conversation between the
+     * authenticated user and [participantId]. If a conversation between
+     * the pair already exists, the existing one is returned (backend
+     * checks both orderings of user_id / participant_b_id). Both 200
+     * and 201 responses are treated as success.
+     */
+    suspend fun createHumanConversation(participantId: String): Conversation
+
+    /**
+     * H2H: post a message to a human conversation. Same domain return
+     * type as [sendMessage] for the AI path so the call sites that
+     * compose the optimistic-Local → server-truth-Remote swap can share
+     * the result shape.
+     */
+    suspend fun sendHumanMessage(
+        conversationId: String,
+        draft: SendMessageDraft,
+    ): SendMessageResult
+
     suspend fun getConversationsPage(
         limit: Int,
         offset: Int,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
@@ -11,4 +11,25 @@ data class ChatMessage(
     val audioDurationSeconds: Int?,
     val tokenCount: Int?,
     val createdAt: String,
+    // H2H: the principal_id of whichever user inserted this row. Null on
+    // legacy rows from before the backend exposed sender_id (handled by
+    // [isFromCurrentUser]'s null-fallback). For AI chats this carries
+    // through but isn't load-bearing — role alone is authoritative there.
+    val senderId: String? = null,
 )
+
+/**
+ * Side-of-conversation derivation. The H2H send path stores every message
+ * with role="user" regardless of sender, so role alone can't tell the
+ * mobile client which side authored a row — sender_id is what
+ * `ChatConversationScreen` uses to align the bubble (right-side current
+ * user vs left-side participant).
+ *
+ * The `senderId == null` fallback keeps AI chat and legacy H2H rows
+ * (inserted before the backend started exposing sender_id) working by
+ * deferring to the existing role check. New code can use this property
+ * uniformly across conversation kinds.
+ */
+fun ChatMessage.isFromCurrentUser(currentUserPrincipal: String): Boolean =
+    senderId == currentUserPrincipal ||
+        (senderId == null && role == ConversationMessageRole.USER)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt
@@ -3,7 +3,10 @@ package com.yral.shared.features.chat.domain.models
 data class Conversation(
     val id: String,
     val userId: String,
-    val influencer: ConversationInfluencer,
+    // Nullable on H2H conversations (where the other party is a user, not
+    // an influencer). Always present on AI / chat-as-human conversations.
+    // Callers branch on [conversationType] to know which case they're in.
+    val influencer: ConversationInfluencer?,
     val conversationUser: ConversationUser? = null,
     val createdAt: String,
     val updatedAt: String,
@@ -11,6 +14,12 @@ data class Conversation(
     val lastMessage: ConversationLastMessage?,
     val recentMessages: List<ChatMessage> = emptyList(),
     val unreadCount: Int = 0,
+    // Raw backend type discriminator: "human_chat" for H2H, "ai_chat" or
+    // null for the existing influencer-backed conversations. Mappers
+    // populate this from the wire; UI/VM branch off it (alongside the
+    // presence of `conversationUser` / `influencer`) to pick the right
+    // header, send path, and visual affordances.
+    val conversationType: String? = null,
 )
 
 data class ConversationUser(

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Conversation.kt
@@ -22,6 +22,11 @@ data class Conversation(
     val conversationType: String? = null,
 )
 
+const val HUMAN_CHAT_CONVERSATION_TYPE = "human_chat"
+
+val Conversation.isHumanChat: Boolean
+    get() = conversationType == HUMAN_CHAT_CONVERSATION_TYPE || conversationUser != null
+
 data class ConversationUser(
     val principalId: String,
     val username: String?,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/UnreadConversationCount.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/UnreadConversationCount.kt
@@ -2,7 +2,7 @@ package com.yral.shared.features.chat.domain.models
 
 private const val CHAT_TAB_UNREAD_BADGE_CAP = 99
 
-internal fun Conversation.countsTowardUnreadConversationBadge(): Boolean = unreadCount > 0 && conversationUser == null
+internal fun Conversation.countsTowardUnreadConversationBadge(): Boolean = unreadCount > 0
 
 internal fun Iterable<Conversation>.totalUnreadConversationBadgeCount(): Int =
     sumOf { conversation ->

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/UnreadConversationCount.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/UnreadConversationCount.kt
@@ -2,7 +2,7 @@ package com.yral.shared.features.chat.domain.models
 
 private const val CHAT_TAB_UNREAD_BADGE_CAP = 99
 
-internal fun Conversation.countsTowardUnreadConversationBadge(): Boolean = unreadCount > 0
+internal fun Conversation.countsTowardUnreadConversationBadge(): Boolean = unreadCount > 0 && !isHumanChat
 
 internal fun Iterable<Conversation>.totalUnreadConversationBadgeCount(): Int =
     sumOf { conversation ->

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/CreateHumanConversationUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/CreateHumanConversationUseCase.kt
@@ -1,0 +1,35 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.Conversation
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+/**
+ * Creates (or fetches the existing) 1:1 H2H conversation between the
+ * authenticated user and the other-user identified by [Params.participantPrincipalId].
+ *
+ * The repository / backend are idempotent — calling twice in quick
+ * succession with the same participant returns the same conversation,
+ * so the profile-screen "Send Message" tap handler doesn't need its
+ * own de-dup guard.
+ */
+class CreateHumanConversationUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<CreateHumanConversationUseCase.Params, Conversation>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: Params): Conversation =
+        chatRepository.createHumanConversation(participantId = parameter.participantPrincipalId)
+
+    data class Params(
+        val participantPrincipalId: String,
+    )
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/SendHumanMessageUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/SendHumanMessageUseCase.kt
@@ -1,0 +1,41 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.SendMessageDraft
+import com.yral.shared.features.chat.domain.models.SendMessageResult
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+/**
+ * H2H send. Mirrors [SendMessageUseCase] but routes through the
+ * `POST /api/v1/chat/human/conversations/{id}/messages` endpoint.
+ *
+ * The result shape ([SendMessageResult] with `assistantMessage = null`
+ * for H2H since the other side responds asynchronously via WebSocket
+ * inbox push, not in this response) is identical to the AI path so the
+ * call site that swaps the optimistic Local for the server-truth
+ * Remote stays the same.
+ */
+class SendHumanMessageUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<SendHumanMessageUseCase.Params, SendMessageResult>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: Params): SendMessageResult =
+        chatRepository.sendHumanMessage(
+            conversationId = parameter.conversationId,
+            draft = parameter.draft,
+        )
+
+    data class Params(
+        val conversationId: String,
+        val draft: SendMessageDraft,
+    )
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -510,6 +510,8 @@ fun ChatConversationScreen(
                             overlayItems = overlayItems,
                             historyPagingItems = historyPagingItems,
                             isBotAccount = viewState.isBotAccount,
+                            isHumanChat = viewState.isHumanChat,
+                            currentUserPrincipalId = viewState.currentUserPrincipalId,
                             renderSystemBanners = viewState.isChatAsHumanCreatorEnabled,
                             streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
                             assistantError = assistantError,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -118,6 +118,7 @@ fun ChatConversationScreen(
                 displayName = params.displayName,
                 userName = params.username,
                 avatarUrl = params.avatarUrl,
+                participantPrincipalId = params.participantPrincipalId,
             )
         } else {
             viewModel.initializeForChatWall(
@@ -294,7 +295,8 @@ fun ChatConversationScreen(
                 viewState.isSubscriptionEnabled &&
                 !hasChatAccess &&
                 atSubscriptionThreshold &&
-                viewState.isInfluencerSubscriptionAvailableToPurchase
+                viewState.isInfluencerSubscriptionAvailableToPurchase &&
+                !viewState.isHumanChat
         Logger.d("SubDebug") {
             "shouldShow=$result | waiting=$hasWaitingAssistant | signed=${viewState.isSocialSignedIn}" +
                 " | subEnabled=${viewState.isSubscriptionEnabled} | access=$hasChatAccess" +
@@ -310,7 +312,8 @@ fun ChatConversationScreen(
             viewState.isSubscriptionEnabled &&
             !hasChatAccess &&
             atSubscriptionThreshold &&
-            !viewState.isInfluencerSubscriptionAvailableToPurchase
+            !viewState.isInfluencerSubscriptionAvailableToPurchase &&
+            !viewState.isHumanChat
     }
 
     val subscriptionCardOverlayMessage =
@@ -479,6 +482,7 @@ fun ChatConversationScreen(
                 onSubscribeClick = {
                     purchaseContext?.let { viewModel.launchInfluencerSubscriptionPurchase(it) }
                 },
+                isHumanChat = viewState.isHumanChat,
             )
 
             Column(

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -105,6 +105,7 @@ fun ChatConversationScreen(
         params.influencerId,
         params.conversationId,
         params.userId,
+        params.participantPrincipalId,
         viewState.isSocialSignedIn,
     ) {
         val conversationId = params.conversationId

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationHeader.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationHeader.kt
@@ -60,6 +60,11 @@ internal fun ChatHeader(
     isSubscribed: Boolean = false,
     isSubscribeLoading: Boolean = false,
     onSubscribeClick: () -> Unit = {},
+    // H2H: hides the "Share Profile" and "Clear Chat" context menu items
+    // and the menu trigger itself if both items end up hidden. Share /
+    // delete-and-recreate both bind to influencer machinery that has no
+    // analogue for human-to-human conversations.
+    isHumanChat: Boolean = false,
 ) {
     Box(
         modifier =
@@ -91,6 +96,7 @@ internal fun ChatHeader(
                 isSubscribed = isSubscribed,
                 isSubscribeLoading = isSubscribeLoading,
                 onSubscribeClick = onSubscribeClick,
+                isHumanChat = isHumanChat,
             )
         }
     }
@@ -209,6 +215,7 @@ private fun RightPart(
     isSubscribed: Boolean = false,
     isSubscribeLoading: Boolean = false,
     onSubscribeClick: () -> Unit = {},
+    isHumanChat: Boolean = false,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -229,14 +236,21 @@ private fun RightPart(
         }
         val menuItems =
             buildList {
-                add(
-                    YralContextMenuItem(
-                        text = stringResource(Res.string.share_profile),
-                        icon = DesignRes.drawable.ic_share,
-                        onClick = onShareProfile,
-                    ),
-                )
-                if (!isBotAccount) {
+                // G5: Share Profile binds to viewModel.shareProfile() which
+                // shares the influencer's profile link. Nonsensical for H2H.
+                if (!isHumanChat) {
+                    add(
+                        YralContextMenuItem(
+                            text = stringResource(Res.string.share_profile),
+                            icon = DesignRes.drawable.ic_share,
+                            onClick = onShareProfile,
+                        ),
+                    )
+                }
+                // G4: Clear Chat calls deleteAndRecreateConversation(influencerId)
+                // which would pass the empty H2H influencerId. Gate alongside
+                // the existing bot-account guard.
+                if (!isBotAccount && !isHumanChat) {
                     add(
                         YralContextMenuItem(
                             text = stringResource(Res.string.clear_chat),
@@ -246,11 +260,15 @@ private fun RightPart(
                     )
                 }
             }
-        YralContextMenu(
-            items = menuItems,
-            triggerIcon = DesignRes.drawable.ic_more,
-            triggerSize = 24.dp,
-            menuIconSize = 20.dp,
-        )
+        // Hide the trigger entirely when no items remain (e.g. H2H).
+        // Otherwise the 3-dot icon would open an empty popup.
+        if (menuItems.isNotEmpty()) {
+            YralContextMenu(
+                items = menuItems,
+                triggerIcon = DesignRes.drawable.ic_more,
+                triggerSize = 24.dp,
+                menuIconSize = 20.dp,
+            )
+        }
     }
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import com.yral.shared.features.chat.domain.models.AssistantErrorPresentation
 import com.yral.shared.features.chat.domain.models.ConversationMessageRole
+import com.yral.shared.features.chat.domain.models.isFromCurrentUser
 import com.yral.shared.features.chat.viewmodel.ConversationMessageItem
 import com.yral.shared.features.chat.viewmodel.LocalMessageStatus
 
@@ -26,6 +27,8 @@ internal fun MessagesList(
     overlayItems: List<ConversationMessageItem>,
     historyPagingItems: LazyPagingItems<ConversationMessageItem>,
     isBotAccount: Boolean = false,
+    isHumanChat: Boolean = false,
+    currentUserPrincipalId: String? = null,
     renderSystemBanners: Boolean = false,
     streamMarkdownLockedRemoteIds: Map<String, Boolean> = emptyMap(),
     assistantError: AssistantErrorPresentation? = null,
@@ -65,6 +68,8 @@ internal fun MessagesList(
                 item = item,
                 isBotAccount = isBotAccount,
                 streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
+                isHumanChat = isHumanChat,
+                currentUserPrincipalId = currentUserPrincipalId,
                 onImageClick = onImageClick,
                 onRetry = onRetry,
             )
@@ -80,6 +85,8 @@ internal fun MessagesList(
                 item = item,
                 isBotAccount = isBotAccount,
                 streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
+                isHumanChat = isHumanChat,
+                currentUserPrincipalId = currentUserPrincipalId,
                 onImageClick = onImageClick,
                 onRetry = onRetry,
             )
@@ -104,6 +111,8 @@ private fun MessageRow(
     item: ConversationMessageItem,
     isBotAccount: Boolean,
     streamMarkdownLockedRemoteIds: Map<String, Boolean>,
+    isHumanChat: Boolean,
+    currentUserPrincipalId: String?,
     onImageClick: (imageUrl: String) -> Unit,
     onRetry: (localId: String) -> Unit,
 ) {
@@ -122,9 +131,21 @@ private fun MessageRow(
         return
     }
     val roleIsUser = role == ConversationMessageRole.USER
-    // For bot accounts, roles are flipped: USER messages come from the AI (shown on left),
-    // ASSISTANT messages come from the human customer (shown on right).
-    val isUser = if (isBotAccount) !roleIsUser else roleIsUser
+    // Bubble-side discriminator:
+    //   - Bot account (creator takeover): roles flipped — USER msgs come from
+    //     the AI (left), ASSISTANT msgs come from the human creator (right).
+    //   - H2H remote message: both peers send role='user' so role collapses
+    //     as a discriminator. Use sender_id == viewer_principal instead.
+    //   - H2H local optimistic add: always the viewer's own send → use
+    //     roleIsUser (which is true for role='user' as expected).
+    //   - AI: role-based — works because USER vs ASSISTANT are distinct.
+    val isUser =
+        when {
+            isBotAccount -> !roleIsUser
+            isHumanChat && item is ConversationMessageItem.Remote && currentUserPrincipalId != null ->
+                item.message.isFromCurrentUser(currentUserPrincipalId)
+            else -> roleIsUser
+        }
 
     // Extract render params from either Remote or Local OUTSIDE the Box so the
     // MessageContent call below has a single slot-table entry. The Local→Remote

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -118,11 +118,7 @@ private fun MessageRow(
 ) {
     val screenWidth = LocalWindowInfo.current.containerSize.width
     val maxWidth = with(LocalDensity.current) { (screenWidth * MESSAGE_MAX_WIDTH_RATIO).toDp() }
-    val role =
-        when (item) {
-            is ConversationMessageItem.Remote -> item.message.role
-            is ConversationMessageItem.Local -> item.message.role
-        }
+    val role = item.role()
     if (role == ConversationMessageRole.SYSTEM && item is ConversationMessageItem.Remote) {
         SystemBannerMessage(
             text = item.message.content.orEmpty(),
@@ -130,7 +126,6 @@ private fun MessageRow(
         )
         return
     }
-    val roleIsUser = role == ConversationMessageRole.USER
     // Bubble-side discriminator:
     //   - Bot account (creator takeover): roles flipped — USER msgs come from
     //     the AI (left), ASSISTANT msgs come from the human creator (right).
@@ -140,12 +135,11 @@ private fun MessageRow(
     //     roleIsUser (which is true for role='user' as expected).
     //   - AI: role-based — works because USER vs ASSISTANT are distinct.
     val isUser =
-        when {
-            isBotAccount -> !roleIsUser
-            isHumanChat && item is ConversationMessageItem.Remote && currentUserPrincipalId != null ->
-                item.message.isFromCurrentUser(currentUserPrincipalId)
-            else -> roleIsUser
-        }
+        item.isCurrentUserMessage(
+            isBotAccount = isBotAccount,
+            isHumanChat = isHumanChat,
+            currentUserPrincipalId = currentUserPrincipalId,
+        )
 
     // Extract render params from either Remote or Local OUTSIDE the Box so the
     // MessageContent call below has a single slot-table entry. The Local→Remote
@@ -218,4 +212,37 @@ private fun MessageRow(
             onRetry = renderOnRetry,
         )
     }
+}
+
+private fun ConversationMessageItem.role(): ConversationMessageRole =
+    when (this) {
+        is ConversationMessageItem.Remote -> {
+            message.role
+        }
+
+        is ConversationMessageItem.Local -> {
+            message.role
+        }
+    }
+
+private fun ConversationMessageItem.isCurrentUserMessage(
+    isBotAccount: Boolean,
+    isHumanChat: Boolean,
+    currentUserPrincipalId: String?,
+): Boolean {
+    val roleIsUser =
+        when (this) {
+            is ConversationMessageItem.Remote -> {
+                if (isHumanChat && currentUserPrincipalId != null) {
+                    message.isFromCurrentUser(currentUserPrincipalId)
+                } else {
+                    message.role == ConversationMessageRole.USER
+                }
+            }
+
+            is ConversationMessageItem.Local -> {
+                message.role == ConversationMessageRole.USER
+            }
+        }
+    return if (isBotAccount) !roleIsUser else roleIsUser
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationSubscribeButtonUiState.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationSubscribeButtonUiState.kt
@@ -14,6 +14,7 @@ internal fun ConversationViewState.headerSubscribeButtonUiState(): ConversationS
             isSocialSignedIn &&
                 isSubscriptionEnabled &&
                 !isBotAccount &&
+                !isHumanChat &&
                 (
                     isChatAccessLoading ||
                         isInfluencerSubscriptionPurchasedAndVerified ||

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/ConversationListItem.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/ConversationListItem.kt
@@ -46,13 +46,13 @@ fun ConversationListItem(
 ) {
     val avatarUrl =
         conversation.conversationUser?.profilePictureUrl?.takeIf { it.isNotBlank() }
-            ?: conversation.influencer.avatarUrl
+            ?: conversation.influencer?.avatarUrl.orEmpty()
     val displayName =
         conversation.conversationUser?.let { user ->
             user.username?.takeIf { it.isNotBlank() }
                 ?: resolveUsername("", user.principalId)
                 ?: ""
-        } ?: conversation.influencer.displayName.ifBlank { conversation.influencer.name }
+        } ?: conversation.influencer?.let { it.displayName.ifBlank { it.name } }.orEmpty()
     Row(
         modifier =
             modifier

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/InboxScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/InboxScreen.kt
@@ -154,8 +154,15 @@ private fun InboxContentWithPullToRefresh(
             onConversationClick = { conversation ->
                 component.openConversation(
                     OpenConversationParams(
-                        influencerId = conversation.influencer.id,
-                        influencerCategory = conversation.influencer.category,
+                        // H2H conversations have no influencer; we pass empty
+                        // placeholders here so OpenConversationParams' existing
+                        // non-null fields parse. The chat-screen + VM
+                        // disambiguate H2H vs AI via Conversation.conversationType
+                        // once loaded. A proper `participantPrincipalId` field
+                        // on OpenConversationParams lands with the profile-button
+                        // commit (plan §6.2).
+                        influencerId = conversation.influencer?.id.orEmpty(),
+                        influencerCategory = conversation.influencer?.category.orEmpty(),
                         conversationId = conversation.id,
                         userId = conversation.userId,
                         username = conversation.conversationUser?.username,
@@ -164,10 +171,10 @@ private fun InboxContentWithPullToRefresh(
                                 user.username?.takeIf { it.isNotBlank() }
                                     ?: resolveUsername("", user.principalId)
                                     ?: ""
-                            } ?: conversation.influencer.displayName.ifBlank { conversation.influencer.name },
+                            } ?: conversation.influencer?.let { it.displayName.ifBlank { it.name } }.orEmpty(),
                         avatarUrl =
                             conversation.conversationUser?.profilePictureUrl?.takeIf { it.isNotBlank() }
-                                ?: conversation.influencer.avatarUrl,
+                                ?: conversation.influencer?.avatarUrl.orEmpty(),
                     ),
                 )
             },

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/InboxScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/inbox/InboxScreen.kt
@@ -156,15 +156,13 @@ private fun InboxContentWithPullToRefresh(
                     OpenConversationParams(
                         // H2H conversations have no influencer; we pass empty
                         // placeholders here so OpenConversationParams' existing
-                        // non-null fields parse. The chat-screen + VM
-                        // disambiguate H2H vs AI via Conversation.conversationType
-                        // once loaded. A proper `participantPrincipalId` field
-                        // on OpenConversationParams lands with the profile-button
-                        // commit (plan §6.2).
+                        // non-null fields parse. participantPrincipalId is the
+                        // canonical H2H discriminator the chat screen reads.
                         influencerId = conversation.influencer?.id.orEmpty(),
                         influencerCategory = conversation.influencer?.category.orEmpty(),
                         conversationId = conversation.id,
                         userId = conversation.userId,
+                        participantPrincipalId = conversation.conversationUser?.principalId,
                         username = conversation.conversationUser?.username,
                         displayName =
                             conversation.conversationUser?.let { user ->

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -48,6 +48,7 @@ import com.yral.shared.features.chat.domain.usecases.GrantChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.MarkConversationAsReadUseCase
 import com.yral.shared.features.chat.domain.usecases.ReleaseHumanCreatorTakeoverUseCase
 import com.yral.shared.features.chat.domain.usecases.SendHumanCreatorMessageUseCase
+import com.yral.shared.features.chat.domain.usecases.SendHumanMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.SendMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.StartHumanCreatorTakeoverUseCase
 import com.yral.shared.features.chat.ui.conversation.shouldRenderAsMarkdown
@@ -113,7 +114,7 @@ class ConversationViewModel(
     private val chatRepository: ChatRepository,
     private val useCaseFailureListener: UseCaseFailureListener,
     private val sendMessageUseCase: SendMessageUseCase,
-    private val sendHumanMessageUseCase: com.yral.shared.features.chat.domain.usecases.SendHumanMessageUseCase,
+    private val sendHumanMessageUseCase: SendHumanMessageUseCase,
     private val createConversationUseCase: CreateConversationUseCase,
     private val deleteConversationUseCase: DeleteConversationUseCase,
     private val markConversationAsReadUseCase: MarkConversationAsReadUseCase,
@@ -1264,13 +1265,59 @@ class ConversationViewModel(
         }
     }
 
+    private fun sendHumanChatMessage(
+        conversationId: String,
+        draft: SendMessageDraft,
+        userLocal: LocalMessage,
+        userLocalId: String,
+        assistantLocalId: String,
+        sentAtMs: Long,
+    ) {
+        _overlay.update { it.copy(pending = it.pending + userLocal) }
+        viewModelScope.launch {
+            sendHumanMessageUseCase(
+                SendHumanMessageUseCase.Params(
+                    conversationId = conversationId,
+                    draft = draft,
+                ),
+            ).onSuccess { result ->
+                handleSendSuccess(result, userLocalId, assistantLocalId, sentAtMs)
+            }.onFailure { error ->
+                handleSendFailure(error, userLocalId, assistantLocalId)
+            }
+        }
+    }
+
+    private fun sendLegacyMessageWithPlaceholder(
+        conversationId: String,
+        draft: SendMessageDraft,
+        userLocal: LocalMessage,
+        userLocalId: String,
+        assistantLocalId: String,
+        timestampMs: Long,
+    ) {
+        val assistantPlaceholder = createAssistantPlaceholder(timestampMs)
+        _overlay.update { it.copy(pending = it.pending + userLocal + assistantPlaceholder) }
+        activeReplyCount.update { it + 1 }
+        viewModelScope.launch {
+            try {
+                sendMessageLegacy(
+                    conversationId = conversationId,
+                    draft = draft,
+                    userLocalId = userLocalId,
+                    assistantLocalId = assistantLocalId,
+                    sentAtMs = timestampMs,
+                )
+            } finally {
+                activeReplyCount.update { it - 1 }
+            }
+        }
+    }
+
     @OptIn(ExperimentalTime::class)
     fun sendMessage(draft: SendMessageDraft) {
         val convId = conversationId ?: return
 
-        // Phase 6: a fresh send supersedes any error from the previous send.
-        // Clear before any new state lands so the user sees their new message
-        // and the streaming placeholder, not a stale error bubble.
         _assistantError.value = null
 
         val now = Clock.System.now().toEpochMilliseconds()
@@ -1304,21 +1351,14 @@ class ConversationViewModel(
         }
 
         if (_viewState.value.isHumanChat) {
-            _overlay.update { it.copy(pending = it.pending + userLocal) }
-            viewModelScope.launch {
-                sendHumanMessageUseCase(
-                    com.yral.shared.features.chat.domain.usecases
-                        .SendHumanMessageUseCase
-                        .Params(
-                            conversationId = convId,
-                            draft = draft,
-                        ),
-                ).onSuccess { result ->
-                    handleSendSuccess(result, localUserId, localAssistantId, now)
-                }.onFailure { error ->
-                    handleSendFailure(error, localUserId, localAssistantId)
-                }
-            }
+            sendHumanChatMessage(
+                conversationId = convId,
+                draft = draft,
+                userLocal = userLocal,
+                userLocalId = localUserId,
+                assistantLocalId = localAssistantId,
+                sentAtMs = now,
+            )
         } else if (shouldStream(draft)) {
             // Phase 7 (revised): when there is NO active stream we add the user
             // Local AND the streaming placeholder in a single _overlay.update so
@@ -1357,25 +1397,14 @@ class ConversationViewModel(
                     )
             }
         } else {
-            val assistantPlaceholder = createAssistantPlaceholder(now)
-            _overlay.update { it.copy(pending = it.pending + userLocal + assistantPlaceholder) }
-            // Phase 7-final: synchronous increment so the send button greys on
-            // the SAME frame the legacy send is dispatched, matching production
-            // chat-ai behavior.
-            activeReplyCount.update { it + 1 }
-            viewModelScope.launch {
-                try {
-                    sendMessageLegacy(
-                        conversationId = convId,
-                        draft = draft,
-                        userLocalId = localUserId,
-                        assistantLocalId = localAssistantId,
-                        sentAtMs = now,
-                    )
-                } finally {
-                    activeReplyCount.update { it - 1 }
-                }
-            }
+            sendLegacyMessageWithPlaceholder(
+                conversationId = convId,
+                draft = draft,
+                userLocal = userLocal,
+                userLocalId = localUserId,
+                assistantLocalId = localAssistantId,
+                timestampMs = now,
+            )
         }
     }
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -113,6 +113,7 @@ class ConversationViewModel(
     private val chatRepository: ChatRepository,
     private val useCaseFailureListener: UseCaseFailureListener,
     private val sendMessageUseCase: SendMessageUseCase,
+    private val sendHumanMessageUseCase: com.yral.shared.features.chat.domain.usecases.SendHumanMessageUseCase,
     private val createConversationUseCase: CreateConversationUseCase,
     private val deleteConversationUseCase: DeleteConversationUseCase,
     private val markConversationAsReadUseCase: MarkConversationAsReadUseCase,
@@ -883,9 +884,20 @@ class ConversationViewModel(
         displayName: String? = null,
         userName: String? = null,
         avatarUrl: String? = null,
+        // H2H: the other-user's principal_id when this conversation came
+        // from the profile-screen Send Message tap. Null for AI chats.
+        // When non-null we also skip the IAP/access-check cascade since
+        // H2H has no subscription product.
+        participantPrincipalId: String? = null,
     ) {
         val isBotAccount = sessionManager.isBotAccount == true
-        _viewState.update { it.copy(influencerSource = influencerSource, isBotAccount = isBotAccount) }
+        _viewState.update {
+            it.copy(
+                influencerSource = influencerSource,
+                isBotAccount = isBotAccount,
+                participantPrincipalId = participantPrincipalId,
+            )
+        }
         val currentConversationId = _viewState.value.conversationId
         if (currentConversationId == conversationId) return
         if (_viewState.value.conversationId != null && _viewState.value.conversationId != conversationId) {
@@ -904,7 +916,14 @@ class ConversationViewModel(
             recentMessages = emptyList(),
             messageCount = PAGE_SIZE + 1,
         )
-        updateInfluencerSubscriptionProductState(influencerId)
+        // N1 gate: single call-site for the entire IAP cascade
+        // (checkChatAccessUseCase → retryUnconsumedDailyChatAccess →
+        // fetchInfluencerSubscriptionProducts). All four fallback entry
+        // points reach back through updateInfluencerSubscriptionProductState
+        // so this one skip covers them all.
+        if (participantPrincipalId == null) {
+            updateInfluencerSubscriptionProductState(influencerId)
+        }
     }
 
     fun initializeForChatWall(
@@ -1264,7 +1283,23 @@ class ConversationViewModel(
             )
         }
 
-        if (shouldStream(draft)) {
+        if (_viewState.value.isHumanChat) {
+            _overlay.update { it.copy(pending = it.pending + userLocal) }
+            viewModelScope.launch {
+                sendHumanMessageUseCase(
+                    com.yral.shared.features.chat.domain.usecases
+                        .SendHumanMessageUseCase
+                        .Params(
+                            conversationId = convId,
+                            draft = draft,
+                        ),
+                ).onSuccess { result ->
+                    handleSendSuccess(result, localUserId, localAssistantId, now)
+                }.onFailure { error ->
+                    handleSendFailure(error, localUserId, localAssistantId)
+                }
+            }
+        } else if (shouldStream(draft)) {
             // Phase 7 (revised): when there is NO active stream we add the user
             // Local AND the streaming placeholder in a single _overlay.update so
             // Compose never composes an intermediate state where only the user
@@ -2200,7 +2235,15 @@ data class ConversationViewState(
     val isHumanCreatorTakeoverEnding: Boolean = false,
     val isHumanCreatorMessageSending: Boolean = false,
     val humanCreatorTakeoverRemainingSeconds: Int = 0,
-)
+    // H2H: present when this conversation is human-to-human (set by
+    // initializeFromInbox when the navigation params carry the other
+    // user's principal_id). [isHumanChat] is the derived single-source-of-
+    // truth gate that all H2H-vs-AI branches in this module read from.
+    val participantPrincipalId: String? = null,
+) {
+    val isHumanChat: Boolean
+        get() = participantPrincipalId != null
+}
 
 sealed class ConversationMessageItem {
     data class Remote(

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -891,15 +891,22 @@ class ConversationViewModel(
         participantPrincipalId: String? = null,
     ) {
         val isBotAccount = sessionManager.isBotAccount == true
+        val viewerPrincipal = sessionManager.userPrincipal
         _viewState.update {
             it.copy(
                 influencerSource = influencerSource,
                 isBotAccount = isBotAccount,
-                participantPrincipalId = participantPrincipalId,
+                currentUserPrincipalId = viewerPrincipal,
             )
         }
         val currentConversationId = _viewState.value.conversationId
-        if (currentConversationId == conversationId) return
+        if (currentConversationId == conversationId) {
+            // Same conversation reopened — participantPrincipalId may need a
+            // refresh (e.g. nav-stack carrying a different value), so update
+            // it without resetting anything else.
+            _viewState.update { it.copy(participantPrincipalId = participantPrincipalId) }
+            return
+        }
         if (_viewState.value.conversationId != null && _viewState.value.conversationId != conversationId) {
             resetState()
         }
@@ -916,6 +923,12 @@ class ConversationViewModel(
             recentMessages = emptyList(),
             messageCount = PAGE_SIZE + 1,
         )
+        // Apply participantPrincipalId AFTER resetState/setConversationId so
+        // resetState's fresh ConversationViewState doesn't blow the H2H
+        // discriminator away. Pre-reset assignment was silently dropped on
+        // every conversation switch, manifesting as Subscribe + 3-dot menu
+        // appearing on H2H chats opened after browsing any other chat first.
+        _viewState.update { it.copy(participantPrincipalId = participantPrincipalId) }
         // N1 gate: single call-site for the entire IAP cascade
         // (checkChatAccessUseCase → retryUnconsumedDailyChatAccess →
         // fetchInfluencerSubscriptionProducts). All four fallback entry
@@ -935,7 +948,14 @@ class ConversationViewModel(
         avatarUrl: String? = null,
     ) {
         val isBotAccount = sessionManager.isBotAccount == true
-        _viewState.update { it.copy(influencerSource = influencerSource, isBotAccount = isBotAccount) }
+        val viewerPrincipal = sessionManager.userPrincipal
+        _viewState.update {
+            it.copy(
+                influencerSource = influencerSource,
+                isBotAccount = isBotAccount,
+                currentUserPrincipalId = viewerPrincipal,
+            )
+        }
         val currentInfluencerId = _viewState.value.influencer?.id
         val currentConversationId = _viewState.value.conversationId
         // same influencer and conversation exists
@@ -2240,6 +2260,11 @@ data class ConversationViewState(
     // user's principal_id). [isHumanChat] is the derived single-source-of-
     // truth gate that all H2H-vs-AI branches in this module read from.
     val participantPrincipalId: String? = null,
+    // H2H: viewer's own principal_id. Plumbed into the message renderer
+    // so bubble side (left vs right) can be decided by sender_id ==
+    // viewer comparison for H2H, where role='user' on both peers and
+    // the role-based discriminator collapses.
+    val currentUserPrincipalId: String? = null,
 ) {
     val isHumanChat: Boolean
         get() = participantPrincipalId != null

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/InboxViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/InboxViewModel.kt
@@ -6,10 +6,14 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import androidx.paging.filter
+import com.yral.featureflag.ChatFeatureFlags
+import com.yral.featureflag.FeatureFlagManager
 import com.yral.shared.core.session.SessionManager
 import com.yral.shared.features.chat.domain.ChatRepository
 import com.yral.shared.features.chat.domain.ConversationsPagingSource
 import com.yral.shared.features.chat.domain.models.Conversation
+import com.yral.shared.features.chat.domain.models.isHumanChat
 import com.yral.shared.libs.arch.domain.UseCaseFailureListener
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -30,9 +35,11 @@ class InboxViewModel(
     private val sessionManager: SessionManager,
     private val useCaseFailureListener: UseCaseFailureListener,
     private val chatUnreadRefreshSignal: ChatUnreadRefreshSignal,
+    flagManager: FeatureFlagManager,
 ) : ViewModel() {
     private val refreshTrigger = MutableStateFlow(0)
     private val mutableUnreadConversationCount = MutableStateFlow(0)
+    private val isH2hChatEnabled = flagManager.get(ChatFeatureFlags.Chat.H2hChatEnabled)
 
     private val pagingConfig =
         PagingConfig(
@@ -68,7 +75,13 @@ class InboxViewModel(
                             principal = principal,
                         )
                     },
-                ).flow
+                ).flow.map { pagingData ->
+                    if (isH2hChatEnabled) {
+                        pagingData
+                    } else {
+                        pagingData.filter { conversation -> !conversation.isHumanChat }
+                    }
+                }
             }.cachedIn(viewModelScope)
 
     fun refreshConversations() {

--- a/shared/features/chat/src/commonTest/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImplUnreadCountTest.kt
+++ b/shared/features/chat/src/commonTest/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImplUnreadCountTest.kt
@@ -16,7 +16,10 @@ import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageResponseDto
 import com.yral.shared.features.chat.data.models.StartHumanCreatorTakeoverResponseDto
 import com.yral.shared.features.chat.data.models.UploadResponseDto
+import com.yral.shared.preferences.Preferences
+import io.ktor.client.HttpClient
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -55,7 +58,11 @@ class ChatRepositoryImplUnreadCountTest {
                         ),
                 )
 
-            val repository = ChatRepositoryImpl(dataSource = dataSource)
+            val repository =
+                ChatRepositoryImpl(
+                    dataSource = dataSource,
+                    streamingDataSource = createUnusedStreamingDataSource(),
+                )
 
             val unreadCount = repository.getUnreadConversationCount(principal = "principal-1")
 
@@ -99,6 +106,69 @@ class ChatRepositoryImplUnreadCountTest {
             unreadCount = unreadCount,
         )
 
+    private fun createUnusedStreamingDataSource(): ChatStreamingDataSource =
+        ChatStreamingDataSource(
+            httpClient = HttpClient(),
+            json = Json,
+            preferences = DummyPreferences,
+            chatBaseUrl = "example.com",
+        )
+
+    private object DummyPreferences : Preferences {
+        override suspend fun putBoolean(
+            key: String,
+            boolean: Boolean,
+        ) = error("unused")
+
+        override suspend fun getBoolean(key: String): Boolean? = error("unused")
+
+        override suspend fun putString(
+            key: String,
+            value: String,
+        ) = error("unused")
+
+        override suspend fun getString(key: String): String? = error("unused")
+
+        override suspend fun putInt(
+            key: String,
+            int: Int,
+        ) = error("unused")
+
+        override suspend fun getInt(key: String): Int? = error("unused")
+
+        override suspend fun putLong(
+            key: String,
+            long: Long,
+        ) = error("unused")
+
+        override suspend fun getLong(key: String): Long? = error("unused")
+
+        override suspend fun putFloat(
+            key: String,
+            float: Float,
+        ) = error("unused")
+
+        override suspend fun getFloat(key: String): Float? = error("unused")
+
+        override suspend fun putDouble(
+            key: String,
+            double: Double,
+        ) = error("unused")
+
+        override suspend fun getDouble(key: String): Double? = error("unused")
+
+        override suspend fun putBytes(
+            key: String,
+            bytes: ByteArray,
+        ) = error("unused")
+
+        override suspend fun getBytes(key: String): ByteArray? = error("unused")
+
+        override suspend fun remove(key: String) = error("unused")
+
+        override suspend fun clearAll() = error("unused")
+    }
+
     private class FakeChatDataSource(
         private val pages: List<ConversationsResponseDto>,
     ) : ChatDataSource {
@@ -128,6 +198,8 @@ class ChatRepositoryImplUnreadCountTest {
 
         override suspend fun createConversation(influencerId: String): ConversationDto = error("unused")
 
+        override suspend fun createHumanConversation(participantId: String): ConversationDto = error("unused")
+
         override suspend fun deleteConversation(conversationId: String): DeleteConversationResponseDto = error("unused")
 
         override suspend fun listConversationMessages(
@@ -138,6 +210,11 @@ class ChatRepositoryImplUnreadCountTest {
         ) = error("unused")
 
         override suspend fun sendMessageJson(
+            conversationId: String,
+            request: SendMessageRequestDto,
+        ): SendMessageResponseDto = error("unused")
+
+        override suspend fun sendHumanMessage(
             conversationId: String,
             request: SendMessageRequestDto,
         ): SendMessageResponseDto = error("unused")

--- a/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/di/ProfileModule.kt
+++ b/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/di/ProfileModule.kt
@@ -52,6 +52,7 @@ val profileModule =
                 fileDownloader = get(),
                 followersMetadataDataSource = get(),
                 checkChatAccessUseCase = get(),
+                createHumanConversationUseCase = get(),
                 publishDraftVideoUseCase = get(),
             )
         }

--- a/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/ui/ProfileMainScreen.kt
+++ b/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/ui/ProfileMainScreen.kt
@@ -303,14 +303,20 @@ fun ProfileMainScreen(
                 is ProfileEvents.HumanConversationCreated -> {
                     // H2H: empty `influencerId` is the convention for human
                     // conversations until OpenConversationParams gets a
-                    // proper conversationKind discriminator. The chat
-                    // screen + VM derive H2H mode from the loaded
-                    // Conversation.conversationType ("human_chat"); this
-                    // record only carries the routing hints.
+                    // proper conversationKind discriminator. Passing
+                    // `userId = event.participantPrincipalId` is what makes
+                    // ChatConversationScreen's LaunchedEffect take the
+                    // initializeFromInbox branch (which uses the existing
+                    // conversationId) instead of initializeForChatWall
+                    // (which would POST a new AI conversation with the
+                    // empty influencerId — the "Having a little trouble
+                    // loading" repro). The chat-screen VM further reads
+                    // viewState.isHumanChat to gate AI affordances.
                     component.openConversation(
                         OpenConversationParams(
                             influencerId = "",
                             conversationId = event.conversationId,
+                            userId = event.participantPrincipalId,
                             participantPrincipalId = event.participantPrincipalId,
                             displayName = event.displayName,
                             username = event.username,

--- a/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/ui/ProfileMainScreen.kt
+++ b/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/ui/ProfileMainScreen.kt
@@ -300,6 +300,26 @@ fun ProfileMainScreen(
                     )
                 }
 
+                is ProfileEvents.HumanConversationCreated -> {
+                    // H2H: empty `influencerId` is the convention for human
+                    // conversations until OpenConversationParams gets a
+                    // proper conversationKind discriminator. The chat
+                    // screen + VM derive H2H mode from the loaded
+                    // Conversation.conversationType ("human_chat"); this
+                    // record only carries the routing hints.
+                    component.openConversation(
+                        OpenConversationParams(
+                            influencerId = "",
+                            conversationId = event.conversationId,
+                            participantPrincipalId = event.participantPrincipalId,
+                            displayName = event.displayName,
+                            username = event.username,
+                            avatarUrl = event.avatarUrl,
+                            influencerSource = ConversationInfluencerSource.PROFILE,
+                        ),
+                    )
+                }
+
                 is ProfileEvents.SubscribeInfluencerDetailsFetched -> {
                     component.openConversation(
                         OpenConversationParams(
@@ -793,6 +813,16 @@ private fun MainContent(
                 onTalkToMeClicked = viewModel::fetchInfluencerDetails,
                 showSubscribe = false,
                 onSubscribeClicked = {},
+                // H2H: button shown only on another user's NON-AI profile
+                // when the H2hChatEnabled flag is on. Own-profile, AI
+                // influencer profiles, and logged-out users never see it.
+                showSendMessage =
+                    !state.isOwnProfile &&
+                        state.isLoggedIn &&
+                        state.isH2hChatEnabled &&
+                        !state.isAiInfluencer,
+                isSendMessageInProgress = state.isCreatingHumanConversation,
+                onSendMessageClicked = { viewModel.onSendMessageClicked() },
                 isProUser = state.isProUser,
                 showCreateInfluencerCta = state.isOwnProfile && state.isLoggedIn && showCreateBotCta,
                 onCreateInfluencerClick = onCreateInfluencerClick,

--- a/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/viewmodel/ProfileViewModel.kt
+++ b/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/viewmodel/ProfileViewModel.kt
@@ -37,6 +37,8 @@ import com.yral.shared.data.domain.models.VideoViews
 import com.yral.shared.data.domain.useCases.GetVideoViewsUseCase
 import com.yral.shared.features.chat.analytics.ChatTelemetry
 import com.yral.shared.features.chat.domain.models.Influencer
+import com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase
+import com.yral.shared.features.chat.domain.usecases.CreateHumanConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.GetInfluencerUseCase
 import com.yral.shared.features.profile.analytics.ProfileTelemetry
 import com.yral.shared.features.profile.domain.DeleteVideoUseCase
@@ -123,8 +125,8 @@ class ProfileViewModel(
     private val getInfluencerUseCase: GetInfluencerUseCase,
     private val fileDownloader: FileDownloader,
     private val followersMetadataDataSource: FollowersMetadataDataSource,
-    private val checkChatAccessUseCase: com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase,
-    private val createHumanConversationUseCase: com.yral.shared.features.chat.domain.usecases.CreateHumanConversationUseCase,
+    private val checkChatAccessUseCase: CheckChatAccessUseCase,
+    private val createHumanConversationUseCase: CreateHumanConversationUseCase,
     private val publishDraftVideoUseCase: PublishDraftVideoUseCase,
 ) : ViewModel() {
     companion object {
@@ -1408,6 +1410,7 @@ sealed class ProfileEvents {
         val message: String,
     ) : ProfileEvents()
     data object RefreshDrafts : ProfileEvents()
+
     /**
      * H2H: a `Send Message` tap successfully created (or fetched the
      * existing) human conversation. The screen observes this and routes

--- a/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/viewmodel/ProfileViewModel.kt
+++ b/shared/features/profile/src/commonMain/kotlin/com/yral/shared/features/profile/viewmodel/ProfileViewModel.kt
@@ -124,6 +124,7 @@ class ProfileViewModel(
     private val fileDownloader: FileDownloader,
     private val followersMetadataDataSource: FollowersMetadataDataSource,
     private val checkChatAccessUseCase: com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase,
+    private val createHumanConversationUseCase: com.yral.shared.features.chat.domain.usecases.CreateHumanConversationUseCase,
     private val publishDraftVideoUseCase: PublishDraftVideoUseCase,
 ) : ViewModel() {
     companion object {
@@ -140,6 +141,7 @@ class ProfileViewModel(
                 isSubscriptionEnabled = flagManager.isEnabled(AppFeatureFlags.Common.EnableSubscription),
                 maxBotCountForCta = flagManager.get(ChatFeatureFlags.Chat.MaxBotCountForCta),
                 maxVisibleBotUsernames = flagManager.get(ChatFeatureFlags.Chat.MaxVisibleBotUsernames),
+                isH2hChatEnabled = flagManager.get(ChatFeatureFlags.Chat.H2hChatEnabled),
             ),
         )
     val state: StateFlow<ViewState> = _state.asStateFlow()
@@ -633,6 +635,54 @@ class ProfileViewModel(
                     }
             } finally {
                 _state.update { it.copy(isTalkToMeInProgress = false) }
+            }
+        }
+    }
+
+    /**
+     * H2H: tap-handler for the Send Message button on another user's
+     * profile. Creates (or fetches) the 1:1 H2H conversation with the
+     * profile owner and emits [ProfileEvents.HumanConversationCreated]
+     * so the screen can route into the chat screen.
+     *
+     * Guards: own-profile and blank-principal cases no-op. The button
+     * itself is hidden in both states so this is a defensive belt-and-
+     * suspenders check.
+     */
+    fun onSendMessageClicked() {
+        val participantPrincipalId = canisterData.userPrincipalId
+        if (participantPrincipalId.isBlank() || _state.value.isOwnProfile) return
+        val accountInfo = _state.value.accountInfo
+        viewModelScope.launch {
+            _state.update { it.copy(isCreatingHumanConversation = true) }
+            try {
+                createHumanConversationUseCase(
+                    com.yral.shared.features.chat.domain.usecases
+                        .CreateHumanConversationUseCase
+                        .Params(participantPrincipalId = participantPrincipalId),
+                ).onSuccess { conversation ->
+                    profileEventsChannel.trySend(
+                        ProfileEvents.HumanConversationCreated(
+                            conversationId = conversation.id,
+                            participantPrincipalId = participantPrincipalId,
+                            displayName =
+                                accountInfo?.displayName?.takeIf { it.isNotBlank() }
+                                    ?: conversation.conversationUser?.username.orEmpty(),
+                            username = accountInfo?.username ?: conversation.conversationUser?.username,
+                            avatarUrl =
+                                accountInfo?.profilePic?.takeIf { it.isNotBlank() }
+                                    ?: conversation.conversationUser?.profilePictureUrl,
+                        ),
+                    )
+                }.onFailure { error ->
+                    Logger.e("onSendMessageClicked") { "Failed to create H2H conversation: $error" }
+                    val message =
+                        error.message
+                            ?: getString(DesignRes.string.something_went_wrong)
+                    profileEventsChannel.trySend(ProfileEvents.Failed(message))
+                }
+            } finally {
+                _state.update { it.copy(isCreatingHumanConversation = false) }
             }
         }
     }
@@ -1287,6 +1337,8 @@ data class ViewState(
     val isSubscribedToInfluencer: Boolean = false,
     val isInfluencerSubscriptionStateLoading: Boolean = false,
     val isTalkToMeInProgress: Boolean = false,
+    val isH2hChatEnabled: Boolean = false,
+    val isCreatingHumanConversation: Boolean = false,
     val isProUser: Boolean = false,
     val isSubscriptionEnabled: Boolean = false,
     val isYralProAvailable: Boolean = false,
@@ -1356,6 +1408,18 @@ sealed class ProfileEvents {
         val message: String,
     ) : ProfileEvents()
     data object RefreshDrafts : ProfileEvents()
+    /**
+     * H2H: a `Send Message` tap successfully created (or fetched the
+     * existing) human conversation. The screen observes this and routes
+     * to the chat screen with all the params it needs.
+     */
+    data class HumanConversationCreated(
+        val conversationId: String,
+        val participantPrincipalId: String,
+        val displayName: String,
+        val username: String?,
+        val avatarUrl: String?,
+    ) : ProfileEvents()
 }
 
 data class PagingState(

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/features/AccountInfoView.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/features/AccountInfoView.kt
@@ -86,6 +86,9 @@ fun AccountInfoView(
     onTalkToMeClicked: () -> Unit = {},
     showSubscribe: Boolean = false,
     onSubscribeClicked: () -> Unit = {},
+    showSendMessage: Boolean = false,
+    isSendMessageInProgress: Boolean = false,
+    onSendMessageClicked: () -> Unit = {},
     isProUser: Boolean = false,
     showCreateInfluencerCta: Boolean = false,
     onCreateInfluencerClick: () -> Unit = {},
@@ -296,6 +299,31 @@ fun AccountInfoView(
                         SubscribeButton(
                             modifier = Modifier.weight(1f),
                             onClick = onSubscribeClicked,
+                        )
+                    }
+                    if (showSendMessage) {
+                        val sendMessageButtonState =
+                            if (isSendMessageInProgress) {
+                                YralButtonState.Loading
+                            } else {
+                                YralButtonState.Enabled
+                            }
+                        YralButton(
+                            modifier = Modifier.weight(1f),
+                            text = if (isSendMessageInProgress) "" else "Send Message",
+                            borderColor = YralColors.Neutral700,
+                            borderWidth = 1.dp,
+                            backgroundColor = YralColors.Neutral800,
+                            textStyle =
+                                LocalAppTopography
+                                    .current
+                                    .baseSemiBold
+                                    .copy(
+                                        color = YralColors.Grey50,
+                                    ),
+                            onClick = onSendMessageClicked,
+                            buttonState = sendMessageButtonState,
+                            buttonHeight = 40.dp,
                         )
                     }
                     if (isAiInfluencer) {

--- a/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
+++ b/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
@@ -64,5 +64,16 @@ object ChatFeatureFlags {
                 // until backend cutover + GA.
                 defaultValue = false,
             )
+        val H2hChatEnabled: FeatureFlag<Boolean> =
+            boolean(
+                keySuffix = "h2hChatEnabled",
+                name = "Human-to-Human chat",
+                description = "When ON, exposes the Send Message button on other-user profile screens and " +
+                    "lets users open 1:1 H2H conversations via POST /api/v1/chat/human/conversations. When " +
+                    "OFF, the button is hidden and any H2H conversations already in the user's inbox are " +
+                    "filtered out at render time so the feature is fully dormant. PR keeps defaultValue = " +
+                    "false until backend cutover + GA.",
+                defaultValue = false,
+            )
     }
 }


### PR DESCRIPTION
## Summary

Adds **Human-to-Human (H2H) direct messaging** to the chat surface — a peer-to-peer 1:1 chat alongside the existing AI influencer chats, accessed via a new **Send Message** button on other users' profiles. The feature ships **dormant behind `H2hChatEnabled` (defaultValue = `false`)** and only activates once: (a) the backend is cut over from `chat-ai.rishi.yral.com` to the new `agent.rishi.yral.com` service, and (b) `H2hChatEnabled` is flipped on via Firebase Remote Config. Same gate model as `SseStreamingEnabled` and `ChatAsHumanCreatorEnabled` — no production behavior change until both gates are set.

## What this PR adds

- **Feature flag**: `chat_h2hChatEnabled` boolean in `ChatFeatureFlags`, defaulted to `false`. When OFF, the Send Message button is hidden, and any H2H rows already in the user's inbox are filtered out at render time so the feature is fully dormant.
- **Profile entry point**: `Send Message` button on other-user profiles (gated to non-own, non-AI-influencer, logged-in users only).
- **Chat service plumbing**: `CreateHumanConversationUseCase`, `SendHumanMessageUseCase`, DTOs, and `ChatRemoteDataSource` calls to `POST /api/v1/chat/human/conversations` and `POST /api/v1/chat/human/conversations/{id}/messages`.
- **Chat-screen H2H mode**: header gates (no Subscribe button, no 3-dot menu, no welcome / IAP affordances when `isHumanChat=true`); send routing branches `if (isHumanChat) sendHumanMessageUseCase(...) else sendMessageUseCase(...)`.
- **Inbox unification**: unified inbox endpoint (`GET /api/v2/chat/conversations` per backend PR #228, already deployed) returns interleaved AI + H2H rows by `updated_at DESC`. Mobile-side renderer reads `conversation.conversationUser` for the peer name + avatar.
- **Bubble-side discriminator** (added in the final commit of this PR): viewer's own principal_id is plumbed into the render path so `isUser` resolves to `senderId == currentUserPrincipalId` for H2H remote messages (since `role='user'` on both peers, the role-based discriminator collapses).
- **Unread-badge inclusion**: H2H rows now contribute to per-row pink badge AND the global chat-tab badge (the prior `&& conversationUser == null` defensive guard was suppressing them).
- **Navigation-stack hardening**: `DefaultRootComponent.openConversation` now *replaces* the matched stale frame on `conversationId` dedup instead of keeping the old `params`. Previously, opening a chat that was already in the back-stack with new params (e.g. `participantPrincipalId`) silently inherited the stale state.

## Activation prerequisites (NOT part of this PR — both must land first)

1. **Backend cutover**: production traffic moved from `chat-ai.rishi.yral.com` to `agent.rishi.yral.com`. The H2H endpoints only exist on the new agent service; chat-ai cannot serve them.
2. **Firebase Remote Config**: `chat_h2hChatEnabled` set to `true` for the audience that should see the feature.

Until both are in place, this PR is a no-op for end users. With `H2hChatEnabled=false` (the committed default), every code path that gates on `state.isH2hChatEnabled` evaluates to false → button hidden, H2H rows filtered out of inbox at render, no H2H API calls made.

## Related backend PRs (already shipped to `agent.rishi.yral.com`)

These are not blockers for *merging* this mobile PR (since the feature is dormant), but they're prerequisites for the end-to-end flow to work when activation lands:

- `dolr-ai/yral-rishi-agent#228` — unified inbox returns interleaved AI + H2H rows, exposes `conversation_type` discriminator. Pre-existing.
- `dolr-ai/yral-rishi-agent#241` — `_can_access_conversation` now allows `participant_b_id` so recipients can read their own H2H conversations. Shipped 2026-06-01.
- `dolr-ai/yral-rishi-agent#245` — H2H `unread_count` subquery now branches on `conversation_type` so recipient unread badge populates. Shipped 2026-06-02.
- `dolr-ai/yral-rishi-agent#247` — `count_unread` + `mark_as_read` viewer-principal-scoped (Part B sweep finding). Shipped 2026-06-02.

## How this PR was tested

End-to-end bidirectional smoke on a connected Motorola g96 5G across two real accounts (`k2adj-...` and `jtdxs-...` / honoredfondcat) against the deployed `agent.rishi.yral.com` backend (with local `CHAT_BASE_URL` + `H2hChatEnabled=true` overrides during the test, reverted before commit; pre-commit hook enforces the `CHAT_BASE_URL` revert and the project's standing convention enforces the flag revert).

**Sender-side (from k2adj profile of another user → tap Send Message):**

- [x] Chat screen opens cleanly, no "Having a little trouble loading" error sheet.
- [x] Header shows the peer's name + avatar; Subscribe button hidden; 3-dot menu hidden (no Share / Clear Chat); no welcome card; no IAP card.
- [x] Typing + send: message appears at the optimistic-local position on the **right** in pink, then persists.
- [x] Back to inbox: the H2H row appears at the top with peer name + avatar.
- [x] Existing AI conversations still interleave correctly with H2H rows by `updated_at DESC`.
- [x] Inbox pagination continues loading without prematurely hitting end-of-list (count returned from backend matches actual row count after the PR #228 JOIN change).

**Recipient-side (switch device login to jtdxs / honoredfondcat → open the same conversation):**

- [x] Inbox row appears at the top with the sender's name + avatar and the last-message preview.
- [x] Pink unread badge with the correct count is visible on the H2H row.
- [x] Global chat-tab badge in the bottom nav also reflects the unread count.
- [x] Tapping the row opens the chat screen with all message history rendered.
- [x] Sender's messages (`k2adj`) appear on the **left** in the dark bubble; recipient's own previous replies appear on the **right** in pink.
- [x] Sending a reply from the recipient side persists; switching back to sender, the reply shows in the conv with inverted bubble sides (now left, since perspective changed). Inversion-on-account-switch confirms the discriminator is viewer-relative, not server-side.
- [x] Pink unread badge clears on the row + globally once the conv is opened (mark-as-read fires for the recipient — gated by backend PRs #241 + #247).

**Negative path (flag off):**

- Set `H2hChatEnabled=false` in Remote Config → Send Message button hidden on user profiles → inbox renders without H2H rows. (Tested via the committed `defaultValue=false` — the very state this PR ships in.)

## Notes for the reviewer

- The branch is 10 commits ahead of `main` and was built incrementally with one logical concern per commit. The first 8 commits build the H2H feature scaffold (wire DTOs → use cases → profile button → chat-screen integration → resetState/header-gate plumbing). The last two are: P7 docs lesson and the **five-bug-fix bundle** surfaced by the Motorola test. The bug-fix commit has a verbose body explaining each fix, the file:line, and the underlying pattern (AI-only assumption that silently regresses on H2H).
- `MOBILE-EXPERT-LESSONS.md` gets two new entries on this branch: P6 (earlier, from the inbox-visibility miss) and P7 (this PR, on permissive deserialization defaults). Both are intentional and explain reasoning patterns rather than code.
- This PR does not introduce a new GET-H2H-messages endpoint on either side. Mobile correctly reuses `GET /api/v1/chat/conversations/{id}/messages` for both AI and H2H message history — that's the canonical path and is now access-checked symmetrically for both sender and `participant_b_id` (per backend PR #241).
- There are four `Task` items in the active queue downstream of this PR that intentionally stay open until after merge: `#54` (post-SSE ConversationContentCache audit), `#56` (H2H `retry()` hardcodes AI send endpoint — small follow-up; would couple `retry()` to the same `isHumanChat` branch `sendMessage()` already uses), `#57` (audit `resetState()` for other H2H-carrier fields), `#59` (audit vestigial H2H-suppression guards including role-based discriminators).

## Reviewer plan

1. **Skim the branch diff** with the commit boundary in mind — `git log main..HEAD` reads top-down as the feature build order; the final fix-bundle commit's body lists every change and why.
2. **Read MOBILE-EXPERT-LESSONS.md** P6 + P7 sections for the project-level reasoning patterns being captured here.
3. **Local toggle test**: flip `H2hChatEnabled.defaultValue` to `true` in the cloned branch + flip `CHAT_BASE_URL` to `"agent.rishi.yral.com"`, build a debug APK, run through the sender+recipient checklist above on a real device. Revert both before committing anything (pre-commit hook will refuse the `CHAT_BASE_URL` override; the flag revert is a standing convention).
4. **Verify dormancy** with committed defaults: build the APK without any toggle change, confirm Send Message button is absent on user profiles and inbox surfaces only AI rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)