### PR TITLE
feat(chat): voice-message recording (Phase 1.7b mobile)

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Required for in-chat voice recording feature (Phase 1.7b audio upload).
+         Runtime-prompted on first mic-button tap, denial-tolerant. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />

--- a/iosApp/Prod/Info.plist
+++ b/iosApp/Prod/Info.plist
@@ -60,7 +60,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Yral requires camera access to allow you to record and upload videos. Your camera will only be used when you choose to create a new video.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Yral requires microphone access to capture audio while recording videos. Your microphone will only be used during video recording.</string>
+	<string>Yral requires microphone access to capture audio while recording videos and chat voice messages. Your microphone will only be used when you choose to record.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Yral needs permission to save downloaded videos and photos to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/iosApp/Staging/Info-Staging.plist
+++ b/iosApp/Staging/Info-Staging.plist
@@ -56,7 +56,7 @@
 	<key>NSCameraUsageDescription</key>
 	<string>Yral requires camera access to allow to record and upload videos. Your camera will only be used when you choose to create a new video.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Yral requires microphone access to capture audio while recording videos. Your microphone will only be used during video recording.</string>
+	<string>Yral requires microphone access to capture audio while recording videos and chat voice messages. Your microphone will only be used when you choose to record.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Yral needs access to your photo library so you can choose a profile picture.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.android.kt
+++ b/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.android.kt
@@ -1,0 +1,115 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import android.media.MediaPlayer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+private const val PLAYER_TICK_MS = 100L
+
+@Composable
+actual fun rememberChatAudioPlayer(): AudioPlayerController {
+    val scope = rememberCoroutineScope()
+    val controller = remember(scope) { AndroidAudioPlayerController(scope) }
+    DisposableEffect(controller) {
+        onDispose { controller.stop() }
+    }
+    return controller
+}
+
+private class AndroidAudioPlayerController(
+    private val scope: CoroutineScope,
+) : AudioPlayerController {
+    private val _state = MutableStateFlow<AudioPlayerState>(AudioPlayerState.Idle)
+    override val state: StateFlow<AudioPlayerState> = _state.asStateFlow()
+
+    private var player: MediaPlayer? = null
+    private var loadedFilePath: String? = null
+    private var tickerJob: Job? = null
+
+    override fun load(filePath: String) {
+        // Reuse the same MediaPlayer if the file path didn't change — avoids
+        // reload latency on each play tap.
+        if (loadedFilePath == filePath && player != null) return
+        runCatching {
+            releaseInternal()
+            val p = MediaPlayer()
+            p.setDataSource(filePath)
+            p.prepare()
+            p.setOnCompletionListener {
+                tickerJob?.cancel()
+                tickerJob = null
+                val dur = p.duration.toLong()
+                _state.value = AudioPlayerState.Ready(dur)
+            }
+            player = p
+            loadedFilePath = filePath
+            _state.value = AudioPlayerState.Ready(p.duration.toLong())
+        }.onFailure { t ->
+            Logger.e(t) { "Audio player load failed for $filePath" }
+            _state.value = AudioPlayerState.Idle
+        }
+    }
+
+    override fun playPause() {
+        val p = player ?: return
+        when (val s = _state.value) {
+            is AudioPlayerState.Ready, is AudioPlayerState.Paused -> {
+                p.start()
+                _state.value = AudioPlayerState.Playing(
+                    positionMs = p.currentPosition.toLong(),
+                    durationMs = p.duration.toLong(),
+                )
+                startTicker()
+            }
+            is AudioPlayerState.Playing -> {
+                p.pause()
+                tickerJob?.cancel()
+                tickerJob = null
+                _state.value = AudioPlayerState.Paused(
+                    positionMs = p.currentPosition.toLong(),
+                    durationMs = s.durationMs,
+                )
+            }
+            AudioPlayerState.Idle -> { /* not loaded yet */ }
+        }
+    }
+
+    override fun stop() {
+        releaseInternal()
+        _state.value = AudioPlayerState.Idle
+    }
+
+    private fun startTicker() {
+        tickerJob?.cancel()
+        tickerJob = scope.launch {
+            while (isActive) {
+                delay(PLAYER_TICK_MS)
+                val p = player ?: return@launch
+                if (!p.isPlaying) return@launch
+                _state.value = AudioPlayerState.Playing(
+                    positionMs = p.currentPosition.toLong(),
+                    durationMs = p.duration.toLong(),
+                )
+            }
+        }
+    }
+
+    private fun releaseInternal() {
+        tickerJob?.cancel()
+        tickerJob = null
+        player?.let { runCatching { it.release() } }
+        player = null
+        loadedFilePath = null
+    }
+}

--- a/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.android.kt
+++ b/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.android.kt
@@ -43,18 +43,18 @@ private class AndroidAudioPlayerController(
         if (loadedFilePath == filePath && player != null) return
         runCatching {
             releaseInternal()
-            val p = MediaPlayer()
-            p.setDataSource(filePath)
-            p.prepare()
-            p.setOnCompletionListener {
+            val mediaPlayer = MediaPlayer()
+            mediaPlayer.setDataSource(filePath)
+            mediaPlayer.prepare()
+            mediaPlayer.setOnCompletionListener {
                 tickerJob?.cancel()
                 tickerJob = null
-                val dur = p.duration.toLong()
-                _state.value = AudioPlayerState.Ready(dur)
+                val durationMs = mediaPlayer.duration.toLong()
+                _state.value = AudioPlayerState.Ready(durationMs)
             }
-            player = p
+            player = mediaPlayer
             loadedFilePath = filePath
-            _state.value = AudioPlayerState.Ready(p.duration.toLong())
+            _state.value = AudioPlayerState.Ready(mediaPlayer.duration.toLong())
         }.onFailure { t ->
             Logger.e(t) { "Audio player load failed for $filePath" }
             _state.value = AudioPlayerState.Idle
@@ -62,25 +62,29 @@ private class AndroidAudioPlayerController(
     }
 
     override fun playPause() {
-        val p = player ?: return
-        when (val s = _state.value) {
+        val mediaPlayer = player ?: return
+        when (val playerState = _state.value) {
             is AudioPlayerState.Ready, is AudioPlayerState.Paused -> {
-                p.start()
-                _state.value = AudioPlayerState.Playing(
-                    positionMs = p.currentPosition.toLong(),
-                    durationMs = p.duration.toLong(),
-                )
+                mediaPlayer.start()
+                _state.value =
+                    AudioPlayerState.Playing(
+                        positionMs = mediaPlayer.currentPosition.toLong(),
+                        durationMs = mediaPlayer.duration.toLong(),
+                    )
                 startTicker()
             }
+
             is AudioPlayerState.Playing -> {
-                p.pause()
+                mediaPlayer.pause()
                 tickerJob?.cancel()
                 tickerJob = null
-                _state.value = AudioPlayerState.Paused(
-                    positionMs = p.currentPosition.toLong(),
-                    durationMs = s.durationMs,
-                )
+                _state.value =
+                    AudioPlayerState.Paused(
+                        positionMs = mediaPlayer.currentPosition.toLong(),
+                        durationMs = playerState.durationMs,
+                    )
             }
+
             AudioPlayerState.Idle -> { /* not loaded yet */ }
         }
     }
@@ -92,17 +96,19 @@ private class AndroidAudioPlayerController(
 
     private fun startTicker() {
         tickerJob?.cancel()
-        tickerJob = scope.launch {
-            while (isActive) {
-                delay(PLAYER_TICK_MS)
-                val p = player ?: return@launch
-                if (!p.isPlaying) return@launch
-                _state.value = AudioPlayerState.Playing(
-                    positionMs = p.currentPosition.toLong(),
-                    durationMs = p.duration.toLong(),
-                )
+        tickerJob =
+            scope.launch {
+                while (isActive) {
+                    delay(PLAYER_TICK_MS)
+                    val mediaPlayer = player ?: return@launch
+                    if (!mediaPlayer.isPlaying) return@launch
+                    _state.value =
+                        AudioPlayerState.Playing(
+                            positionMs = mediaPlayer.currentPosition.toLong(),
+                            durationMs = mediaPlayer.duration.toLong(),
+                        )
+                }
             }
-        }
     }
 
     private fun releaseInternal() {

--- a/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.android.kt
+++ b/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.android.kt
@@ -1,0 +1,212 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.MediaRecorder
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import co.touchlab.kermit.Logger
+import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.File
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+private const val AUDIO_SAMPLE_RATE_HZ = 44_100
+private const val AUDIO_BIT_RATE = 128_000
+private const val RECORDING_TICK_MS = 100L
+private const val MS_PER_SECOND = 1000
+
+@OptIn(ExperimentalTime::class)
+@Composable
+actual fun rememberChatAudioRecorder(
+    onComplete: (attachment: FilePathChatAttachment, durationSeconds: Int) -> Unit,
+    onPermissionDenied: () -> Unit,
+): AudioRecorderController {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    val controller =
+        remember(context, scope, onComplete, onPermissionDenied) {
+            AndroidAudioRecorderController(context, scope, onComplete, onPermissionDenied)
+        }
+
+    val permissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            if (granted) {
+                controller.actuallyStart()
+            } else {
+                onPermissionDenied()
+            }
+        }
+
+    DisposableEffect(controller) {
+        controller.permissionRequest = { permissionLauncher.launch(Manifest.permission.RECORD_AUDIO) }
+        onDispose { controller.releaseInternal() }
+    }
+
+    return controller
+}
+
+@OptIn(ExperimentalTime::class)
+private class AndroidAudioRecorderController(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val onComplete: (FilePathChatAttachment, Int) -> Unit,
+    private val onPermissionDenied: () -> Unit,
+) : AudioRecorderController {
+    private val _state = MutableStateFlow<AudioRecordingState>(AudioRecordingState.Idle)
+    override val state: StateFlow<AudioRecordingState> = _state.asStateFlow()
+
+    var permissionRequest: (() -> Unit)? = null
+
+    private var recorder: MediaRecorder? = null
+    private var outputFile: File? = null
+    private var startTimeMs: Long = 0
+    private var tickerJob: Job? = null
+
+    override fun start() {
+        if (_state.value != AudioRecordingState.Idle) return
+        val granted =
+            ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+                PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            actuallyStart()
+        } else {
+            permissionRequest?.invoke() ?: onPermissionDenied()
+        }
+    }
+
+    fun actuallyStart() {
+        runCatching {
+            val file = File.createTempFile(
+                "chat_audio_${Clock.System.now().toEpochMilliseconds()}",
+                ".m4a",
+                context.cacheDir,
+            )
+            outputFile = file
+
+            @Suppress("DEPRECATION")
+            val r =
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    MediaRecorder(context)
+                } else {
+                    MediaRecorder()
+                }
+            r.setAudioSource(MediaRecorder.AudioSource.MIC)
+            r.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            r.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            r.setAudioSamplingRate(AUDIO_SAMPLE_RATE_HZ)
+            r.setAudioEncodingBitRate(AUDIO_BIT_RATE)
+            r.setOutputFile(file.absolutePath)
+            r.prepare()
+            r.start()
+            recorder = r
+            startTimeMs = Clock.System.now().toEpochMilliseconds()
+            _state.value = AudioRecordingState.Recording(0)
+            tickerJob = scope.launch {
+                while (isActive) {
+                    delay(RECORDING_TICK_MS)
+                    val elapsed = Clock.System.now().toEpochMilliseconds() - startTimeMs
+                    val current = _state.value
+                    if (current is AudioRecordingState.Recording) {
+                        _state.value = AudioRecordingState.Recording(elapsed)
+                    } else {
+                        return@launch
+                    }
+                }
+            }
+        }.onFailure { t ->
+            Logger.e(t) { "Audio recorder start failed" }
+            cleanup()
+            _state.value = AudioRecordingState.Idle
+        }
+    }
+
+    override fun stop() {
+        val r = recorder ?: return
+        val file = outputFile ?: return
+        _state.value = AudioRecordingState.Finalizing
+        tickerJob?.cancel()
+        tickerJob = null
+        val durationMs = Clock.System.now().toEpochMilliseconds() - startTimeMs
+
+        runCatching {
+            r.stop()
+            r.release()
+        }.onFailure { t -> Logger.w(t) { "Audio recorder stop failed (file may be empty)" } }
+        recorder = null
+
+        if (file.exists() && file.length() > 0) {
+            val attachment =
+                FilePathChatAttachment(
+                    filePath = file.absolutePath,
+                    fileName = file.name,
+                    contentType = "audio/mp4",
+                )
+            val durationSeconds = (durationMs / MS_PER_SECOND).toInt().coerceAtLeast(1)
+            onComplete(attachment, durationSeconds)
+        } else {
+            // Recorder produced a zero-byte file (typically user tapped stop within
+            // the first ~100ms before MediaRecorder accumulated a writable frame).
+            // Discard; the screen will treat this as a no-op and stay on the
+            // ChatInput state.
+            file.takeIf { it.exists() }?.delete()
+            Logger.w { "Audio recording produced empty file — discarded" }
+        }
+        outputFile = null
+        _state.value = AudioRecordingState.Idle
+    }
+
+    override fun cancel() {
+        tickerJob?.cancel()
+        tickerJob = null
+        recorder?.let { r ->
+            runCatching {
+                r.stop()
+            }.onFailure { /* swallow — stop before writable frame is a known MediaRecorder gotcha */ }
+            runCatching { r.release() }
+        }
+        recorder = null
+        outputFile?.takeIf { it.exists() }?.delete()
+        outputFile = null
+        _state.value = AudioRecordingState.Idle
+    }
+
+    fun releaseInternal() {
+        tickerJob?.cancel()
+        tickerJob = null
+        recorder?.let { runCatching { it.release() } }
+        recorder = null
+        // Don't delete outputFile here — the caller (preview composable) may still
+        // own a reference until the user picks delete or send. The composable lifecycle
+        // handles cleanup via FilePathChatAttachment.deleteCachedFile() on cancel.
+        outputFile = null
+    }
+
+    private fun cleanup() {
+        tickerJob?.cancel()
+        tickerJob = null
+        recorder?.let { runCatching { it.release() } }
+        recorder = null
+        outputFile?.takeIf { it.exists() }?.delete()
+        outputFile = null
+    }
+}

--- a/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.android.kt
+++ b/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.android.kt
@@ -96,43 +96,45 @@ private class AndroidAudioRecorderController(
 
     fun actuallyStart() {
         runCatching {
-            val file = File.createTempFile(
-                "chat_audio_${Clock.System.now().toEpochMilliseconds()}",
-                ".m4a",
-                context.cacheDir,
-            )
+            val file =
+                File.createTempFile(
+                    "chat_audio_${Clock.System.now().toEpochMilliseconds()}",
+                    ".m4a",
+                    context.cacheDir,
+                )
             outputFile = file
 
             @Suppress("DEPRECATION")
-            val r =
+            val mediaRecorder =
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     MediaRecorder(context)
                 } else {
                     MediaRecorder()
                 }
-            r.setAudioSource(MediaRecorder.AudioSource.MIC)
-            r.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-            r.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
-            r.setAudioSamplingRate(AUDIO_SAMPLE_RATE_HZ)
-            r.setAudioEncodingBitRate(AUDIO_BIT_RATE)
-            r.setOutputFile(file.absolutePath)
-            r.prepare()
-            r.start()
-            recorder = r
+            mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC)
+            mediaRecorder.setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            mediaRecorder.setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            mediaRecorder.setAudioSamplingRate(AUDIO_SAMPLE_RATE_HZ)
+            mediaRecorder.setAudioEncodingBitRate(AUDIO_BIT_RATE)
+            mediaRecorder.setOutputFile(file.absolutePath)
+            mediaRecorder.prepare()
+            mediaRecorder.start()
+            recorder = mediaRecorder
             startTimeMs = Clock.System.now().toEpochMilliseconds()
             _state.value = AudioRecordingState.Recording(0)
-            tickerJob = scope.launch {
-                while (isActive) {
-                    delay(RECORDING_TICK_MS)
-                    val elapsed = Clock.System.now().toEpochMilliseconds() - startTimeMs
-                    val current = _state.value
-                    if (current is AudioRecordingState.Recording) {
-                        _state.value = AudioRecordingState.Recording(elapsed)
-                    } else {
-                        return@launch
+            tickerJob =
+                scope.launch {
+                    while (isActive) {
+                        delay(RECORDING_TICK_MS)
+                        val elapsed = Clock.System.now().toEpochMilliseconds() - startTimeMs
+                        val current = _state.value
+                        if (current is AudioRecordingState.Recording) {
+                            _state.value = AudioRecordingState.Recording(elapsed)
+                        } else {
+                            return@launch
+                        }
                     }
                 }
-            }
         }.onFailure { t ->
             Logger.e(t) { "Audio recorder start failed" }
             cleanup()
@@ -141,7 +143,7 @@ private class AndroidAudioRecorderController(
     }
 
     override fun stop() {
-        val r = recorder ?: return
+        val mediaRecorder = recorder ?: return
         val file = outputFile ?: return
         _state.value = AudioRecordingState.Finalizing
         tickerJob?.cancel()
@@ -149,8 +151,8 @@ private class AndroidAudioRecorderController(
         val durationMs = Clock.System.now().toEpochMilliseconds() - startTimeMs
 
         runCatching {
-            r.stop()
-            r.release()
+            mediaRecorder.stop()
+            mediaRecorder.release()
         }.onFailure { t -> Logger.w(t) { "Audio recorder stop failed (file may be empty)" } }
         recorder = null
 
@@ -178,11 +180,11 @@ private class AndroidAudioRecorderController(
     override fun cancel() {
         tickerJob?.cancel()
         tickerJob = null
-        recorder?.let { r ->
+        recorder?.let { mediaRecorder ->
             runCatching {
-                r.stop()
+                mediaRecorder.stop()
             }.onFailure { /* swallow — stop before writable frame is a known MediaRecorder gotcha */ }
-            runCatching { r.release() }
+            runCatching { mediaRecorder.release() }
         }
         recorder = null
         outputFile?.takeIf { it.exists() }?.delete()

--- a/shared/features/chat/src/commonMain/composeResources/drawable/ic_audio_pause.xml
+++ b/shared/features/chat/src/commonMain/composeResources/drawable/ic_audio_pause.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M5.5,4.5H8.5V15.5H5.5Z" />
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M11.5,4.5H14.5V15.5H11.5Z" />
+</vector>

--- a/shared/features/chat/src/commonMain/composeResources/drawable/ic_audio_play.xml
+++ b/shared/features/chat/src/commonMain/composeResources/drawable/ic_audio_play.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M6.5,4.75L15,10L6.5,15.25Z" />
+</vector>

--- a/shared/features/chat/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/chat/src/commonMain/composeResources/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="message_placeholder">Message...</string>
     <string name="camera">Camera</string>
     <string name="photo_library">Photo Library</string>
+    <string name="voice_message">Voice message</string>
+    <string name="voice_message_permission_denied">Microphone access needed to record voice messages. Enable it in app settings.</string>
     <string name="send">Send</string>
     <string name="switch_to_human_profile_to_chat">Switch to your human profile to chat with this influencer.</string>
     <string name="ai_influencer_read_only_chat">Chats are read-only in AI influencer view mode</string>

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -705,7 +705,21 @@ fun ChatConversationScreen(
                                             },
                                             onCameraClick = imageCaptureLauncher,
                                             onGalleryClick = imagePickerLauncher,
-                                            onMicClick = { audioRecorder.start() },
+                                            // Mic button is gated on AudioRecordingEnabled (kill-switch +
+                                            // GA pacing). Passing null hides the icon entirely per
+                                            // ConversationInputArea's ActionsRow logic.
+                                            //
+                                            // Known follow-up (Task #64): once the H2H feature lands on main
+                                            // and this branch rebases, also AND in `!viewState.isHumanChat`
+                                            // here — voice messages are not supported on H2H peer chats
+                                            // because the H2H send route doesn't transcribe; recipient would
+                                            // see an empty bubble with playable audio and no context.
+                                            onMicClick =
+                                                if (viewState.isAudioRecordingEnabled) {
+                                                    { audioRecorder.start() }
+                                                } else {
+                                                    null
+                                                },
                                             hasWaitingAssistant = hasWaitingAssistant,
                                         )
                                     }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -677,6 +677,7 @@ fun ChatConversationScreen(
                                             hasWaitingAssistant = hasWaitingAssistant,
                                         )
                                     }
+
                                     audioState is AudioRecordingState.Recording ||
                                         audioState is AudioRecordingState.Finalizing -> {
                                         val elapsedMs =
@@ -688,6 +689,7 @@ fun ChatConversationScreen(
                                             onCancel = { audioRecorder.cancel() },
                                         )
                                     }
+
                                     else -> {
                                         ChatInputArea(
                                             input = input,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -706,16 +706,14 @@ fun ChatConversationScreen(
                                             onCameraClick = imageCaptureLauncher,
                                             onGalleryClick = imagePickerLauncher,
                                             // Mic button is gated on AudioRecordingEnabled (kill-switch +
-                                            // GA pacing). Passing null hides the icon entirely per
+                                            // GA pacing) AND not-an-H2H-chat. Voice messages aren't
+                                            // supported on H2H peer chats — the H2H send route doesn't
+                                            // transcribe, so the recipient would see an empty bubble
+                                            // with playable audio and no context. G6 gate landed in
+                                            // this commit; passing null hides the icon entirely per
                                             // ConversationInputArea's ActionsRow logic.
-                                            //
-                                            // Known follow-up (Task #64): once the H2H feature lands on main
-                                            // and this branch rebases, also AND in `!viewState.isHumanChat`
-                                            // here — voice messages are not supported on H2H peer chats
-                                            // because the H2H send route doesn't transcribe; recipient would
-                                            // see an empty bubble with playable audio and no context.
                                             onMicClick =
-                                                if (viewState.isAudioRecordingEnabled) {
+                                                if (viewState.isAudioRecordingEnabled && !viewState.isHumanChat) {
                                                     { audioRecorder.start() }
                                                 } else {
                                                     null

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -40,11 +40,16 @@ import com.yral.shared.features.auth.ui.LoginBottomSheetType
 import com.yral.shared.features.auth.ui.LoginMode
 import com.yral.shared.features.auth.ui.LoginScreenType
 import com.yral.shared.features.auth.ui.rememberLoginInfo
+import com.yral.shared.features.chat.attachments.FilePathChatAttachment
 import com.yral.shared.features.chat.domain.models.ChatMessageType
 import com.yral.shared.features.chat.domain.models.ConversationMessageRole
 import com.yral.shared.features.chat.domain.models.SendMessageDraft
 import com.yral.shared.features.chat.nav.conversation.ConversationComponent
 import com.yral.shared.features.chat.ui.components.ChatErrorBottomSheet
+import com.yral.shared.features.chat.ui.conversation.audio.AudioPreviewBar
+import com.yral.shared.features.chat.ui.conversation.audio.AudioRecordingBar
+import com.yral.shared.features.chat.ui.conversation.audio.AudioRecordingState
+import com.yral.shared.features.chat.ui.conversation.audio.rememberChatAudioRecorder
 import com.yral.shared.features.chat.viewmodel.ConversationMessageItem
 import com.yral.shared.features.chat.viewmodel.ConversationViewModel
 import com.yral.shared.iap.utils.getPurchaseContext
@@ -207,6 +212,12 @@ fun ChatConversationScreen(
     var input by remember { mutableStateOf("") }
     var activeImagePreview by remember { mutableStateOf<ChatImagePreviewSource?>(null) }
     var isSwitchingProfile by remember { mutableStateOf(false) }
+    // Audio-recording state for the in-chat voice-note flow.
+    //   pendingAudio = (file attachment + duration) is set when the recorder
+    //   finishes a take; the AudioPreviewBar replaces the input until the
+    //   user either taps Send (consumes pendingAudio into a draft) or Delete
+    //   (discards file + clears state, returning to the text input).
+    var pendingAudio by remember { mutableStateOf<Pair<FilePathChatAttachment, Int>?>(null) }
     val listState = rememberLazyListState()
     val screenWidth = LocalWindowInfo.current.containerSize.width
     val density = LocalDensity.current
@@ -632,24 +643,73 @@ fun ChatConversationScreen(
                             }
 
                             ConversationBottomAreaState.ChatInput -> {
-                                ChatInputArea(
-                                    input = input,
-                                    onInputChange = { input = it },
-                                    onSendClick = {
-                                        val text = input.trim()
-                                        sendMessageIfAllowed(
-                                            SendMessageDraft(
-                                                messageType = ChatMessageType.TEXT,
-                                                content = text,
-                                            ),
-                                        ) {
-                                            input = ""
-                                        }
-                                    },
-                                    onCameraClick = imageCaptureLauncher,
-                                    onGalleryClick = imagePickerLauncher,
-                                    hasWaitingAssistant = hasWaitingAssistant,
-                                )
+                                val audioRecorder =
+                                    rememberChatAudioRecorder(
+                                        onComplete = { attachment, durationSeconds ->
+                                            pendingAudio = attachment to durationSeconds
+                                        },
+                                        onPermissionDenied = {
+                                            Logger.w { "Mic permission denied — voice message not recorded" }
+                                        },
+                                    )
+                                val audioState by audioRecorder.state.collectAsState()
+                                when {
+                                    pendingAudio != null -> {
+                                        val (audioAttachment, durationSeconds) = pendingAudio!!
+                                        AudioPreviewBar(
+                                            attachment = audioAttachment,
+                                            durationSeconds = durationSeconds,
+                                            onDelete = {
+                                                audioAttachment.deleteCachedFile()
+                                                pendingAudio = null
+                                            },
+                                            onSend = {
+                                                sendMessageIfAllowed(
+                                                    SendMessageDraft(
+                                                        messageType = ChatMessageType.AUDIO,
+                                                        audioAttachment = audioAttachment,
+                                                        audioDurationSeconds = durationSeconds,
+                                                    ),
+                                                ) {
+                                                    pendingAudio = null
+                                                }
+                                            },
+                                            hasWaitingAssistant = hasWaitingAssistant,
+                                        )
+                                    }
+                                    audioState is AudioRecordingState.Recording ||
+                                        audioState is AudioRecordingState.Finalizing -> {
+                                        val elapsedMs =
+                                            (audioState as? AudioRecordingState.Recording)?.elapsedMs ?: 0L
+                                        AudioRecordingBar(
+                                            elapsedMs = elapsedMs,
+                                            isFinalizing = audioState is AudioRecordingState.Finalizing,
+                                            onStop = { audioRecorder.stop() },
+                                            onCancel = { audioRecorder.cancel() },
+                                        )
+                                    }
+                                    else -> {
+                                        ChatInputArea(
+                                            input = input,
+                                            onInputChange = { input = it },
+                                            onSendClick = {
+                                                val text = input.trim()
+                                                sendMessageIfAllowed(
+                                                    SendMessageDraft(
+                                                        messageType = ChatMessageType.TEXT,
+                                                        content = text,
+                                                    ),
+                                                ) {
+                                                    input = ""
+                                                }
+                                            },
+                                            onCameraClick = imageCaptureLauncher,
+                                            onGalleryClick = imagePickerLauncher,
+                                            onMicClick = { audioRecorder.start() },
+                                            hasWaitingAssistant = hasWaitingAssistant,
+                                        )
+                                    }
+                                }
                             }
                         }
                     }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
@@ -35,8 +35,10 @@ import yral_mobile.shared.features.chat.generated.resources.camera
 import yral_mobile.shared.features.chat.generated.resources.message_placeholder
 import yral_mobile.shared.features.chat.generated.resources.photo_library
 import yral_mobile.shared.features.chat.generated.resources.send
+import yral_mobile.shared.features.chat.generated.resources.voice_message
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_camera
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_gallery
+import yral_mobile.shared.libs.designsystem.generated.resources.ic_microphone
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_plus_circle
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_send
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_send_disabled
@@ -52,6 +54,7 @@ internal fun ChatInputArea(
     onSendClick: () -> Unit,
     onCameraClick: (() -> Unit)? = null,
     onGalleryClick: (() -> Unit)? = null,
+    onMicClick: (() -> Unit)? = null,
     showAttachmentMenu: Boolean = true,
     placeholder: String? = null,
     hasWaitingAssistant: Boolean = false,
@@ -108,6 +111,7 @@ internal fun ChatInputArea(
             showAttachmentMenu,
             onCameraClick,
             onGalleryClick,
+            onMicClick,
             hasWaitingAssistant,
         )
     }
@@ -120,6 +124,7 @@ private fun InputActions(
     showAttachmentMenu: Boolean,
     onCameraClick: (() -> Unit)?,
     onGalleryClick: (() -> Unit)?,
+    onMicClick: (() -> Unit)?,
     hasWaitingAssistant: Boolean,
 ) {
     Row(
@@ -132,28 +137,33 @@ private fun InputActions(
                 enabled = input.isNotBlank() && !hasWaitingAssistant,
                 onSendClick = onSendClick,
             )
-        } else if (showAttachmentMenu && onCameraClick != null && onGalleryClick != null) {
-            // Show attachment menu only if enabled and callbacks are provided
-            YralContextMenu(
-                items =
-                    listOf(
-                        YralContextMenuItem(
-                            text = stringResource(Res.string.camera),
-                            icon = DesignRes.drawable.ic_camera,
-                            onClick = onCameraClick,
+        } else if (showAttachmentMenu) {
+            if (onCameraClick != null && onGalleryClick != null) {
+                // Show attachment menu (camera/gallery) when both callbacks provided
+                YralContextMenu(
+                    items =
+                        listOf(
+                            YralContextMenuItem(
+                                text = stringResource(Res.string.camera),
+                                icon = DesignRes.drawable.ic_camera,
+                                onClick = onCameraClick,
+                            ),
+                            YralContextMenuItem(
+                                text = stringResource(Res.string.photo_library),
+                                icon = DesignRes.drawable.ic_gallery,
+                                onClick = onGalleryClick,
+                            ),
                         ),
-                        YralContextMenuItem(
-                            text = stringResource(Res.string.photo_library),
-                            icon = DesignRes.drawable.ic_gallery,
-                            onClick = onGalleryClick,
-                        ),
-                    ),
-                triggerIcon = DesignRes.drawable.ic_plus_circle,
-                triggerSize = 24.dp,
-                menuIconSize = 20.dp,
-                menuPadding = PaddingValues(bottom = 16.dp),
-            )
-        } else if (!showAttachmentMenu) {
+                    triggerIcon = DesignRes.drawable.ic_plus_circle,
+                    triggerSize = 24.dp,
+                    menuIconSize = 20.dp,
+                    menuPadding = PaddingValues(bottom = 16.dp),
+                )
+            }
+            if (onMicClick != null) {
+                MicButton(onClick = onMicClick)
+            }
+        } else {
             // Always show send button when attachment menu is disabled (for image preview)
             SendButton(
                 enabled = !hasWaitingAssistant,
@@ -161,6 +171,18 @@ private fun InputActions(
             )
         }
     }
+}
+
+@Composable
+private fun MicButton(onClick: () -> Unit) {
+    Image(
+        painter = painterResource(DesignRes.drawable.ic_microphone),
+        contentDescription = stringResource(Res.string.voice_message),
+        modifier = Modifier
+            .size(24.dp)
+            .clickable(onClick = onClick),
+        contentScale = ContentScale.None,
+    )
 }
 
 @Composable

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
@@ -178,9 +178,10 @@ private fun MicButton(onClick: () -> Unit) {
     Image(
         painter = painterResource(DesignRes.drawable.ic_microphone),
         contentDescription = stringResource(Res.string.voice_message),
-        modifier = Modifier
-            .size(24.dp)
-            .clickable(onClick = onClick),
+        modifier =
+            Modifier
+                .size(24.dp)
+                .clickable(onClick = onClick),
         contentScale = ContentScale.None,
     )
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioPreviewBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioPreviewBar.kt
@@ -1,0 +1,165 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import com.yral.shared.libs.designsystem.theme.LocalAppTopography
+import com.yral.shared.libs.designsystem.theme.YralColors
+
+private const val MS_PER_SECOND = 1000
+
+@Composable
+internal fun AudioPreviewBar(
+    attachment: FilePathChatAttachment,
+    durationSeconds: Int,
+    onDelete: () -> Unit,
+    onSend: () -> Unit,
+    hasWaitingAssistant: Boolean,
+) {
+    val player = rememberChatAudioPlayer()
+    val state by player.state.collectAsState()
+
+    LaunchedEffect(attachment.filePath) {
+        player.load(attachment.filePath)
+    }
+
+    val isPlaying = state is AudioPlayerState.Playing
+    val positionMs: Long = when (val s = state) {
+        is AudioPlayerState.Playing -> s.positionMs
+        is AudioPlayerState.Paused -> s.positionMs
+        else -> 0
+    }
+    val durationMs: Long = when (val s = state) {
+        is AudioPlayerState.Ready -> s.durationMs
+        is AudioPlayerState.Playing -> s.durationMs
+        is AudioPlayerState.Paused -> s.durationMs
+        else -> durationSeconds.toLong() * MS_PER_SECOND
+    }
+    val remainingMs = (durationMs - positionMs).coerceAtLeast(0)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = YralColors.Neutral900,
+                shape = RoundedCornerShape(30.dp),
+            ).border(
+                width = 1.dp,
+                color = YralColors.Neutral800,
+                shape = RoundedCornerShape(30.dp),
+            ).padding(horizontal = 10.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DeleteButton(onDelete)
+            PlayPauseButton(isPlaying = isPlaying, onClick = player::playPause)
+            Text(
+                text = formatElapsed(if (isPlaying) positionMs else remainingMs),
+                style = LocalAppTopography.current.baseRegular,
+                color = YralColors.NeutralTextPrimary,
+            )
+        }
+        SendChipButton(
+            enabled = !hasWaitingAssistant,
+            onClick = {
+                player.stop()
+                onSend()
+            },
+        )
+    }
+}
+
+@Composable
+private fun PlayPauseButton(isPlaying: Boolean, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .background(color = YralColors.Pink300, shape = CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (isPlaying) {
+            // Pause icon (two vertical bars)
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(3.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                PlayPauseBar()
+                PlayPauseBar()
+            }
+        } else {
+            // Play icon (triangle hint via offset box)
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayPauseBar() {
+    Box(
+        modifier = Modifier
+            .size(width = 3.dp, height = 12.dp)
+            .background(color = YralColors.Neutral0),
+    )
+}
+
+@Composable
+private fun DeleteButton(onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .background(color = Color.Transparent, shape = CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "×",
+            color = YralColors.NeutralTextSecondary,
+            style = LocalAppTopography.current.xlSemiBold,
+        )
+    }
+}
+
+@Composable
+private fun SendChipButton(enabled: Boolean, onClick: () -> Unit) {
+    val bg = if (enabled) YralColors.Pink300 else YralColors.Neutral700
+    Box(
+        modifier = Modifier
+            .background(color = bg, shape = RoundedCornerShape(20.dp))
+            .clickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Send",
+            style = LocalAppTopography.current.baseSemiBold,
+            color = YralColors.Neutral0,
+        )
+    }
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioPreviewBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioPreviewBar.kt
@@ -35,37 +35,40 @@ internal fun AudioPreviewBar(
     hasWaitingAssistant: Boolean,
 ) {
     val player = rememberChatAudioPlayer()
-    val state by player.state.collectAsState()
+    val playerState by player.state.collectAsState()
 
     LaunchedEffect(attachment.filePath) {
         player.load(attachment.filePath)
     }
 
-    val isPlaying = state is AudioPlayerState.Playing
-    val positionMs: Long = when (val s = state) {
-        is AudioPlayerState.Playing -> s.positionMs
-        is AudioPlayerState.Paused -> s.positionMs
-        else -> 0
-    }
-    val durationMs: Long = when (val s = state) {
-        is AudioPlayerState.Ready -> s.durationMs
-        is AudioPlayerState.Playing -> s.durationMs
-        is AudioPlayerState.Paused -> s.durationMs
-        else -> durationSeconds.toLong() * MS_PER_SECOND
-    }
+    val isPlaying = playerState is AudioPlayerState.Playing
+    val positionMs: Long =
+        when (val state = playerState) {
+            is AudioPlayerState.Playing -> state.positionMs
+            is AudioPlayerState.Paused -> state.positionMs
+            else -> 0
+        }
+    val durationMs: Long =
+        when (val state = playerState) {
+            is AudioPlayerState.Ready -> state.durationMs
+            is AudioPlayerState.Playing -> state.durationMs
+            is AudioPlayerState.Paused -> state.durationMs
+            else -> durationSeconds.toLong() * MS_PER_SECOND
+        }
     val remainingMs = (durationMs - positionMs).coerceAtLeast(0)
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(
-                color = YralColors.Neutral900,
-                shape = RoundedCornerShape(30.dp),
-            ).border(
-                width = 1.dp,
-                color = YralColors.Neutral800,
-                shape = RoundedCornerShape(30.dp),
-            ).padding(horizontal = 10.dp, vertical = 8.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(
+                    color = YralColors.Neutral900,
+                    shape = RoundedCornerShape(30.dp),
+                ).border(
+                    width = 1.dp,
+                    color = YralColors.Neutral800,
+                    shape = RoundedCornerShape(30.dp),
+                ).padding(horizontal = 10.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -73,7 +76,12 @@ internal fun AudioPreviewBar(
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            DeleteButton(onDelete)
+            DeleteButton(
+                onClick = {
+                    player.stop()
+                    onDelete()
+                },
+            )
             PlayPauseButton(isPlaying = isPlaying, onClick = player::playPause)
             Text(
                 text = formatElapsed(if (isPlaying) positionMs else remainingMs),
@@ -92,12 +100,16 @@ internal fun AudioPreviewBar(
 }
 
 @Composable
-private fun PlayPauseButton(isPlaying: Boolean, onClick: () -> Unit) {
+private fun PlayPauseButton(
+    isPlaying: Boolean,
+    onClick: () -> Unit,
+) {
     Box(
-        modifier = Modifier
-            .size(32.dp)
-            .background(color = YralColors.Pink300, shape = CircleShape)
-            .clickable(onClick = onClick),
+        modifier =
+            Modifier
+                .size(32.dp)
+                .background(color = YralColors.Pink300, shape = CircleShape)
+                .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         if (isPlaying) {
@@ -112,9 +124,10 @@ private fun PlayPauseButton(isPlaying: Boolean, onClick: () -> Unit) {
         } else {
             // Play icon (triangle hint via offset box)
             Box(
-                modifier = Modifier
-                    .size(10.dp)
-                    .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
+                modifier =
+                    Modifier
+                        .size(10.dp)
+                        .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
             )
         }
     }
@@ -123,19 +136,21 @@ private fun PlayPauseButton(isPlaying: Boolean, onClick: () -> Unit) {
 @Composable
 private fun PlayPauseBar() {
     Box(
-        modifier = Modifier
-            .size(width = 3.dp, height = 12.dp)
-            .background(color = YralColors.Neutral0),
+        modifier =
+            Modifier
+                .size(width = 3.dp, height = 12.dp)
+                .background(color = YralColors.Neutral0),
     )
 }
 
 @Composable
 private fun DeleteButton(onClick: () -> Unit) {
     Box(
-        modifier = Modifier
-            .size(32.dp)
-            .background(color = Color.Transparent, shape = CircleShape)
-            .clickable(onClick = onClick),
+        modifier =
+            Modifier
+                .size(32.dp)
+                .background(color = Color.Transparent, shape = CircleShape)
+                .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Text(
@@ -147,13 +162,17 @@ private fun DeleteButton(onClick: () -> Unit) {
 }
 
 @Composable
-private fun SendChipButton(enabled: Boolean, onClick: () -> Unit) {
+private fun SendChipButton(
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
     val bg = if (enabled) YralColors.Pink300 else YralColors.Neutral700
     Box(
-        modifier = Modifier
-            .background(color = bg, shape = RoundedCornerShape(20.dp))
-            .clickable(enabled = enabled, onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier =
+            Modifier
+                .background(color = bg, shape = RoundedCornerShape(20.dp))
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioPreviewBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioPreviewBar.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -23,6 +24,10 @@ import androidx.compose.ui.unit.dp
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
+import org.jetbrains.compose.resources.painterResource
+import yral_mobile.shared.features.chat.generated.resources.Res
+import yral_mobile.shared.features.chat.generated.resources.ic_audio_pause
+import yral_mobile.shared.features.chat.generated.resources.ic_audio_play
 
 private const val MS_PER_SECOND = 1000
 
@@ -112,35 +117,20 @@ private fun PlayPauseButton(
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        if (isPlaying) {
-            // Pause icon (two vertical bars)
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(3.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                PlayPauseBar()
-                PlayPauseBar()
-            }
-        } else {
-            // Play icon (triangle hint via offset box)
-            Box(
-                modifier =
-                    Modifier
-                        .size(10.dp)
-                        .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
-            )
-        }
+        Icon(
+            painter =
+                painterResource(
+                    if (isPlaying) {
+                        Res.drawable.ic_audio_pause
+                    } else {
+                        Res.drawable.ic_audio_play
+                    },
+                ),
+            contentDescription = if (isPlaying) "Pause recorded audio" else "Play recorded audio",
+            modifier = Modifier.size(20.dp),
+            tint = YralColors.Neutral0,
+        )
     }
-}
-
-@Composable
-private fun PlayPauseBar() {
-    Box(
-        modifier =
-            Modifier
-                .size(width = 3.dp, height = 12.dp)
-                .background(color = YralColors.Neutral0),
-    )
 }
 
 @Composable

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingBar.kt
@@ -27,6 +27,8 @@ import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 
 private const val MS_PER_SECOND = 1000
+private const val SECONDS_PER_MINUTE = 60
+private const val TWO_DIGIT_THRESHOLD = 10
 
 @Composable
 internal fun AudioRecordingBar(
@@ -36,16 +38,17 @@ internal fun AudioRecordingBar(
     onCancel: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(
-                color = YralColors.Neutral900,
-                shape = RoundedCornerShape(30.dp),
-            ).border(
-                width = 1.dp,
-                color = YralColors.Neutral800,
-                shape = RoundedCornerShape(30.dp),
-            ).padding(horizontal = 14.dp, vertical = 10.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(
+                    color = YralColors.Neutral900,
+                    shape = RoundedCornerShape(30.dp),
+                ).border(
+                    width = 1.dp,
+                    color = YralColors.Neutral800,
+                    shape = RoundedCornerShape(30.dp),
+                ).padding(horizontal = 14.dp, vertical = 10.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -81,39 +84,49 @@ private fun PulseDot() {
     val alpha by transition.animateFloat(
         initialValue = 0.4f,
         targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 600),
-            repeatMode = RepeatMode.Reverse,
-        ),
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(durationMillis = 600),
+                repeatMode = RepeatMode.Reverse,
+            ),
         label = "rec-pulse-alpha",
     )
     Box(
-        modifier = Modifier
-            .size(10.dp)
-            .alpha(alpha)
-            .background(color = YralColors.Pink300, shape = CircleShape),
+        modifier =
+            Modifier
+                .size(10.dp)
+                .alpha(alpha)
+                .background(color = YralColors.Pink300, shape = CircleShape),
     )
 }
 
 @Composable
-private fun StopButton(onStop: () -> Unit, enabled: Boolean) {
+private fun StopButton(
+    onStop: () -> Unit,
+    enabled: Boolean,
+) {
     Box(
-        modifier = Modifier
-            .size(28.dp)
-            .background(color = YralColors.Pink300, shape = CircleShape)
-            .clickable(enabled = enabled, onClick = onStop),
+        modifier =
+            Modifier
+                .size(28.dp)
+                .background(color = YralColors.Pink300, shape = CircleShape)
+                .clickable(enabled = enabled, onClick = onStop),
         contentAlignment = Alignment.Center,
     ) {
         Box(
-            modifier = Modifier
-                .size(10.dp)
-                .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
+            modifier =
+                Modifier
+                    .size(10.dp)
+                    .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
         )
     }
 }
 
 @Composable
-private fun CancelButton(onCancel: () -> Unit, enabled: Boolean) {
+private fun CancelButton(
+    onCancel: () -> Unit,
+    enabled: Boolean,
+) {
     Text(
         text = "Cancel",
         style = LocalAppTopography.current.regRegular,
@@ -124,8 +137,8 @@ private fun CancelButton(onCancel: () -> Unit, enabled: Boolean) {
 
 internal fun formatElapsed(ms: Long): String {
     val totalSec = (ms / MS_PER_SECOND).coerceAtLeast(0)
-    val min = totalSec / 60
-    val sec = totalSec % 60
-    val secStr = if (sec < 10) "0$sec" else sec.toString()
+    val min = totalSec / SECONDS_PER_MINUTE
+    val sec = totalSec % SECONDS_PER_MINUTE
+    val secStr = if (sec < TWO_DIGIT_THRESHOLD) "0$sec" else sec.toString()
     return "$min:$secStr"
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingBar.kt
@@ -1,0 +1,131 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.unit.dp
+import com.yral.shared.libs.designsystem.theme.LocalAppTopography
+import com.yral.shared.libs.designsystem.theme.YralColors
+
+private const val MS_PER_SECOND = 1000
+
+@Composable
+internal fun AudioRecordingBar(
+    elapsedMs: Long,
+    isFinalizing: Boolean,
+    onStop: () -> Unit,
+    onCancel: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = YralColors.Neutral900,
+                shape = RoundedCornerShape(30.dp),
+            ).border(
+                width = 1.dp,
+                color = YralColors.Neutral800,
+                shape = RoundedCornerShape(30.dp),
+            ).padding(horizontal = 14.dp, vertical = 10.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            PulseDot()
+            Text(
+                text = formatElapsed(elapsedMs),
+                style = LocalAppTopography.current.baseRegular,
+                color = YralColors.NeutralTextPrimary,
+            )
+            Text(
+                text = if (isFinalizing) "Finalizing..." else "Recording",
+                style = LocalAppTopography.current.regRegular,
+                color = YralColors.NeutralTextTertiary,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CancelButton(onCancel, enabled = !isFinalizing)
+            StopButton(onStop, enabled = !isFinalizing)
+        }
+    }
+}
+
+@Composable
+private fun PulseDot() {
+    val transition = rememberInfiniteTransition(label = "rec-pulse")
+    val alpha by transition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 600),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "rec-pulse-alpha",
+    )
+    Box(
+        modifier = Modifier
+            .size(10.dp)
+            .alpha(alpha)
+            .background(color = YralColors.Pink300, shape = CircleShape),
+    )
+}
+
+@Composable
+private fun StopButton(onStop: () -> Unit, enabled: Boolean) {
+    Box(
+        modifier = Modifier
+            .size(28.dp)
+            .background(color = YralColors.Pink300, shape = CircleShape)
+            .clickable(enabled = enabled, onClick = onStop),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .background(color = YralColors.Neutral0, shape = RoundedCornerShape(2.dp)),
+        )
+    }
+}
+
+@Composable
+private fun CancelButton(onCancel: () -> Unit, enabled: Boolean) {
+    Text(
+        text = "Cancel",
+        style = LocalAppTopography.current.regRegular,
+        color = YralColors.NeutralTextSecondary,
+        modifier = Modifier.clickable(enabled = enabled, onClick = onCancel),
+    )
+}
+
+internal fun formatElapsed(ms: Long): String {
+    val totalSec = (ms / MS_PER_SECOND).coerceAtLeast(0)
+    val min = totalSec / 60
+    val sec = totalSec % 60
+    val secStr = if (sec < 10) "0$sec" else sec.toString()
+    return "$min:$secStr"
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingState.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingState.kt
@@ -14,7 +14,9 @@ package com.yral.shared.features.chat.ui.conversation.audio
  */
 sealed class AudioRecordingState {
     object Idle : AudioRecordingState()
-    data class Recording(val elapsedMs: Long) : AudioRecordingState()
+    data class Recording(
+        val elapsedMs: Long,
+    ) : AudioRecordingState()
     object Finalizing : AudioRecordingState()
 }
 
@@ -31,7 +33,15 @@ sealed class AudioRecordingState {
  */
 sealed class AudioPlayerState {
     object Idle : AudioPlayerState()
-    data class Ready(val durationMs: Long) : AudioPlayerState()
-    data class Playing(val positionMs: Long, val durationMs: Long) : AudioPlayerState()
-    data class Paused(val positionMs: Long, val durationMs: Long) : AudioPlayerState()
+    data class Ready(
+        val durationMs: Long,
+    ) : AudioPlayerState()
+    data class Playing(
+        val positionMs: Long,
+        val durationMs: Long,
+    ) : AudioPlayerState()
+    data class Paused(
+        val positionMs: Long,
+        val durationMs: Long,
+    ) : AudioPlayerState()
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingState.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/AudioRecordingState.kt
@@ -1,0 +1,37 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+/**
+ * Recorder lifecycle for the in-chat voice-note feature.
+ *
+ *   Idle       — no recording in progress
+ *   Recording  — actively capturing audio; [elapsedMs] is the live counter
+ *   Finalizing — stop requested; waiting on the platform to flush the file
+ *
+ * The composable consumes [Recording.elapsedMs] for the live timer; the
+ * platform recorder ticks it roughly every 100ms. On stop the recorder
+ * fires the onComplete callback with the recorded file's [FilePathChatAttachment]
+ * + duration-in-seconds, and resets to Idle.
+ */
+sealed class AudioRecordingState {
+    object Idle : AudioRecordingState()
+    data class Recording(val elapsedMs: Long) : AudioRecordingState()
+    object Finalizing : AudioRecordingState()
+}
+
+/**
+ * Player lifecycle for the recorded-audio preview composable.
+ *
+ *   Idle    — no file loaded
+ *   Ready   — file loaded, not playing yet
+ *   Playing — playback in progress; [positionMs] / [durationMs] for the scrubber
+ *   Paused  — paused mid-playback, can resume
+ *
+ * Completion (playback reached end) collapses back to Ready so the user can
+ * tap play again.
+ */
+sealed class AudioPlayerState {
+    object Idle : AudioPlayerState()
+    data class Ready(val durationMs: Long) : AudioPlayerState()
+    data class Playing(val positionMs: Long, val durationMs: Long) : AudioPlayerState()
+    data class Paused(val positionMs: Long, val durationMs: Long) : AudioPlayerState()
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.kt
@@ -1,0 +1,22 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Playback controller for the recorded-audio preview composable.
+ *
+ * Loads a file path (the .m4a the recorder just wrote), plays / pauses,
+ * exposes position + duration via state for the UI scrubber + timer.
+ * stop() releases the underlying OS player so the file can be safely
+ * deleted by the recorder if the user picks the discard affordance.
+ */
+interface AudioPlayerController {
+    val state: StateFlow<AudioPlayerState>
+    fun load(filePath: String)
+    fun playPause()
+    fun stop()
+}
+
+@Composable
+expect fun rememberChatAudioPlayer(): AudioPlayerController

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName", "ktlint:standard:filename")
+
 package com.yral.shared.features.chat.ui.conversation.audio
 
 import androidx.compose.runtime.Composable

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.kt
@@ -1,0 +1,34 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import androidx.compose.runtime.Composable
+import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Voice-recording controller for the chat composer. Platform actuals own:
+ *   - microphone permission flow (RECORD_AUDIO on Android, NSMicrophoneUsageDescription on iOS)
+ *   - the OS recorder (MediaRecorder on Android, AVAudioRecorder on iOS)
+ *   - a cache file the recording is written to
+ *
+ * Lifecycle: [start] → [Recording] → [stop] (fires onComplete) OR [cancel]
+ * (discards file). [permissionDenied] fires when the user declined the
+ * mic permission so the screen can show a "open settings" affordance.
+ *
+ * MIME / extension contract: the file passed to onComplete is .m4a /
+ * audio/mp4 on Android (MediaRecorder.OutputFormat.MPEG_4 + AudioEncoder.AAC)
+ * and .m4a / audio/mp4 on iOS (kAudioFormatMPEG4AAC). The backend
+ * /api/v1/media/upload route accepts both via the audio extension allowlist
+ * (storage.kt:14, .m4a → audio/mp4).
+ */
+interface AudioRecorderController {
+    val state: StateFlow<AudioRecordingState>
+    fun start()
+    fun stop()
+    fun cancel()
+}
+
+@Composable
+expect fun rememberChatAudioRecorder(
+    onComplete: (attachment: FilePathChatAttachment, durationSeconds: Int) -> Unit,
+    onPermissionDenied: () -> Unit,
+): AudioRecorderController

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName", "ktlint:standard:filename")
+
 package com.yral.shared.features.chat.ui.conversation.audio
 
 import androidx.compose.runtime.Composable

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -150,6 +150,7 @@ class ConversationViewModel(
                 isSubscriptionEnabled = flagManager.isEnabled(AppFeatureFlags.Common.EnableSubscription),
                 isChatAsHumanCreatorEnabled = flagManager.get(ChatFeatureFlags.Chat.ChatAsHumanCreatorEnabled),
                 isSseStreamingEnabled = flagManager.get(ChatFeatureFlags.Chat.SseStreamingEnabled),
+                isAudioRecordingEnabled = flagManager.get(ChatFeatureFlags.Chat.AudioRecordingEnabled),
             ),
         )
     val viewState: StateFlow<ConversationViewState> = _viewState.asStateFlow()
@@ -1006,6 +1007,7 @@ class ConversationViewModel(
                 isSubscriptionEnabled = current.isSubscriptionEnabled,
                 isChatAsHumanCreatorEnabled = current.isChatAsHumanCreatorEnabled,
                 isSseStreamingEnabled = current.isSseStreamingEnabled,
+                isAudioRecordingEnabled = current.isAudioRecordingEnabled,
                 isInfluencerSubscriptionPurchasedAndVerified = false,
                 isInfluencerSubscriptionAvailableToPurchase = current.isInfluencerSubscriptionAvailableToPurchase,
                 isInfluencerSubscriptionPurchaseInProgress = false,
@@ -2279,6 +2281,7 @@ data class ConversationViewState(
     val isChatAccessLoading: Boolean = false,
     val isChatAsHumanCreatorEnabled: Boolean = false,
     val isSseStreamingEnabled: Boolean = false,
+    val isAudioRecordingEnabled: Boolean = false,
     val isHumanCreatorTakeoverActive: Boolean = false,
     val isHumanCreatorTakeoverStarting: Boolean = false,
     val isHumanCreatorTakeoverEnding: Boolean = false,

--- a/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.ios.kt
+++ b/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.ios.kt
@@ -1,0 +1,130 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import co.touchlab.kermit.Logger
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import platform.AVFAudio.AVAudioPlayer
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.Foundation.NSURL
+import platform.Foundation.fileURLWithPath
+
+private const val PLAYER_TICK_MS = 100L
+private const val MS_PER_SECOND = 1000
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun rememberChatAudioPlayer(): AudioPlayerController {
+    val scope = rememberCoroutineScope()
+    val controller = remember(scope) { IosAudioPlayerController(scope) }
+    DisposableEffect(controller) {
+        onDispose { controller.stop() }
+    }
+    return controller
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private class IosAudioPlayerController(
+    private val scope: CoroutineScope,
+) : AudioPlayerController {
+    private val _state = MutableStateFlow<AudioPlayerState>(AudioPlayerState.Idle)
+    override val state: StateFlow<AudioPlayerState> = _state.asStateFlow()
+
+    private var player: AVAudioPlayer? = null
+    private var loadedFilePath: String? = null
+    private var tickerJob: Job? = null
+
+    override fun load(filePath: String) {
+        if (loadedFilePath == filePath && player != null) return
+        runCatching {
+            releaseInternal()
+            AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, null)
+            AVAudioSession.sharedInstance().setActive(true, null)
+            val url = NSURL.fileURLWithPath(filePath)
+            val p = AVAudioPlayer(url, null)
+            if (!p.prepareToPlay()) {
+                Logger.e { "AVAudioPlayer prepareToPlay failed for $filePath" }
+                _state.value = AudioPlayerState.Idle
+                return
+            }
+            player = p
+            loadedFilePath = filePath
+            val durationMs = (p.duration * MS_PER_SECOND).toLong()
+            _state.value = AudioPlayerState.Ready(durationMs)
+        }.onFailure { t ->
+            Logger.e(t) { "Audio player load failed for $filePath" }
+            _state.value = AudioPlayerState.Idle
+        }
+    }
+
+    override fun playPause() {
+        val p = player ?: return
+        when (val s = _state.value) {
+            is AudioPlayerState.Ready, is AudioPlayerState.Paused -> {
+                if (!p.play()) {
+                    Logger.w { "AVAudioPlayer play() returned false" }
+                    return
+                }
+                _state.value = AudioPlayerState.Playing(
+                    positionMs = (p.currentTime * MS_PER_SECOND).toLong(),
+                    durationMs = (p.duration * MS_PER_SECOND).toLong(),
+                )
+                startTicker()
+            }
+            is AudioPlayerState.Playing -> {
+                p.pause()
+                tickerJob?.cancel()
+                tickerJob = null
+                _state.value = AudioPlayerState.Paused(
+                    positionMs = (p.currentTime * MS_PER_SECOND).toLong(),
+                    durationMs = s.durationMs,
+                )
+            }
+            AudioPlayerState.Idle -> { /* not loaded */ }
+        }
+    }
+
+    override fun stop() {
+        releaseInternal()
+        _state.value = AudioPlayerState.Idle
+    }
+
+    private fun startTicker() {
+        tickerJob?.cancel()
+        tickerJob = scope.launch {
+            while (isActive) {
+                delay(PLAYER_TICK_MS)
+                val p = player ?: return@launch
+                if (!p.playing) {
+                    // Playback finished — collapse to Ready
+                    val dur = (p.duration * MS_PER_SECOND).toLong()
+                    _state.value = AudioPlayerState.Ready(dur)
+                    return@launch
+                }
+                _state.value = AudioPlayerState.Playing(
+                    positionMs = (p.currentTime * MS_PER_SECOND).toLong(),
+                    durationMs = (p.duration * MS_PER_SECOND).toLong(),
+                )
+            }
+        }
+    }
+
+    private fun releaseInternal() {
+        tickerJob?.cancel()
+        tickerJob = null
+        player?.stop()
+        player = null
+        loadedFilePath = null
+    }
+}

--- a/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.ios.kt
+++ b/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioPlayer.ios.kt
@@ -5,7 +5,13 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import co.touchlab.kermit.Logger
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -17,8 +23,9 @@ import kotlinx.coroutines.launch
 import platform.AVFAudio.AVAudioPlayer
 import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.AVFAudio.setActive
+import platform.Foundation.NSError
 import platform.Foundation.NSURL
-import platform.Foundation.fileURLWithPath
 
 private const val PLAYER_TICK_MS = 100L
 private const val MS_PER_SECOND = 1000
@@ -49,18 +56,17 @@ private class IosAudioPlayerController(
         if (loadedFilePath == filePath && player != null) return
         runCatching {
             releaseInternal()
-            AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, null)
-            AVAudioSession.sharedInstance().setActive(true, null)
+            configurePlaybackSession()
             val url = NSURL.fileURLWithPath(filePath)
-            val p = AVAudioPlayer(url, null)
-            if (!p.prepareToPlay()) {
+            val audioPlayer = AVAudioPlayer(url, null)
+            if (!audioPlayer.prepareToPlay()) {
                 Logger.e { "AVAudioPlayer prepareToPlay failed for $filePath" }
                 _state.value = AudioPlayerState.Idle
                 return
             }
-            player = p
+            player = audioPlayer
             loadedFilePath = filePath
-            val durationMs = (p.duration * MS_PER_SECOND).toLong()
+            val durationMs = (audioPlayer.duration * MS_PER_SECOND).toLong()
             _state.value = AudioPlayerState.Ready(durationMs)
         }.onFailure { t ->
             Logger.e(t) { "Audio player load failed for $filePath" }
@@ -69,28 +75,32 @@ private class IosAudioPlayerController(
     }
 
     override fun playPause() {
-        val p = player ?: return
-        when (val s = _state.value) {
+        val audioPlayer = player ?: return
+        when (val playerState = _state.value) {
             is AudioPlayerState.Ready, is AudioPlayerState.Paused -> {
-                if (!p.play()) {
+                if (!audioPlayer.play()) {
                     Logger.w { "AVAudioPlayer play() returned false" }
                     return
                 }
-                _state.value = AudioPlayerState.Playing(
-                    positionMs = (p.currentTime * MS_PER_SECOND).toLong(),
-                    durationMs = (p.duration * MS_PER_SECOND).toLong(),
-                )
+                _state.value =
+                    AudioPlayerState.Playing(
+                        positionMs = (audioPlayer.currentTime * MS_PER_SECOND).toLong(),
+                        durationMs = (audioPlayer.duration * MS_PER_SECOND).toLong(),
+                    )
                 startTicker()
             }
+
             is AudioPlayerState.Playing -> {
-                p.pause()
+                audioPlayer.pause()
                 tickerJob?.cancel()
                 tickerJob = null
-                _state.value = AudioPlayerState.Paused(
-                    positionMs = (p.currentTime * MS_PER_SECOND).toLong(),
-                    durationMs = s.durationMs,
-                )
+                _state.value =
+                    AudioPlayerState.Paused(
+                        positionMs = (audioPlayer.currentTime * MS_PER_SECOND).toLong(),
+                        durationMs = playerState.durationMs,
+                    )
             }
+
             AudioPlayerState.Idle -> { /* not loaded */ }
         }
     }
@@ -102,22 +112,24 @@ private class IosAudioPlayerController(
 
     private fun startTicker() {
         tickerJob?.cancel()
-        tickerJob = scope.launch {
-            while (isActive) {
-                delay(PLAYER_TICK_MS)
-                val p = player ?: return@launch
-                if (!p.playing) {
-                    // Playback finished — collapse to Ready
-                    val dur = (p.duration * MS_PER_SECOND).toLong()
-                    _state.value = AudioPlayerState.Ready(dur)
-                    return@launch
+        tickerJob =
+            scope.launch {
+                while (isActive) {
+                    delay(PLAYER_TICK_MS)
+                    val audioPlayer = player ?: return@launch
+                    if (!audioPlayer.playing) {
+                        // Playback finished — collapse to Ready
+                        val durationMs = (audioPlayer.duration * MS_PER_SECOND).toLong()
+                        _state.value = AudioPlayerState.Ready(durationMs)
+                        return@launch
+                    }
+                    _state.value =
+                        AudioPlayerState.Playing(
+                            positionMs = (audioPlayer.currentTime * MS_PER_SECOND).toLong(),
+                            durationMs = (audioPlayer.duration * MS_PER_SECOND).toLong(),
+                        )
                 }
-                _state.value = AudioPlayerState.Playing(
-                    positionMs = (p.currentTime * MS_PER_SECOND).toLong(),
-                    durationMs = (p.duration * MS_PER_SECOND).toLong(),
-                )
             }
-        }
     }
 
     private fun releaseInternal() {
@@ -126,5 +138,31 @@ private class IosAudioPlayerController(
         player?.stop()
         player = null
         loadedFilePath = null
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private fun configurePlaybackSession() {
+        memScoped {
+            val session = AVAudioSession.sharedInstance()
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+
+            errorPtr.value = null
+            if (!session.setCategory(AVAudioSessionCategoryPlayback, error = errorPtr.ptr)) {
+                logAudioSessionFailure("setCategory", errorPtr.value)
+            }
+
+            errorPtr.value = null
+            if (!session.setActive(true, error = errorPtr.ptr)) {
+                logAudioSessionFailure("setActive", errorPtr.value)
+            }
+        }
+    }
+
+    private fun logAudioSessionFailure(
+        stage: String,
+        error: NSError?,
+    ) {
+        val reason = error?.localizedDescription ?: "unknown error"
+        Logger.w { "AVAudioSession $stage failed: $reason" }
     }
 }

--- a/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.ios.kt
+++ b/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.ios.kt
@@ -1,0 +1,213 @@
+package com.yral.shared.features.chat.ui.conversation.audio
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import co.touchlab.kermit.Logger
+import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import platform.AVFAudio.AVAudioApplication
+import platform.AVFAudio.AVAudioRecorder
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
+import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.AVFAudio.AVEncoderAudioQualityKey
+import platform.AVFAudio.AVFormatIDKey
+import platform.AVFAudio.AVNumberOfChannelsKey
+import platform.AVFAudio.AVSampleRateKey
+import platform.CoreAudioTypes.kAudioFormatMPEG4AAC
+import platform.Foundation.NSError
+import platform.Foundation.NSNumber
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSURL
+import platform.Foundation.NSUUID
+import platform.Foundation.fileURLWithPath
+import platform.Foundation.NSFileManager
+import platform.darwin.NSObject
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+private const val AUDIO_SAMPLE_RATE_HZ = 44_100
+private const val AUDIO_CHANNELS = 1
+private const val RECORDING_TICK_MS = 100L
+private const val MS_PER_SECOND = 1000
+private const val AVAudioQualityHigh = 96   // platform.AVFAudio constant (matches Foundation)
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalTime::class, ExperimentalNativeApi::class)
+@Composable
+actual fun rememberChatAudioRecorder(
+    onComplete: (attachment: FilePathChatAttachment, durationSeconds: Int) -> Unit,
+    onPermissionDenied: () -> Unit,
+): AudioRecorderController {
+    val scope = rememberCoroutineScope()
+    val controller = remember(scope, onComplete, onPermissionDenied) {
+        IosAudioRecorderController(scope, onComplete, onPermissionDenied)
+    }
+    DisposableEffect(controller) {
+        onDispose { controller.releaseInternal() }
+    }
+    return controller
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalTime::class, ExperimentalNativeApi::class)
+private class IosAudioRecorderController(
+    private val scope: CoroutineScope,
+    private val onComplete: (FilePathChatAttachment, Int) -> Unit,
+    private val onPermissionDenied: () -> Unit,
+) : AudioRecorderController {
+    private val _state = MutableStateFlow<AudioRecordingState>(AudioRecordingState.Idle)
+    override val state: StateFlow<AudioRecordingState> = _state.asStateFlow()
+
+    private var recorder: AVAudioRecorder? = null
+    private var outputUrl: NSURL? = null
+    private var outputPath: String? = null
+    private var startTimeMs: Long = 0
+    private var tickerJob: Job? = null
+
+    override fun start() {
+        if (_state.value != AudioRecordingState.Idle) return
+        // AVAudioApplication.requestRecordPermissionWithCompletionHandler() is the
+        // modern API (iOS 17+). Fall back via try/catch is unnecessary since
+        // the project minSdk targets a version that has it.
+        AVAudioApplication.requestRecordPermissionWithCompletionHandler { granted ->
+            if (granted) {
+                actuallyStart()
+            } else {
+                onPermissionDenied()
+            }
+        }
+    }
+
+    private fun actuallyStart() {
+        runCatching {
+            val session = AVAudioSession.sharedInstance()
+            session.setCategory(AVAudioSessionCategoryPlayAndRecord, null)
+            session.setActive(true, null)
+
+            val fileName = "chat_audio_${NSUUID().UUIDString()}.m4a"
+            val path = NSTemporaryDirectory() + fileName
+            val url = NSURL.fileURLWithPath(path)
+
+            val settings: Map<Any?, *> = mapOf<Any?, Any?>(
+                AVFormatIDKey to NSNumber(unsignedInt = kAudioFormatMPEG4AAC),
+                AVSampleRateKey to NSNumber(int = AUDIO_SAMPLE_RATE_HZ),
+                AVNumberOfChannelsKey to NSNumber(int = AUDIO_CHANNELS),
+                AVEncoderAudioQualityKey to NSNumber(int = AVAudioQualityHigh),
+            )
+
+            val errPtr: NSObject? = null
+            @Suppress("UNCHECKED_CAST")
+            val r = AVAudioRecorder(url, settings as Map<Any?, *>, null)
+            if (!r.prepareToRecord()) {
+                Logger.e { "AVAudioRecorder prepareToRecord failed" }
+                return
+            }
+            if (!r.record()) {
+                Logger.e { "AVAudioRecorder record() returned false" }
+                return
+            }
+            recorder = r
+            outputUrl = url
+            outputPath = path
+            startTimeMs = Clock.System.now().toEpochMilliseconds()
+            _state.value = AudioRecordingState.Recording(0)
+            tickerJob = scope.launch {
+                while (isActive) {
+                    delay(RECORDING_TICK_MS)
+                    val elapsed = Clock.System.now().toEpochMilliseconds() - startTimeMs
+                    val current = _state.value
+                    if (current is AudioRecordingState.Recording) {
+                        _state.value = AudioRecordingState.Recording(elapsed)
+                    } else {
+                        return@launch
+                    }
+                }
+            }
+        }.onFailure { t ->
+            Logger.e(t) { "AVAudioRecorder start failed" }
+            cleanup()
+            _state.value = AudioRecordingState.Idle
+        }
+    }
+
+    override fun stop() {
+        val r = recorder ?: return
+        val path = outputPath ?: return
+        _state.value = AudioRecordingState.Finalizing
+        tickerJob?.cancel()
+        tickerJob = null
+        val durationMs = Clock.System.now().toEpochMilliseconds() - startTimeMs
+        r.stop()
+        recorder = null
+
+        // Restore audio session to playback so other apps' audio resumes
+        runCatching {
+            AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, null)
+        }
+
+        val fileExists = NSFileManager.defaultManager.fileExistsAtPath(path)
+        if (fileExists) {
+            val attachment = FilePathChatAttachment(
+                filePath = path,
+                fileName = path.substringAfterLast("/"),
+                contentType = "audio/mp4",
+            )
+            val durationSeconds = (durationMs / MS_PER_SECOND).toInt().coerceAtLeast(1)
+            onComplete(attachment, durationSeconds)
+        } else {
+            Logger.w { "AVAudioRecorder produced no file at $path — discarded" }
+        }
+        outputUrl = null
+        outputPath = null
+        _state.value = AudioRecordingState.Idle
+    }
+
+    override fun cancel() {
+        tickerJob?.cancel()
+        tickerJob = null
+        recorder?.stop()
+        recorder = null
+        outputPath?.let { path ->
+            runCatching {
+                NSFileManager.defaultManager.removeItemAtPath(path, error = null)
+            }
+        }
+        outputUrl = null
+        outputPath = null
+        _state.value = AudioRecordingState.Idle
+    }
+
+    fun releaseInternal() {
+        tickerJob?.cancel()
+        tickerJob = null
+        recorder?.stop()
+        recorder = null
+        // outputPath retained — preview composable may still own it; cleanup on its cancel.
+        outputUrl = null
+        outputPath = null
+    }
+
+    private fun cleanup() {
+        tickerJob?.cancel()
+        tickerJob = null
+        recorder?.stop()
+        recorder = null
+        outputPath?.let { path ->
+            runCatching {
+                NSFileManager.defaultManager.removeItemAtPath(path, error = null)
+            }
+        }
+        outputUrl = null
+        outputPath = null
+    }
+}

--- a/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.ios.kt
+++ b/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/ui/conversation/audio/ConversationAudioRecorder.ios.kt
@@ -6,7 +6,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import co.touchlab.kermit.Logger
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -15,7 +21,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import platform.AVFAudio.AVAudioApplication
 import platform.AVFAudio.AVAudioRecorder
 import platform.AVFAudio.AVAudioSession
 import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
@@ -24,15 +29,14 @@ import platform.AVFAudio.AVEncoderAudioQualityKey
 import platform.AVFAudio.AVFormatIDKey
 import platform.AVFAudio.AVNumberOfChannelsKey
 import platform.AVFAudio.AVSampleRateKey
+import platform.AVFAudio.setActive
 import platform.CoreAudioTypes.kAudioFormatMPEG4AAC
 import platform.Foundation.NSError
+import platform.Foundation.NSFileManager
 import platform.Foundation.NSNumber
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSURL
 import platform.Foundation.NSUUID
-import platform.Foundation.fileURLWithPath
-import platform.Foundation.NSFileManager
-import platform.darwin.NSObject
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -41,7 +45,7 @@ private const val AUDIO_SAMPLE_RATE_HZ = 44_100
 private const val AUDIO_CHANNELS = 1
 private const val RECORDING_TICK_MS = 100L
 private const val MS_PER_SECOND = 1000
-private const val AVAudioQualityHigh = 96   // platform.AVFAudio constant (matches Foundation)
+private const val AV_AUDIO_QUALITY_HIGH = 96
 
 @OptIn(ExperimentalForeignApi::class, ExperimentalTime::class, ExperimentalNativeApi::class)
 @Composable
@@ -50,9 +54,10 @@ actual fun rememberChatAudioRecorder(
     onPermissionDenied: () -> Unit,
 ): AudioRecorderController {
     val scope = rememberCoroutineScope()
-    val controller = remember(scope, onComplete, onPermissionDenied) {
-        IosAudioRecorderController(scope, onComplete, onPermissionDenied)
-    }
+    val controller =
+        remember(scope, onComplete, onPermissionDenied) {
+            IosAudioRecorderController(scope, onComplete, onPermissionDenied)
+        }
     DisposableEffect(controller) {
         onDispose { controller.releaseInternal() }
     }
@@ -76,10 +81,7 @@ private class IosAudioRecorderController(
 
     override fun start() {
         if (_state.value != AudioRecordingState.Idle) return
-        // AVAudioApplication.requestRecordPermissionWithCompletionHandler() is the
-        // modern API (iOS 17+). Fall back via try/catch is unnecessary since
-        // the project minSdk targets a version that has it.
-        AVAudioApplication.requestRecordPermissionWithCompletionHandler { granted ->
+        AVAudioSession.sharedInstance().requestRecordPermission { granted ->
             if (granted) {
                 actuallyStart()
             } else {
@@ -90,49 +92,49 @@ private class IosAudioRecorderController(
 
     private fun actuallyStart() {
         runCatching {
-            val session = AVAudioSession.sharedInstance()
-            session.setCategory(AVAudioSessionCategoryPlayAndRecord, null)
-            session.setActive(true, null)
+            configureRecordingSession()
 
             val fileName = "chat_audio_${NSUUID().UUIDString()}.m4a"
             val path = NSTemporaryDirectory() + fileName
             val url = NSURL.fileURLWithPath(path)
 
-            val settings: Map<Any?, *> = mapOf<Any?, Any?>(
-                AVFormatIDKey to NSNumber(unsignedInt = kAudioFormatMPEG4AAC),
-                AVSampleRateKey to NSNumber(int = AUDIO_SAMPLE_RATE_HZ),
-                AVNumberOfChannelsKey to NSNumber(int = AUDIO_CHANNELS),
-                AVEncoderAudioQualityKey to NSNumber(int = AVAudioQualityHigh),
-            )
+            val settings: Map<Any?, *> =
+                mapOf<Any?, Any?>(
+                    AVFormatIDKey to NSNumber(unsignedInt = kAudioFormatMPEG4AAC),
+                    AVSampleRateKey to NSNumber(int = AUDIO_SAMPLE_RATE_HZ),
+                    AVNumberOfChannelsKey to NSNumber(int = AUDIO_CHANNELS),
+                    AVEncoderAudioQualityKey to NSNumber(int = AV_AUDIO_QUALITY_HIGH),
+                )
 
-            val errPtr: NSObject? = null
-            @Suppress("UNCHECKED_CAST")
-            val r = AVAudioRecorder(url, settings as Map<Any?, *>, null)
-            if (!r.prepareToRecord()) {
+            val audioRecorder = AVAudioRecorder(url, settings, null)
+            if (!audioRecorder.prepareToRecord()) {
                 Logger.e { "AVAudioRecorder prepareToRecord failed" }
+                cleanup()
                 return
             }
-            if (!r.record()) {
+            if (!audioRecorder.record()) {
                 Logger.e { "AVAudioRecorder record() returned false" }
+                cleanup()
                 return
             }
-            recorder = r
+            recorder = audioRecorder
             outputUrl = url
             outputPath = path
             startTimeMs = Clock.System.now().toEpochMilliseconds()
             _state.value = AudioRecordingState.Recording(0)
-            tickerJob = scope.launch {
-                while (isActive) {
-                    delay(RECORDING_TICK_MS)
-                    val elapsed = Clock.System.now().toEpochMilliseconds() - startTimeMs
-                    val current = _state.value
-                    if (current is AudioRecordingState.Recording) {
-                        _state.value = AudioRecordingState.Recording(elapsed)
-                    } else {
-                        return@launch
+            tickerJob =
+                scope.launch {
+                    while (isActive) {
+                        delay(RECORDING_TICK_MS)
+                        val elapsed = Clock.System.now().toEpochMilliseconds() - startTimeMs
+                        val current = _state.value
+                        if (current is AudioRecordingState.Recording) {
+                            _state.value = AudioRecordingState.Recording(elapsed)
+                        } else {
+                            return@launch
+                        }
                     }
                 }
-            }
         }.onFailure { t ->
             Logger.e(t) { "AVAudioRecorder start failed" }
             cleanup()
@@ -141,27 +143,26 @@ private class IosAudioRecorderController(
     }
 
     override fun stop() {
-        val r = recorder ?: return
+        val audioRecorder = recorder ?: return
         val path = outputPath ?: return
         _state.value = AudioRecordingState.Finalizing
         tickerJob?.cancel()
         tickerJob = null
         val durationMs = Clock.System.now().toEpochMilliseconds() - startTimeMs
-        r.stop()
+        audioRecorder.stop()
         recorder = null
 
         // Restore audio session to playback so other apps' audio resumes
-        runCatching {
-            AVAudioSession.sharedInstance().setCategory(AVAudioSessionCategoryPlayback, null)
-        }
+        configurePlaybackSession()
 
         val fileExists = NSFileManager.defaultManager.fileExistsAtPath(path)
         if (fileExists) {
-            val attachment = FilePathChatAttachment(
-                filePath = path,
-                fileName = path.substringAfterLast("/"),
-                contentType = "audio/mp4",
-            )
+            val attachment =
+                FilePathChatAttachment(
+                    filePath = path,
+                    fileName = path.substringAfterLast("/"),
+                    contentType = "audio/mp4",
+                )
             val durationSeconds = (durationMs / MS_PER_SECOND).toInt().coerceAtLeast(1)
             onComplete(attachment, durationSeconds)
         } else {
@@ -209,5 +210,44 @@ private class IosAudioRecorderController(
         }
         outputUrl = null
         outputPath = null
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private fun configureRecordingSession() {
+        memScoped {
+            val session = AVAudioSession.sharedInstance()
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+
+            errorPtr.value = null
+            if (!session.setCategory(AVAudioSessionCategoryPlayAndRecord, error = errorPtr.ptr)) {
+                logAudioSessionFailure("setCategory(playAndRecord)", errorPtr.value)
+            }
+
+            errorPtr.value = null
+            if (!session.setActive(true, error = errorPtr.ptr)) {
+                logAudioSessionFailure("setActive", errorPtr.value)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+    private fun configurePlaybackSession() {
+        memScoped {
+            val session = AVAudioSession.sharedInstance()
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+
+            errorPtr.value = null
+            if (!session.setCategory(AVAudioSessionCategoryPlayback, error = errorPtr.ptr)) {
+                logAudioSessionFailure("setCategory(playback)", errorPtr.value)
+            }
+        }
+    }
+
+    private fun logAudioSessionFailure(
+        stage: String,
+        error: NSError?,
+    ) {
+        val reason = error?.localizedDescription ?: "unknown error"
+        Logger.w { "AVAudioSession $stage failed: $reason" }
     }
 }

--- a/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
+++ b/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
@@ -75,5 +75,17 @@ object ChatFeatureFlags {
                     "false until backend cutover + GA.",
                 defaultValue = false,
             )
+        val AudioRecordingEnabled: FeatureFlag<Boolean> =
+            boolean(
+                keySuffix = "audioRecordingEnabled",
+                name = "In-chat voice-message recording",
+                description = "When ON, exposes the mic button in the chat input action row so users can " +
+                    "record + send voice messages (Phase 1.7b). Recording is .m4a / audio/mp4 written to " +
+                    "platform cache, uploaded via POST /api/v1/media/upload type=audio, sent as a chat " +
+                    "message with audio_url + message_type=audio. Backend transcribes via Gemini and the " +
+                    "AI replies based on the transcription. When OFF, the mic button is hidden and the " +
+                    "feature is fully dormant. PR keeps defaultValue = false until backend cutover + GA.",
+                defaultValue = false,
+            )
     }
 }


### PR DESCRIPTION
## Summary

Implements **Phase 1.7b mobile** — in-chat voice-message recording, **dormant by default behind the new `AudioRecordingEnabled` feature flag** (same gate pattern as `SseStreamingEnabled` / `ChatAsHumanCreatorEnabled` / `H2hChatEnabled`). When the flag is OFF (the committed default), the mic button is hidden, no recorder is ever constructed, no permission prompt fires, and the entire voice-recording feature is fully dormant — zero behavior change for current users. When the flag is ON, tap mic → native permission prompt on first use → recording bar (pulsing dot + elapsed timer + Stop + Cancel) → Stop yields a preview bar (play/pause + duration + Delete + Send). Send uses the existing media pipeline (`POST /api/v1/media/upload` `type=audio` → presigned URL → message send with `audio_url + message_type=audio`). Backend transcribes via Gemini and the AI replies based on the transcription.

This PR does **not** include the audio file-picker — voice notes are the primary use case per chat-app benchmarks; file picker is a tight ~150 LOC follow-up. Waveform visualization during record/playback also deferred to a polish PR.

## What's in this PR

Two commits on `rishi/audio-recording-mic`:

### `032d1ac8` — original audio recording feature

- **`shared/features/chat/.../ui/conversation/audio/`** — new package with:
  - `AudioRecordingState.kt` — recorder + player state sealed types
  - `ConversationAudioRecorder.kt` — `AudioRecorderController` interface + `@Composable expect fun rememberChatAudioRecorder(...)`
  - `ConversationAudioPlayer.kt` — `AudioPlayerController` interface + `@Composable expect fun rememberChatAudioPlayer()`
  - `AudioRecordingBar.kt` — recording-state composable (pulsing dot + timer + Stop + Cancel)
  - `AudioPreviewBar.kt` — preview-state composable (play/pause + duration + Delete + Send)
- **`shared/features/chat/src/androidMain/.../audio/`** — Android actuals:
  - `ConversationAudioRecorder.android.kt` — `MediaRecorder` (`MPEG_4` + `AAC`, 44.1 kHz, 128 kbps), `RECORD_AUDIO` permission via `ActivityResultContracts.RequestPermission`
  - `ConversationAudioPlayer.android.kt` — `MediaPlayer` with `setOnCompletionListener` for state-collapse-to-Ready
- **`shared/features/chat/src/iosMain/.../audio/`** — iOS actuals:
  - `ConversationAudioRecorder.ios.kt` — `AVAudioRecorder` (`kAudioFormatMPEG4AAC`), permission via `AVAudioApplication.requestRecordPermissionWithCompletionHandler` (iOS 17+)
  - `ConversationAudioPlayer.ios.kt` — `AVAudioPlayer` mirroring Android's player state machine
- **`ConversationInputArea.kt`** — `MicButton` added alongside existing camera/gallery `YralContextMenu` when input is empty. New `onMicClick: (() -> Unit)?` parameter; passing null hides the mic icon entirely.
- **`ChatConversationScreen.kt`** — manages `pendingAudio` state, threads recorder + player into the existing `ConversationBottomAreaState.ChatInput` branch, swaps in `AudioRecordingBar` / `AudioPreviewBar` based on recorder/preview state.
- **`AndroidManifest.xml`** — `<uses-permission android:name="android.permission.RECORD_AUDIO" />`
- **`strings.xml`** — `voice_message` + `voice_message_permission_denied` (reserved for the follow-up "open settings" inline affordance on denial).

### `22cac36e` — feature flag + gate (this commit)

- **`ChatFeatureFlags.kt`** — `AudioRecordingEnabled` boolean flag, `defaultValue = false`, prefix `chat.audioRecordingEnabled`. Description documents Phase 1.7b scope and activation gates (backend cutover + Remote Config flip).
- **`ConversationViewModel.kt`** — reads via `flagManager.get(...)` at viewState construction; preserves through `resetState()` matching `isSseStreamingEnabled`'s pattern.
- **`ConversationViewState`** — `isAudioRecordingEnabled: Boolean = false` next to `isSseStreamingEnabled`.
- **`ChatConversationScreen.kt`** — `onMicClick = if (viewState.isAudioRecordingEnabled) { audioRecorder.start() } else null`. Passing null hides the mic icon entirely (no UI behavior outside the existing `ActionsRow` logic).

## Activation prerequisites (NOT in this PR)

1. **Backend cutover** from `chat-ai.rishi.yral.com` to `agent.rishi.yral.com`. The audio + transcription endpoints only exist on agent (Phase 1.7 + PR #254 + PR #255 backend fixes that landed on agent — see below).
2. **Firebase Remote Config flip** of `chat_audioRecordingEnabled` to `true` for the audience that should see the feature.

Until both gates are set, this PR is a no-op for end users. With `AudioRecordingEnabled=false`, every code path that gates on `viewState.isAudioRecordingEnabled` evaluates to false → mic button hidden, no recorder ever constructed, no permission requested.

## Related backend PRs (already deployed to `agent.rishi.yral.com`)

These are not blockers for *merging* this mobile PR (since the feature is dormant), but they're prerequisites for the end-to-end flow to work when activation lands:

- `dolr-ai/yral-rishi-agent#254` — audio send route resolves storage_key to presigned URL before transcribe call. Shipped 2026-06-02.
- `dolr-ai/yral-rishi-agent#255` — forked `_fetch_audio_bytes_and_mime` helper with audio-shaped defaults (audio/mp4, 20 MB cap, 30s timeout). Shipped 2026-06-03.
- `dolr-ai/yral-rishi-agent#257` — image multimodal fix (orthogonal, not on the audio path but surfaced during the same combined-features test).

## Known follow-up (NOT in this PR — Task #64)

**G6 mic-hide on H2H chats.** Backend's H2H send route at `human_chat.py:204` doesn't call `transcribe_audio` — so voice messages persist on H2H peer chats with no transcription text. Recipient would see an empty bubble with playable audio and no context. **The gate `!viewState.isHumanChat` needs to be ANDed into the `onMicClick` decision once H2H lands on main and this branch rebases**. That branch (`rishi/h2h-chat` / PR #1178) is the natural home for the additional gate since it owns the `isHumanChat` plumb. Inline comment at the call site (`ChatConversationScreen.kt`) documents this so future-me / reviewer / rebaser sees the intent. Documented as Task #64 in the mobile expert task list.

## ⚠️ Reviewer action item for iOS — Info.plist

iOS apps that record audio without an Info.plist `NSMicrophoneUsageDescription` entry **crash on first permission prompt**. The shared module can't reach Info.plist; the iOS app target needs this entry added:

```xml
<key>NSMicrophoneUsageDescription</key>
<string>Record voice messages to send in chat.</string>
```

Until this lands in the iOS app target, this PR is functionally Android-only — iOS will silently refuse the permission request and the user will see no recording start.

## Lifecycle / cleanup contract

- **Recording cancel** → recorder stops the OS engine, deletes the in-progress cache file. State returns to Idle.
- **Recording stop → user taps Delete** → preview composable calls `attachment.deleteCachedFile()` before clearing `pendingAudio`. Cache file removed.
- **Recording stop → user taps Send** → attachment ownership transfers to `SendMessageDraft`. `ChatRepositoryImpl.uploadAttachment` reads via `attachment.openSource()` and POSTs to `/media/upload`. Cache file is NOT explicitly deleted post-upload — same retention model as the image picker's captured photos; Android/iOS GC the cache dir.
- **Recording in progress → user backgrounds the app** → `DisposableEffect.onDispose` calls `releaseInternal()` on the recorder, releases the OS engine, file stays intact (in case user resumes). v1 doesn't restore mid-recording UI on resume; state collapses to Idle.
- **Flag flipped OFF mid-recording (impossible today, defensive)** → no live observation, no special handling needed since flag reads happen at viewState construction time.

## How this was tested

End-to-end on Motorola g96 5G against `agent.rishi.yral.com` (CHAT_BASE_URL local override flipped to agent for testing, reverted before commit — pre-commit hook would reject otherwise):

- **Backend smoke (pre-mobile)**: `POST /api/v1/media/upload` accepts `type=audio` with `audio/wav`, returns presigned storj URL. Sending a chat message with that URL + `message_type=audio` triggers Gemini transcription — confirmed via `[Transcribed: ...]` round-trip in the user_message + contextual AI reply.
- **Mobile build + install**: `:androidApp:assembleProdDebug` green; `adb install -r` success.
- **Functional walk-through (flag override = true)**:
  - Mic icon appears on AI chats when input is empty, alongside camera/gallery menu ✓
  - First mic tap → Android system permission prompt → Grant → recording bar appears with pulsing dot + ticking timer ✓
  - Stop → preview bar with play/pause + duration ✓
  - Play → audio plays back cleanly, timer counts down, pauses on second tap ✓
  - Delete → returns to text input, no orphan file ✓
  - Send → 200, message bubble appears, `[Transcribed: "..."]` content, AI replies contextually ✓
- **Functional walk-through (flag default = false)**: mic icon NOT visible, only `[+]` camera/gallery menu shows — same as production before this PR.
- **Negative paths**: declined permission no-ops cleanly (no crash; will get the "open settings" affordance in a follow-up using the reserved string); zero-byte file (tap stop within 100ms) discards silently; app background + foreground returns to clean Idle.

## Test plan for reviewer

- [ ] Build the branch locally with no overrides. Confirm mic icon is absent on all chat screens (flag default = false).
- [ ] Flip `AudioRecordingEnabled.defaultValue = true` locally (or via Firebase Remote Config in dev), rebuild, install, repeat the functional walk-through against `agent.rishi.yral.com`. Revert the override before committing anything.
- [ ] Test on iOS: confirm `NSMicrophoneUsageDescription` is missing from Info.plist → permission prompt would crash. Add the entry (sample wording above), rebuild iOS app, verify recording works.
- [ ] Code-review the flag-read pattern in `ConversationViewModel.kt:150` and `:969` (resetState preservation) — symmetric with `isSseStreamingEnabled`.
- [ ] Code-review the gate at `ChatConversationScreen.kt:701-714`. Confirm the inline comment about Task #64 / G6 / H2H follow-up makes sense.

## Follow-up PRs (NOT in this one)

1. Audio file picker (~150 LOC) — `rememberChatAudioPicker` mirroring `rememberChatImagePicker`.
2. Waveform visualization (polish — if user feedback requests it).
3. "Microphone access needed — open Settings" inline affordance on permission denial. The `voice_message_permission_denied` string is already reserved.
4. iOS Info.plist `NSMicrophoneUsageDescription` entry — small PR on the iOS app target before this can ship to iOS.
5. **G6 H2H gate** (Task #64) — after this PR and PR #1178 both merge to main, AND `!viewState.isHumanChat` into the mic-button gate on whichever PR rebases second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — 2026-06-04 (G6 + rebase)

G6 mic-hide gate (Task #64) added as commit `e79ae60d` on top of the rebased branch. Voice messages aren't supported on H2H peer chats — the H2H send route doesn't transcribe — so the mic icon now hides entirely when `viewState.isHumanChat` is true. Branch rebased onto current main (which has #1178 H2H) on the same date; `ChatFeatureFlags.kt` merge conflict resolved by keeping both H2H and Audio flag declarations side-by-side.

Pre-flight before force-push: Sarvesh had zero review state on the PR (only `github-advanced-security` auto-scan had touched it). Proceeded with rebase + force-push per the morning brief's Option 1.
