### PR TITLE
fix(auth): stop overcounting bots from stale OAuth token claim

### DIFF
--- a/shared/features/auth/src/commonMain/kotlin/com/yral/shared/features/auth/DefaultAuthClient.kt
+++ b/shared/features/auth/src/commonMain/kotlin/com/yral/shared/features/auth/DefaultAuthClient.kt
@@ -266,14 +266,16 @@ class DefaultAuthClient(
         }
         if (persistBotIdentities) {
             persistBotIdentitiesFromToken(idToken)
-            updateBotCountFromPrefs()
+            // Intentionally do NOT update sessionManager.botCount from the local
+            // identity cache here. The JWT's `ext_ai_account_delegated_identities`
+            // claim is occasionally stale (deleted bots not pruned), which can
+            // overcount and cause the "Create AI Influencer" CTA to flicker
+            // hidden between the token-merge and the v7-canister reconcile.
+            // The v7-authoritative count lands via RootViewModel's
+            // refreshAccountDirectoryFromCanister → reconciledBots.size; the
+            // token-side merge here only needs to persist identities for the
+            // account switcher.
         }
-    }
-
-    private suspend fun updateBotCountFromPrefs() {
-        val count = botIdentitiesStore.get().size
-        Logger.d("BotIdentitySource") { "updateBotCountFromPrefs source=local_pref count=$count" }
-        sessionManager.updateBotCount(count)
     }
 
     override suspend fun refreshTokens() {


### PR DESCRIPTION
## Summary
- "Create AI Influencer" CTA on creator's own profile was flickering hidden every session refresh + account switch
- Root cause: `persistTokens` was writing `sessionManager.botCount = botIdentitiesStore.size` from the JWT-merged cache. For users with deleted bots, the JWT's `ext_ai_account_delegated_identities` claim still lists the orphan, so `botCount` got set to N+1 while v7 canister authoritatively says N. The two writers raced and the CTA gate (`botCount < maxBotCountForCta`) flipped on every recompose.
- Fix: drop the token-side `updateBotCountFromPrefs()` call. Identities still persist for the account switcher; only the v7-reconciled count from `RootViewModel.refreshAccountDirectoryFromCanister` drives `botCount`, so any stale token entry can't reach the CTA gate.

## Repro on Motorola (2026-06-03)
Real bot count = 2 (Anastasia + Mr. Stand, both v7-listed in account switcher). Captured logs:
```
persistBotIdentitiesFromToken existing=2 new=3 merged=3
updateBotCountFromPrefs source=local_pref count=3   ← CTA hidden
... ~1.5s later ...
refreshAccountDirectory source=v7 bots=2 reconciled=2  ← botCount → 2, CTA visible
```
Every session refresh / switch retriggered both writers; last-wins.

## Out of scope
The JWT staleness itself is an auth-issuer bug — backend team notified to prune deleted bots from `ext_ai_account_delegated_identities`. This PR is the mobile-side defense so the symptom is gone today regardless of when the auth-side cleanup lands.

## Test plan
- [ ] Build green on CI
- [ ] Install on Motorola, log out + log back in, open creator profile → CTA visible immediately, doesn't vanish
- [ ] Switch to bot profile → CTA hidden (correct, `isBotAccount` true)
- [ ] Switch back to creator profile → CTA reappears, stays visible across multiple navigation cycles
- [ ] Account switcher still lists all bot accounts correctly (identities still persisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)