### PR TITLE
fix(chat): respect ChatAsHumanCreatorEnabled flag in BotAccountReadOnly branch

### DIFF
--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -601,13 +601,32 @@ fun ChatConversationScreen(
                             }
 
                             ConversationBottomAreaState.BotAccountReadOnly -> {
-                                BotAccountConversationPrompt(
-                                    message = aiInfluencerReadOnlyMessage,
-                                    buttonText = null,
-                                    avatarUrl = null,
-                                    isSwitching = false,
-                                    onSwitchClick = null,
-                                )
+                                if (viewState.isChatAsHumanCreatorEnabled) {
+                                    val creatorDisplayName =
+                                        viewState.influencer
+                                            ?.displayName
+                                            ?.takeIf { it.isNotBlank() }
+                                            ?: viewState.influencer?.name.orEmpty()
+                                    CreatorTakeoverBar(
+                                        isActive = viewState.isHumanCreatorTakeoverActive,
+                                        isStarting = viewState.isHumanCreatorTakeoverStarting,
+                                        isEnding = viewState.isHumanCreatorTakeoverEnding,
+                                        isMessageSending = viewState.isHumanCreatorMessageSending,
+                                        remainingSeconds = viewState.humanCreatorTakeoverRemainingSeconds,
+                                        creatorDisplayName = creatorDisplayName,
+                                        onToggleOn = { viewModel.startHumanCreatorTakeover() },
+                                        onToggleOff = { viewModel.releaseHumanCreatorTakeover() },
+                                        onSend = { text -> viewModel.sendAsHumanCreator(text) },
+                                    )
+                                } else {
+                                    BotAccountConversationPrompt(
+                                        message = aiInfluencerReadOnlyMessage,
+                                        buttonText = null,
+                                        avatarUrl = null,
+                                        isSwitching = false,
+                                        onSwitchClick = null,
+                                    )
+                                }
                             }
 
                             ConversationBottomAreaState.InfluencerSubscription -> {


### PR DESCRIPTION
## Summary
- The `BotAccountPrompt` branch in `ChatConversationScreen.kt` (lines 563-601) was already flag-gated: when `ChatAsHumanCreatorEnabled` is on, it renders `CreatorTakeoverBar` instead of the legacy "switch to your human profile" prompt.
- The sibling `BotAccountReadOnly` branch (line 603) hits when a bot account opens a chat with a **human participant** (post-H2H), and it was unconditionally rendering the read-only "Chats are read-only in AI influencer view mode" banner — ignoring the flag entirely.
- Result: when `ChatAsHumanCreatorEnabled` is on AND the H2H pipeline is also on, the creator (signed in as their bot) sees the takeover bar on AI-influencer chats but NOT on H2H chats with users they were already talking to. The two surfaces should behave the same.
- Fix: mirror the same `if (viewState.isChatAsHumanCreatorEnabled) CreatorTakeoverBar else BotAccountConversationPrompt` shape into the `BotAccountReadOnly` branch. When the flag is off, the read-only banner continues to render unchanged.

## Bug discovery
Surfaced as **Task #63** during the H2H + Chat-as-Human merge sequencing on 2026-06-04. Both flags ship dormant by default; once the team flips both, the discrepancy becomes visible.

## Scope
Single file, +26/-7 lines, single concern. Off `main` directly.

## Test plan
- [ ] CI green
- [ ] On Motorola: bot account → open H2H chat with a human user → `CreatorTakeoverBar` visible (not the read-only banner)
- [ ] On Motorola: bot account → open standard AI-influencer chat with a regular user → `CreatorTakeoverBar` visible (unchanged from before)
- [ ] Toggle `ChatAsHumanCreatorEnabled` off (set defaultValue=false locally) → both screens revert to legacy prompt/banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)