### PR TITLE
fix(chat): drop SSE streaming cursor; show YralLoadingDots while waiting for first token

### DIFF
--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt
@@ -145,10 +145,10 @@ private fun RegularBubble(
     //   1. Path lock — `markdownLockedOverride` pins Markdown vs Text for the full
     //      lifetime of a streamed message. Streaming uses the locked path and the
     //      post-`done` Remote uses the same path. No mid-stream or done-time swap.
-    //   2. Cursor isolation — the streaming cursor "▌" is rendered as a SEPARATE
-    //      composable sibling below, NOT appended to the content string. The string
-    //      passed to Markdown(...) is the cursor-free buffer so per-batch re-parses
-    //      grow only by the new token text, not by a moving trailing character.
+    //   2. Waiting state — when isStreaming is true but no content has arrived
+    //      yet, show the same YralLoadingDots used by WaitingBubble. Once content
+    //      starts streaming in, NO trailing cursor or indicator is rendered — the
+    //      live token text alone is the signal that the reply is still arriving.
     //   3. Coalescing — the VM batches tokens that arrive within ~250ms before
     //      pushing them to the streaming buffer, so this composable's content
     //      changes ~1-3 times per reply instead of once per network token.
@@ -189,13 +189,10 @@ private fun RegularBubble(
                 )
             }
         }
-        if (isStreaming) {
-            Text(
-                text = STREAMING_CURSOR,
-                style = appTypography.baseRegular,
-                color = textColor,
-                modifier = Modifier.padding(horizontal = 8.dp),
-            )
+        if (isStreaming && displayContent.isBlank()) {
+            Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                YralLoadingDots()
+            }
         }
         MessageImages(
             mediaUrls = mediaUrls,
@@ -204,8 +201,6 @@ private fun RegularBubble(
         )
     }
 }
-
-private const val STREAMING_CURSOR = "▌"
 
 @Composable
 private fun markdownTypography(appTypography: AppTopography): DefaultMarkdownTypography =


### PR DESCRIPTION
## Summary
- Alpha-team feedback on 2026-06-09: a `▌` block-cursor character (U+258C, reads as a stray `|` in some Android font fallbacks) was rendered throughout the SSE streaming lifecycle inside `ConversationMessageBubble.RegularBubble`. Testers parsed it as a stray pipe character inside the AI's reply bubble.
- Spec from Rishi: wherever the cursor was acting as a "loading/waiting" indicator → replace with `YralLoadingDots` (the dancing dots already used by `WaitingBubble` for non-streaming assistant placeholders). Wherever it was acting as a trailing typing-caret → just remove it.

## Change
- Pre-first-token (`isStreaming && content.isBlank()`) → render `YralLoadingDots()` inside the existing padded `Box`, matching the `WaitingBubble` pattern.
- Mid-stream (`isStreaming && content.isNotBlank()`) → no trailing indicator at all. The live token text alone signals that the reply is still arriving.
- Post-stream → unchanged. Just the final content.
- Removed the now-unused `private const val STREAMING_CURSOR = "▌"`.
- Updated the Phase 5c rendering-contract comment block. Item 2 ("Cursor isolation") guarded markdown re-parse cost when the cursor was rendered alongside streaming text; that constraint is moot now that there is no cursor.

## Files
- `shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt` — only file touched. +8 / -13 lines.

## Verification done locally
Rishi tested on Motorola against `agent.rishi.yral.com` with all 6 v2 feature flags overridden ON (post-cutover state, mirrors alpha):

- T1: Pre-first-token state shows the YralLoadingDots — pass
- T2: Streaming state shows clean text, no cursor — pass
- T3: Complete state unchanged — pass
- T4: H2H chats unaffected (no streaming, no dots) — pass

No regressions observed in the SSE streaming feature itself (path lock, coalescing, markdown rendering, idle watchdog all unchanged).

## Out of scope
SSE streaming (`SseStreamingEnabled`) stays ON. Coach v1.2 polish is a separate workstream. The deeper SSE behaviour around mid-stream navigation (placeholder cleanup on plain coroutine cancel, dedup against the server-confirmed reply on inbox re-entry, send-button gate behaviour across stream timeouts) is a known pre-existing concern that surfaced briefly during testing — those are NOT addressed here and warrant a separate triage if/when they reproduce reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)