### PR TITLE
fix(chat): clear paged-history snapshot on resetState to prevent cross-conv cache poison

### DIFF
--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -1020,6 +1020,10 @@ class ConversationViewModel(
         loadedMessageIds.value = emptySet()
         initialOffset.value = null
         historyRefreshTrigger.value = 0
+        // Cross-conv leak fix: clear paged-history snapshot so the debounced
+        // cache writer can't compose (new convId, stale prev-conv history)
+        // and poison the new conversation's cache before its own paging arrives.
+        lastHistorySnapshot.value = emptyList()
         stopTakeoverPolling()
         stopCountdownTicker()
         // Phase 7: tear down any in-flight stream and drop queued sends. The


### PR DESCRIPTION
## Summary
- **Bug:** Sending a message in conversation A and quickly switching to conversation B caused A's message to appear inside B's chat — persistently, surviving re-entries to B. Reproduced repeatably with "hi Jay" → switch to Stap Sister.
- **Root cause:** The debounced Phase 5b cache writer (`ConversationViewModel.kt:347-362`) `combine`s `(conversationId, overlay.sent, lastHistorySnapshot)` and writes the merged result to `ConversationContentCache`. `resetState()` cleared every input EXCEPT `lastHistorySnapshot`, so the 500ms debounce could fire with `(B_id, B_cache, A_history)` before B's own paging arrived — poisoning B's cache with A's messages.
- **Fix:** Clear `lastHistorySnapshot.value = emptyList()` in `resetState()` alongside `_overlay`, `loadedMessageIds`, `initialOffset`, etc.

## Why this bug existed
This is the same family as the audio-history bug we fixed yesterday (stale per-conversation flow leaking across a conv switch). `resetState()` already nulled the others; `lastHistorySnapshot` was added later in the Phase 5b cache work and missed the reset list.

## Test plan
- [x] T1: Send "hi Jay" in Jay → quickly switch to Stap Sister → confirm "hi Jay" does NOT appear in Stap. **Passed on Motorola.**
- [x] T2: Re-open Stap Sister a second time (forces cache-read path) → confirm still no "hi Jay". **Passed.**
- [x] T3: Reverse direction — send in Stap → switch to Jay → confirm Stap message doesn't appear in Jay. **Passed.**
- [x] Compiles clean (`./gradlew :shared:features:chat:compileKotlinMetadata`).

## Scope
4-line change in one file. Defense-in-depth audit of related per-conv flows in `setConversationId()` can be a follow-up if needed (Task #57 already tracks H2H-carrier audit; this is a related but distinct concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)