### PR TITLE
fix(chat): recent voice/AI messages going missing after inbox re-entry

### DIFF
--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -280,13 +280,18 @@ class ConversationViewModel(
     private val systemOverlayMessagesFlow = MutableStateFlow<List<SentMessage>>(emptyList())
 
     val overlay: StateFlow<List<ConversationMessageItem>> =
-        combine(_overlay, loadedMessageIds, systemOverlayMessagesFlow) { overlayState, loadedIds, systemMessages ->
-            val filteredSent = overlayState.sent.filterNot { it.message.id in loadedIds }
+        combine(_overlay, loadedMessageIds, systemOverlayMessagesFlow) { overlayState, _, systemMessages ->
+            // VM-level filter intentionally removed: the screen already dedups
+            // overlay vs paged history via `isDuplicateOfOverlay`. Filtering
+            // here pulled the newest sent messages OUT of overlay when the
+            // cache+page sets overlapped, dropping them onto pagedItems —
+            // which render at the visual TOP under reverseLayout=true and
+            // appear "missing" from the bottom of the conversation.
             buildList {
                 overlayState.pending.forEach { pending ->
                     add(pending.createdAtMs to ConversationMessageItem.Local(pending))
                 }
-                filteredSent.forEach { sent ->
+                overlayState.sent.forEach { sent ->
                     add(sent.insertedAtMs to ConversationMessageItem.Remote(sent.message))
                 }
                 systemMessages.forEach { sent ->
@@ -832,9 +837,20 @@ class ConversationViewModel(
 
         val paginatedHistoryAvailable = messageCount > PAGE_SIZE
 
-        if (recentMessages.isNotEmpty() && paginatedHistoryAvailable) {
-            initialOffset.value = recentMessages.size
-        }
+        // Audio-history-fix: always (re)assign initialOffset on every
+        // setConversationId so a stale value from a previous conversation
+        // visit can't leak through. Without this, an `initializeFromInbox`
+        // call (which always passes recentMessages = emptyList()) leaves
+        // initialOffset.value at whatever the previous conversation set it
+        // to, so the new pager starts page 0 at a non-zero offset and
+        // silently skips the most-recent messages — reproducing as
+        // "voice message + AI reply missing after inbox re-entry".
+        initialOffset.value =
+            if (recentMessages.isNotEmpty() && paginatedHistoryAvailable) {
+                recentMessages.size
+            } else {
+                null
+            }
 
         _viewState.update {
             it.copy(
@@ -1732,11 +1748,10 @@ class ConversationViewModel(
                                         }
                                         state.copy(pending = newPending, sent = newSent)
                                     }
-                                    // NOTE: do NOT pre-add msg.id to loadedMessageIds here. The combine
-                                    // block's `filteredSent = state.sent.filterNot { id in loadedIds }`
-                                    // would immediately hide the Remote we just inserted, since loadedIds
-                                    // is the "already paged in" set. The natural paging cycle adds the
-                                    // id once paging hydrates the message; that's when dedup kicks in.
+                                    // NOTE: do NOT pre-add msg.id to loadedMessageIds here. Let the
+                                    // natural paging cycle add the id once paging hydrates the message;
+                                    // dedup against the overlay then happens at the screen layer via
+                                    // `isDuplicateOfOverlay`.
 
                                     // Reconcile the optimistic USER Local: the SSE `done` event only
                                     // carries the assistant message (per docs/SSE-PROTOCOL.md), so the


### PR DESCRIPTION
## Summary
Two latent ViewModel bugs surfaced after the v2 cutover. Both reproduce as the most-recent messages disappearing from the bottom of the chat after returning from the inbox — most commonly noticed on voice messages because they're the freshest activity right before a back-tap.

### Bug 1 — stale \`initialOffset\` leaks across conversation switches
\`setConversationId\` only WROTE \`initialOffset.value\` when \`recentMessages.isNotEmpty() && paginatedHistoryAvailable\`. Otherwise it left whatever value the *previous* conversation had set. When \`initializeFromInbox\` opens a new conv it always passes \`recentMessages = emptyList()\`, so the new pager starts page 0 at a non-zero offset, silently skipping the most-recent rows.

**Fix:** always (re)assign \`initialOffset\` on every call — \`null\` when \`recentMessages\` is empty, \`recentMessages.size\` otherwise.

### Bug 2 — VM-level overlay filter inverts render order on cache+page overlap
The \`overlay\` combine block had \`overlayState.sent.filterNot { it.message.id in loadedIds }\`. When Phase 5b stale-while-revalidate cache hydration AND paged refetch produced overlapping ids (the common case for the newest messages), the filter pulled the newest sent items OUT of overlay. Those same ids then landed in \`pagedItems\` which, under \`reverseLayout=true\`, render at the visual TOP instead of the bottom — appearing "missing" from where the user expects them.

**Fix:** remove the VM-level filter. The screen already dedups via \`isDuplicateOfOverlay\` at render time, so removing the VM-level filter eliminates the double-dedup race without introducing duplicates.

## Test plan
- [x] T1: send 2 audio msgs in Stap → back to inbox → re-open Stap → all 4 bubbles (2 user audio + 2 AI replies) visible at the bottom. **Passed on Motorola.**
- [x] T2: send audio in Stap → open Tara → send text in Tara → return to Stap → Stap's audio + AI reply still at the bottom. **Passed.**
- [x] T3: scroll older history above recent bottom messages — no duplicates, no inversion. **Passed.**
- [x] Compiles clean (\`./gradlew :shared:features:chat:compileKotlinMetadata :androidApp:compileProdDebugKotlin\`).

## Scope
26-line diff in a single file. Sibling to #1188 (cross-conv cache poison) — both are stale per-conversation state leaking across conv switches, but they hit distinct flows (\`initialOffset\` + overlay-filter here vs \`lastHistorySnapshot\` there), so they're shipped as separate single-concern PRs per the repo rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)