### PR TITLE
feat(coach): hide raw structured proposal data from chat bubbles

### DIFF
--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
@@ -412,7 +412,6 @@ private fun CoachMessageBubble(
             if (showProposalCard) {
                 Spacer(modifier = Modifier.height(6.dp))
                 CoachProposalCard(
-                    proposedChanges = message.proposedChanges.orEmpty(),
                     reasoning = message.reasoning.orEmpty(),
                     applied = message.applied,
                     onApplyClick = onApplyClick,
@@ -422,9 +421,15 @@ private fun CoachMessageBubble(
     }
 }
 
+/**
+ * Coach pivot 2026-06-11 (Bucket 1 Item 1) — render ONLY the plain-English
+ * `reasoning` field, never the raw structured `proposedChanges` blob. The
+ * structured changes are still on the domain model + used by the apply
+ * call; we just don't show the JSON-y payload to the creator anymore.
+ * The actual edit surface is moving to the Soul File page (Bucket 2).
+ */
 @Composable
 private fun CoachProposalCard(
-    proposedChanges: String,
     reasoning: String,
     applied: Boolean,
     onApplyClick: () -> Unit,
@@ -449,17 +454,9 @@ private fun CoachProposalCard(
             Text(
                 text = reasoning,
                 style = LocalAppTopography.current.regRegular,
-                color = YralColors.NeutralTextSecondary,
+                color = YralColors.NeutralTextPrimary,
             )
-            Spacer(modifier = Modifier.height(8.dp))
         }
-        Text(
-            text = proposedChanges,
-            style = LocalAppTopography.current.regRegular,
-            color = YralColors.NeutralTextPrimary,
-            maxLines = 8,
-            overflow = TextOverflow.Ellipsis,
-        )
         Spacer(modifier = Modifier.height(10.dp))
         Box(
             modifier =


### PR DESCRIPTION
## Summary

**Coach pivot 2026-06-11 — Bucket 1 Item 1.** Render only the plain-English \`reasoning\` field in the Coach proposal card. Stop showing the raw structured \`proposed_changes\` payload (looked like JSON-ish system-instruction text to creators — confusing, non-actionable).

The structured data is still on the domain model (CoachMessage) and still drives the apply call. We just don't surface it to creators anymore. The actual edit surface is moving to a dedicated Soul File page (Bucket 2, this week).

## Before / after

Before (truncated for readability):
\`\`\`
┌──────────────────────────────┐
│ PROPOSED UPDATE              │
│ I'll make her tone playful…  │  ← reasoning (kept)
│                              │
│ {"core_personality": "You    │  ← proposed_changes (removed)
│ are Anastasia, sultry and    │
│ warm, with sharper one-      │
│ liners..."}                  │
│                              │
│  [ Apply ]                   │
└──────────────────────────────┘
\`\`\`

After:
\`\`\`
┌──────────────────────────────┐
│ PROPOSED UPDATE              │
│ I'll make her tone playful   │  ← reasoning (now NeutralTextPrimary,
│ and slightly biting, with    │     was NeutralTextSecondary)
│ sharper one-liners when the  │
│ user is teasing.             │
│                              │
│  [ Apply ]                   │
└──────────────────────────────┘
\`\`\`

## Scope

- One file, 8 insertions / 11 deletions.
- No behavior change to the apply flow, proposal generation, receipt rendering, or any other Coach surface.
- No backend dependency. Forward-compatible — if the backend later renames or restructures the proposal payload, this PR doesn't care.

## Test plan
- [x] T1: Type a message that triggers Coach to propose a change. Proposal card renders.
- [x] T2: **Verified on Motorola** — card shows pink-bordered \`Proposed update\` header + reasoning text + Apply button. NO raw structured blob between the reasoning and Apply.
- [x] T3: **Verified on Motorola** — tapping Apply opens the confirm dialog. Confirm → applied → receipt message appears, card marks itself \"Applied\" (inert). Whole flow unchanged.
- [x] Compiles clean (\`./gradlew :shared:features:coach:compileDebugKotlinAndroid\` + full \`:androidApp:assembleProdDebug\`).

## Flag posture
All chat/agent flags remain \`defaultValue = false\` on this PR (cutover-gate rule). Local flag flips were used for the Motorola test, reverted before commit.

## Related work
- Item 2 (gate Save on \`pending_proposal_exists\`) — separate PR coming, coordinated with backend PR-4.
- Item 3 (\`proposal_id\` in /apply body) — separate PR tomorrow, coordinated with backend PR-3.
- Bucket 2 Soul File View/Edit page — blocked on Session 6's contract doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)