### PR TITLE
feat(coach): unify Save flow — gate on pending_proposal_exists + bind /apply to proposal_id (Bucket 1 Items 2 + 3)

### DIFF
--- a/shared/features/coach/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/coach/src/commonMain/composeResources/values/strings.xml
@@ -26,4 +26,9 @@
     <string name="coach_start_over_confirm_cancel">Cancel</string>
     <string name="coach_save_cta">Save changes to %1$s</string>
     <string name="coach_save_cta_generic">Save changes</string>
+    <string name="coach_proposal_superseded_apply">Replaced</string>
+    <string name="coach_proposal_superseded_subtitle">Replaced by a newer proposal — apply the newest card instead.</string>
+    <string name="coach_proposal_discarded_apply">Discarded</string>
+    <string name="coach_continue_coaching">Continue coaching</string>
+    <string name="coach_im_done_for_now">I\'m done for now</string>
 </resources>

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachDataSource.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachDataSource.kt
@@ -1,5 +1,6 @@
 package com.yral.shared.features.coach.data
 
+import com.yral.shared.features.coach.data.models.ApplyCoachProposalRequestDto
 import com.yral.shared.features.coach.data.models.ApplyCoachProposalResponseDto
 import com.yral.shared.features.coach.data.models.CoachSessionDto
 import com.yral.shared.features.coach.data.models.CreateCoachSessionRequestDto
@@ -18,7 +19,10 @@ interface CoachDataSource {
         request: SendCoachMessageRequestDto,
     ): SendCoachMessageResponseDto
 
-    suspend fun applyProposal(coachConversationId: String): ApplyCoachProposalResponseDto
+    suspend fun applyProposal(
+        coachConversationId: String,
+        request: ApplyCoachProposalRequestDto,
+    ): ApplyCoachProposalResponseDto
 
     suspend fun listMessages(coachConversationId: String): ListCoachMessagesResponseDto
 }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachRemoteDataSource.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package com.yral.shared.features.coach.data
 
 import com.yral.shared.core.exceptions.YralException
+import com.yral.shared.features.coach.data.models.ApplyCoachProposalRequestDto
 import com.yral.shared.features.coach.data.models.ApplyCoachProposalResponseDto
 import com.yral.shared.features.coach.data.models.CoachSessionDto
 import com.yral.shared.features.coach.data.models.CreateCoachSessionRequestDto
@@ -12,11 +13,23 @@ import com.yral.shared.http.httpPost
 import com.yral.shared.preferences.PrefKeys
 import com.yral.shared.preferences.Preferences
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.headers
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpHeaders
 import io.ktor.http.path
 import kotlinx.serialization.json.Json
+
+/**
+ * Coach LLM-backed POSTs (send + apply) routinely take >30s on live
+ * testing. The global HttpClient timeout (30s in HttpClientFactory)
+ * was cutting calls off mid-reply and showing the user "incomplete
+ * messages." Bumping to 90s for these two routes only; non-LLM Coach
+ * routes (createSession, listMessages) keep the global default.
+ * Tracked as the mobile-side stopgap until Session 6's latency work
+ * lands or token streaming ships.
+ */
+private const val COACH_LLM_TIMEOUT_MS = 90_000L
 
 class CoachRemoteDataSource(
     private val httpClient: HttpClient,
@@ -57,10 +70,24 @@ class CoachRemoteDataSource(
             }
             headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
             setBody(request)
+            timeout { requestTimeoutMillis = COACH_LLM_TIMEOUT_MS }
         }
     }
 
-    override suspend fun applyProposal(coachConversationId: String): ApplyCoachProposalResponseDto {
+    /**
+     * PR-3 (#356, merged 2026-06-12) — body now carries the explicit
+     * `proposal_id` of the card the user tapped. Pre-PR-3 the endpoint
+     * implicitly picked the latest pending proposal, which silently
+     * applied newer proposals when the creator scrolled up to an older
+     * card. ViewModel currently passes `activeProposalMessage.id`
+     * (latest unapplied) because the post-Item-1 UI has Apply only on
+     * the latest proposal card; future per-card Apply would pass the
+     * tapped card's id directly.
+     */
+    override suspend fun applyProposal(
+        coachConversationId: String,
+        request: ApplyCoachProposalRequestDto,
+    ): ApplyCoachProposalResponseDto {
         val idToken = getIdToken()
         return httpPost(
             httpClient = httpClient,
@@ -71,6 +98,8 @@ class CoachRemoteDataSource(
                 path(COACH_CONVERSATIONS_PATH, coachConversationId, APPLY_PATH)
             }
             headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+            setBody(request)
+            timeout { requestTimeoutMillis = COACH_LLM_TIMEOUT_MS }
         }
     }
 

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachRepositoryImpl.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachRepositoryImpl.kt
@@ -5,7 +5,7 @@ import com.yral.shared.features.coach.data.models.SendCoachMessageRequestDto
 import com.yral.shared.features.coach.data.models.toDomain
 import com.yral.shared.features.coach.domain.CoachRepository
 import com.yral.shared.features.coach.domain.models.ApplyCoachProposalResult
-import com.yral.shared.features.coach.domain.models.CoachMessage
+import com.yral.shared.features.coach.domain.models.CoachMessagesPage
 import com.yral.shared.features.coach.domain.models.CoachSession
 import com.yral.shared.features.coach.domain.models.SendCoachMessageResult
 
@@ -40,6 +40,6 @@ class CoachRepositoryImpl(
     override suspend fun applyProposal(coachConversationId: String): ApplyCoachProposalResult =
         dataSource.applyProposal(coachConversationId).toDomain()
 
-    override suspend fun listMessages(coachConversationId: String): List<CoachMessage> =
+    override suspend fun listMessages(coachConversationId: String): CoachMessagesPage =
         dataSource.listMessages(coachConversationId).toDomain()
 }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachRepositoryImpl.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/CoachRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.yral.shared.features.coach.data
 
+import com.yral.shared.features.coach.data.models.ApplyCoachProposalRequestDto
 import com.yral.shared.features.coach.data.models.CreateCoachSessionRequestDto
 import com.yral.shared.features.coach.data.models.SendCoachMessageRequestDto
 import com.yral.shared.features.coach.data.models.toDomain
@@ -37,8 +38,15 @@ class CoachRepositoryImpl(
                     ),
             ).toDomain()
 
-    override suspend fun applyProposal(coachConversationId: String): ApplyCoachProposalResult =
-        dataSource.applyProposal(coachConversationId).toDomain()
+    override suspend fun applyProposal(
+        coachConversationId: String,
+        proposalId: String,
+    ): ApplyCoachProposalResult =
+        dataSource
+            .applyProposal(
+                coachConversationId = coachConversationId,
+                request = ApplyCoachProposalRequestDto(proposalId = proposalId),
+            ).toDomain()
 
     override suspend fun listMessages(coachConversationId: String): CoachMessagesPage =
         dataSource.listMessages(coachConversationId).toDomain()

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
@@ -2,6 +2,7 @@ package com.yral.shared.features.coach.data.models
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class CreateCoachSessionRequestDto(
@@ -36,7 +37,7 @@ data class CoachMessageDto(
      * Future PR-B mobile UX (per-bullet "tap to override" entry from
      * the Soul File summary) can read the typed contents separately.
      */
-    @SerialName("proposed_global_rule_override") val proposedGlobalRuleOverride: kotlinx.serialization.json.JsonElement? = null,
+    @SerialName("proposed_global_rule_override") val proposedGlobalRuleOverride: JsonElement? = null,
     @SerialName("reasoning") val reasoning: String? = null,
     @SerialName("suggestions") val suggestions: List<String>? = null,
     @SerialName("applied") val applied: Boolean = false,

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
@@ -47,6 +47,26 @@ data class SendCoachMessageResponseDto(
     @SerialName("pending_proposal_exists") val pendingProposalExists: Boolean = false,
 )
 
+/**
+ * Coach pivot Bucket 1 Item 3 (PR-3, migration 035) — `/apply` now
+ * requires the caller to name the specific proposal being applied.
+ * Pre-PR-3 the endpoint implicitly picked "most recent pending,"
+ * which silently applied newer proposals when the creator scrolled
+ * up and tapped Save on an older card. Sending the explicit id from
+ * the card the user actually tapped closes that trust gap.
+ *
+ * Backend responses to know about:
+ *  - 422 — proposal_id missing or blank
+ *  - 404 — id not in this session (likely cross-session mismatch)
+ *  - 409 — proposal exists but its status isn't 'pending' (e.g. it
+ *    was superseded by a newer one or already applied). Body carries
+ *    `current_status`.
+ */
+@Serializable
+data class ApplyCoachProposalRequestDto(
+    @SerialName("proposal_id") val proposalId: String,
+)
+
 @Serializable
 data class ApplyCoachProposalResponseDto(
     @SerialName("applied") val applied: Boolean,

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
@@ -24,9 +24,34 @@ data class CoachMessageDto(
     @SerialName("role") val role: String,
     @SerialName("content") val content: String,
     @SerialName("proposed_changes") val proposedChanges: String? = null,
+    /**
+     * Coach Fix 1 PR-B — when the creator asks for something that
+     * conflicts with a platform-wide rule (response_length,
+     * language_mirror), Coach emits this field INSTEAD of
+     * `proposed_changes`. On /apply, backend merges into
+     * `ai_influencers.global_rule_overrides`. Mobile treats override
+     * messages as proposals for card-rendering + Apply purposes; the
+     * structured payload itself ({key, value}) stays opaque on this
+     * surface because the reasoning text already explains the change.
+     * Future PR-B mobile UX (per-bullet "tap to override" entry from
+     * the Soul File summary) can read the typed contents separately.
+     */
+    @SerialName("proposed_global_rule_override") val proposedGlobalRuleOverride: kotlinx.serialization.json.JsonElement? = null,
     @SerialName("reasoning") val reasoning: String? = null,
     @SerialName("suggestions") val suggestions: List<String>? = null,
     @SerialName("applied") val applied: Boolean = false,
+    /**
+     * PR-3 (migration 035) — proposal lifecycle on `coach_messages.status`.
+     * One of `pending` / `applied` / `superseded` / `discarded` / `na`.
+     * `na` covers non-proposal rows (creator messages, opening, receipt).
+     * Defaults to `"na"` for backward-compat with older backends.
+     *
+     * Mobile drives card state off this: PENDING = active Apply button,
+     * APPLIED = "Applied" disabled label, SUPERSEDED = "Replaced by newer
+     * proposal" subtitle + Apply disabled.
+     */
+    @SerialName("status") val status: String = "na",
+    @SerialName("status_changed_at") val statusChangedAt: String? = null,
     @SerialName("created_at") val createdAt: String,
 )
 
@@ -71,9 +96,22 @@ data class ApplyCoachProposalRequestDto(
 data class ApplyCoachProposalResponseDto(
     @SerialName("applied") val applied: Boolean,
     @SerialName("history_id") val historyId: String,
-    @SerialName("previous_instructions") val previousInstructions: String,
-    @SerialName("new_instructions") val newInstructions: String,
-    @SerialName("applied_at") val appliedAt: String,
+    /**
+     * Personality-edit apply path returns these as the full text
+     * before/after of `system_instructions`. The override and
+     * sectioned-edit apply paths return DIFFERENT fields (override_key/
+     * override_value, or section-specific) and OMIT these — so they
+     * MUST be nullable. Backend dispatches the apply response shape
+     * based on which proposal type ran; mobile only ever reads
+     * `receipt_message`, so a missing pair is harmless. Pre-2026-06-12
+     * mobile declared these as non-nullable, which caused the
+     * `MissingFieldException` Rishi hit on every override apply — the
+     * backend had already flipped status='applied' but mobile surfaced
+     * "could not apply" because deserialization threw.
+     */
+    @SerialName("previous_instructions") val previousInstructions: String? = null,
+    @SerialName("new_instructions") val newInstructions: String? = null,
+    @SerialName("applied_at") val appliedAt: String? = null,
     @SerialName("receipt_message") val receiptMessage: CoachMessageDto? = null,
 )
 

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/CoachDtos.kt
@@ -40,6 +40,11 @@ data class SendCoachMessageRequestDto(
 data class SendCoachMessageResponseDto(
     @SerialName("creator_message") val creatorMessage: CoachMessageDto,
     @SerialName("coach_message") val coachMessage: CoachMessageDto,
+    // PR-4 (2026-06-11) — mobile gates the Save button on this. Backend
+    // computes against post-turn state so a proposal emitted this turn
+    // is reflected immediately. Defaulting to `false` keeps older
+    // backends backward-compatible.
+    @SerialName("pending_proposal_exists") val pendingProposalExists: Boolean = false,
 )
 
 @Serializable
@@ -57,4 +62,8 @@ data class ListCoachMessagesResponseDto(
     @SerialName("coach_conversation_id") val coachConversationId: String,
     @SerialName("messages") val messages: List<CoachMessageDto>,
     @SerialName("total") val total: Int,
+    // PR-4 (2026-06-11) — present on session reload so the Save button
+    // shows the correct state without scanning every message for an
+    // unapplied proposal. Defaults to `false` for older backends.
+    @SerialName("pending_proposal_exists") val pendingProposalExists: Boolean = false,
 )

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/Mappers.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/Mappers.kt
@@ -5,6 +5,7 @@ import com.yral.shared.features.coach.domain.models.CoachMessage
 import com.yral.shared.features.coach.domain.models.CoachMessageRole
 import com.yral.shared.features.coach.domain.models.CoachMessagesPage
 import com.yral.shared.features.coach.domain.models.CoachSession
+import com.yral.shared.features.coach.domain.models.ProposalStatus
 import com.yral.shared.features.coach.domain.models.SendCoachMessageResult
 
 fun CoachSessionDto.toDomain(): CoachSession =
@@ -23,9 +24,21 @@ fun CoachMessageDto.toDomain(): CoachMessage =
         role = CoachMessageRole.fromApi(role),
         content = content,
         proposedChanges = proposedChanges,
+        // Override-style proposals come on a different field than
+        // proposed_changes (Coach Fix 1 PR-B). Mobile treats both as
+        // "this turn is a proposal" for card-rendering; backend
+        // dispatches the correct write on /apply.
+        hasOverrideProposal = proposedGlobalRuleOverride != null,
         reasoning = reasoning,
         suggestions = suggestions,
         applied = applied,
+        status = ProposalStatus.fromApi(status),
+        statusChangedAt = statusChangedAt,
+        // `isReceipt` is set in CoachViewModel ONLY when the message
+        // arrived via the `apply` response's `receipt_message` field.
+        // Everything coming through this mapper (sendMessage, list) is
+        // not-receipt by default.
+        isReceipt = false,
         createdAt = createdAt,
     )
 

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/Mappers.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/data/models/Mappers.kt
@@ -3,6 +3,7 @@ package com.yral.shared.features.coach.data.models
 import com.yral.shared.features.coach.domain.models.ApplyCoachProposalResult
 import com.yral.shared.features.coach.domain.models.CoachMessage
 import com.yral.shared.features.coach.domain.models.CoachMessageRole
+import com.yral.shared.features.coach.domain.models.CoachMessagesPage
 import com.yral.shared.features.coach.domain.models.CoachSession
 import com.yral.shared.features.coach.domain.models.SendCoachMessageResult
 
@@ -32,6 +33,7 @@ fun SendCoachMessageResponseDto.toDomain(): SendCoachMessageResult =
     SendCoachMessageResult(
         creatorMessage = creatorMessage.toDomain(),
         coachMessage = coachMessage.toDomain(),
+        pendingProposalExists = pendingProposalExists,
     )
 
 fun ApplyCoachProposalResponseDto.toDomain(): ApplyCoachProposalResult =
@@ -44,4 +46,8 @@ fun ApplyCoachProposalResponseDto.toDomain(): ApplyCoachProposalResult =
         receiptMessage = receiptMessage?.toDomain(),
     )
 
-fun ListCoachMessagesResponseDto.toDomain(): List<CoachMessage> = messages.map { it.toDomain() }
+fun ListCoachMessagesResponseDto.toDomain(): CoachMessagesPage =
+    CoachMessagesPage(
+        messages = messages.map { it.toDomain() },
+        pendingProposalExists = pendingProposalExists,
+    )

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/CoachRepository.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/CoachRepository.kt
@@ -17,7 +17,10 @@ interface CoachRepository {
         requestProposal: Boolean,
     ): SendCoachMessageResult
 
-    suspend fun applyProposal(coachConversationId: String): ApplyCoachProposalResult
+    suspend fun applyProposal(
+        coachConversationId: String,
+        proposalId: String,
+    ): ApplyCoachProposalResult
 
     suspend fun listMessages(coachConversationId: String): CoachMessagesPage
 }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/CoachRepository.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/CoachRepository.kt
@@ -1,7 +1,7 @@
 package com.yral.shared.features.coach.domain
 
 import com.yral.shared.features.coach.domain.models.ApplyCoachProposalResult
-import com.yral.shared.features.coach.domain.models.CoachMessage
+import com.yral.shared.features.coach.domain.models.CoachMessagesPage
 import com.yral.shared.features.coach.domain.models.CoachSession
 import com.yral.shared.features.coach.domain.models.SendCoachMessageResult
 
@@ -19,5 +19,5 @@ interface CoachRepository {
 
     suspend fun applyProposal(coachConversationId: String): ApplyCoachProposalResult
 
-    suspend fun listMessages(coachConversationId: String): List<CoachMessage>
+    suspend fun listMessages(coachConversationId: String): CoachMessagesPage
 }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/models/CoachMessage.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/models/CoachMessage.kt
@@ -6,14 +6,62 @@ data class CoachMessage(
     val role: CoachMessageRole,
     val content: String,
     val proposedChanges: String? = null,
+    /**
+     * Coach Fix 1 PR-B — true when this turn proposed a per-bot
+     * platform-rule override (response_length, language_mirror) via
+     * the backend's `proposed_global_rule_override` field. Mobile
+     * treats this the same as a regular `proposedChanges` proposal
+     * for proposal-card + Apply rendering; backend dispatches the
+     * correct write on /apply based on which field is set.
+     */
+    val hasOverrideProposal: Boolean = false,
     val reasoning: String? = null,
     val suggestions: List<String>? = null,
+    /**
+     * Legacy bool from pre-PR-3 days. Now derived from [status] for
+     * the existing call-sites that read it; kept until those are
+     * migrated. New code should branch on [status] instead.
+     */
     val applied: Boolean = false,
+    /**
+     * PR-3 (migration 035) — proposal lifecycle. Drives the
+     * Apply-card-state rendering. Non-proposal rows (creator messages,
+     * opening, receipt) carry NA so the UI doesn't have to special-case.
+     */
+    val status: ProposalStatus = ProposalStatus.NA,
+    val statusChangedAt: String? = null,
+    /**
+     * Mobile-only flag set when this message arrived as the apply
+     * response's `receipt_message`. Drives the "Continue coaching /
+     * I'm done for now" CTA pair render below the latest receipt.
+     * Backend doesn't currently distinguish receipts from other coach
+     * rows — confirmed with Session 6 that local tracking is fine.
+     */
+    val isReceipt: Boolean = false,
     val createdAt: String,
 ) {
     val hasProposal: Boolean
-        get() = !proposedChanges.isNullOrBlank()
+        get() = !proposedChanges.isNullOrBlank() || hasOverrideProposal
 
     val hasSuggestions: Boolean
         get() = !suggestions.isNullOrEmpty()
+}
+
+/**
+ * PR-3 (migration 035) `coach_messages.status` enum, mapped from the
+ * backend string. Unknown slugs (forward-compat additions) collapse to
+ * NA so we never crash on a new lifecycle state.
+ */
+enum class ProposalStatus(val apiValue: String) {
+    PENDING("pending"),
+    APPLIED("applied"),
+    SUPERSEDED("superseded"),
+    DISCARDED("discarded"),
+    NA("na"),
+    ;
+
+    companion object {
+        fun fromApi(value: String?): ProposalStatus =
+            entries.firstOrNull { it.apiValue == value } ?: NA
+    }
 }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/models/CoachSession.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/models/CoachSession.kt
@@ -32,8 +32,13 @@ data class CoachMessagesPage(
 data class ApplyCoachProposalResult(
     val applied: Boolean,
     val historyId: String,
-    val previousInstructions: String,
-    val newInstructions: String,
-    val appliedAt: String,
+    /**
+     * Personality-edit apply path populates these; override + section
+     * paths leave them null because their apply response shape is
+     * different. Mobile only reads `receiptMessage`.
+     */
+    val previousInstructions: String? = null,
+    val newInstructions: String? = null,
+    val appliedAt: String? = null,
     val receiptMessage: CoachMessage? = null,
 )

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/models/CoachSession.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/models/CoachSession.kt
@@ -11,6 +11,22 @@ data class CoachSession(
 data class SendCoachMessageResult(
     val creatorMessage: CoachMessage,
     val coachMessage: CoachMessage,
+    /**
+     * PR-4 (2026-06-11) — does an unapplied proposal exist in the
+     * conversation right after this send? Used by the Save button gate.
+     */
+    val pendingProposalExists: Boolean = false,
+)
+
+/**
+ * PR-4 (2026-06-11) — list-messages endpoint now returns the
+ * `pending_proposal_exists` flag alongside the message list. Wrapped
+ * here so the screen can drive the Save button state from a single
+ * domain object rather than threading the bool separately.
+ */
+data class CoachMessagesPage(
+    val messages: List<CoachMessage>,
+    val pendingProposalExists: Boolean,
 )
 
 data class ApplyCoachProposalResult(

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/usecases/CoachUseCases.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/usecases/CoachUseCases.kt
@@ -4,6 +4,7 @@ import com.yral.shared.crashlytics.core.ExceptionType
 import com.yral.shared.features.coach.domain.CoachRepository
 import com.yral.shared.features.coach.domain.models.ApplyCoachProposalResult
 import com.yral.shared.features.coach.domain.models.CoachMessage
+import com.yral.shared.features.coach.domain.models.CoachMessagesPage
 import com.yral.shared.features.coach.domain.models.CoachSession
 import com.yral.shared.features.coach.domain.models.SendCoachMessageResult
 import com.yral.shared.libs.arch.domain.SuspendUseCase
@@ -66,8 +67,8 @@ class ListCoachMessagesUseCase(
     private val repository: CoachRepository,
     appDispatchers: AppDispatchers,
     useCaseFailureListener: UseCaseFailureListener,
-) : SuspendUseCase<String, List<CoachMessage>>(appDispatchers.network, useCaseFailureListener) {
+) : SuspendUseCase<String, CoachMessagesPage>(appDispatchers.network, useCaseFailureListener) {
     override val exceptionType: String = EXCEPTION_TYPE
 
-    override suspend fun execute(parameter: String): List<CoachMessage> = repository.listMessages(parameter)
+    override suspend fun execute(parameter: String): CoachMessagesPage = repository.listMessages(parameter)
 }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/usecases/CoachUseCases.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/domain/usecases/CoachUseCases.kt
@@ -57,10 +57,27 @@ class ApplyCoachProposalUseCase(
     private val repository: CoachRepository,
     appDispatchers: AppDispatchers,
     useCaseFailureListener: UseCaseFailureListener,
-) : SuspendUseCase<String, ApplyCoachProposalResult>(appDispatchers.network, useCaseFailureListener) {
+) : SuspendUseCase<ApplyCoachProposalUseCase.Params, ApplyCoachProposalResult>(
+        appDispatchers.network,
+        useCaseFailureListener,
+    ) {
     override val exceptionType: String = EXCEPTION_TYPE
 
-    override suspend fun execute(parameter: String): ApplyCoachProposalResult = repository.applyProposal(parameter)
+    override suspend fun execute(parameter: Params): ApplyCoachProposalResult =
+        repository.applyProposal(
+            coachConversationId = parameter.coachConversationId,
+            proposalId = parameter.proposalId,
+        )
+
+    /**
+     * PR-3 (#356) — caller must specify which proposal to apply.
+     * ViewModel passes `activeProposalMessage.id`; the value travels
+     * through to the backend `/apply` body unchanged.
+     */
+    data class Params(
+        val coachConversationId: String,
+        val proposalId: String,
+    )
 }
 
 class ListCoachMessagesUseCase(

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.yral.shared.features.coach.domain.models.CoachMessage
 import com.yral.shared.features.coach.domain.models.CoachMessageRole
+import com.yral.shared.features.coach.domain.models.ProposalStatus
 import com.yral.shared.features.coach.nav.CoachComponent
 import com.yral.shared.features.coach.nav.OpenCoachParams
 import com.yral.shared.features.coach.viewmodel.CoachError
@@ -70,10 +71,12 @@ import yral_mobile.shared.features.coach.generated.resources.coach_header_hint
 import yral_mobile.shared.features.coach.generated.resources.coach_input_placeholder
 import yral_mobile.shared.features.coach.generated.resources.coach_loading_session
 import yral_mobile.shared.features.coach.generated.resources.coach_proposal_applied
+import yral_mobile.shared.features.coach.generated.resources.coach_continue_coaching
+import yral_mobile.shared.features.coach.generated.resources.coach_im_done_for_now
 import yral_mobile.shared.features.coach.generated.resources.coach_proposal_apply_cta
+import yral_mobile.shared.features.coach.generated.resources.coach_proposal_discarded_apply
+import yral_mobile.shared.features.coach.generated.resources.coach_proposal_superseded_subtitle
 import yral_mobile.shared.features.coach.generated.resources.coach_proposal_card_title
-import yral_mobile.shared.features.coach.generated.resources.coach_save_cta
-import yral_mobile.shared.features.coach.generated.resources.coach_save_cta_generic
 import yral_mobile.shared.features.coach.generated.resources.coach_screen_title
 import yral_mobile.shared.features.coach.generated.resources.coach_send
 import yral_mobile.shared.features.coach.generated.resources.coach_send_failed
@@ -136,7 +139,12 @@ fun CoachScreen(
                     messages = viewState.pending,
                     isCoachThinking = viewState.isCoachThinking,
                     activeProposalMessageId = viewState.activeProposalMessage?.id,
+                    activeProposalLockedBySend = viewState.activeProposalLockedBySend,
                     openingSuggestions = viewState.openingSuggestions,
+                    showPostApplyCtaPair = viewState.showPostApplyCtaPair,
+                    onApplyClick = { viewModel.requestApplyProposal() },
+                    onContinueCoaching = { viewModel.dismissPostApplyCtas() },
+                    onImDoneForNow = { component.onBack() },
                     onSuggestionTap = { suggestion -> viewModel.sendMessage(suggestion) },
                 )
             }
@@ -146,26 +154,26 @@ fun CoachScreen(
             CoachErrorBanner(error = err, onDismiss = { viewModel.clearError() })
         }
 
-        // Coach pivot 2026-06-12 (Bucket 1 Items 2 + 3 unified) — Save
-        // IS the apply now. Gated on backend-computed
-        // `pending_proposal_exists` (PR-4) so the button only shows
-        // when there's a concrete proposal to commit, and tapping it
-        // opens the existing apply-confirm dialog → /apply with the
-        // proposal_id of the active card (PR-3). The standalone Apply
-        // button that used to sit on the proposal card was removed in
-        // the same change — two-button confusion gone.
-        if (viewState.pendingProposalExists) {
-            CoachSaveButton(
-                botName = viewState.botName,
-                enabled = !viewState.isCoachThinking && !viewState.isApplying,
-                onSave = { viewModel.requestApplyProposal() },
+        // Per Rishi 2026-06-12 evening — bottom Save button removed
+        // entirely. The single save affordance is the inline Apply
+        // button on the proposal card (rendered by CoachProposalCard).
+        // Two buttons doing the same thing was redundant; the inline
+        // Apply is where the creator's eye lands when reading the
+        // proposal anyway.
+
+        // Per Rishi — post-apply, the CTA pair ("Continue coaching"
+        // / "I'm done for now") is a forced decision moment, so the
+        // input area HIDES until the creator picks. Otherwise the
+        // chat surface shows two competing affordances (CTAs vs.
+        // "just keep typing") and the creator doesn't know which
+        // path is "correct." Tapping Continue brings the input
+        // back; tapping I'm done navigates away.
+        if (!viewState.showPostApplyCtaPair) {
+            CoachInputArea(
+                onSend = { text -> viewModel.sendMessage(text) },
+                enabled = viewState.coachConversationId != null && !viewState.isCoachThinking,
             )
         }
-
-        CoachInputArea(
-            onSend = { text -> viewModel.sendMessage(text) },
-            enabled = viewState.coachConversationId != null && !viewState.isCoachThinking,
-        )
     }
 
     if (viewState.showApplyConfirm) {
@@ -311,11 +319,19 @@ private fun CoachMessagesList(
     messages: List<CoachMessage>,
     isCoachThinking: Boolean,
     activeProposalMessageId: String?,
+    activeProposalLockedBySend: Boolean,
     openingSuggestions: List<String>,
+    showPostApplyCtaPair: Boolean,
+    onApplyClick: () -> Unit,
+    onContinueCoaching: () -> Unit,
+    onImDoneForNow: () -> Unit,
     onSuggestionTap: (String) -> Unit,
 ) {
     val listState = rememberLazyListState()
-    val rowCount = messages.size + if (openingSuggestions.isNotEmpty()) 1 else 0
+    val rowCount =
+        messages.size +
+            (if (openingSuggestions.isNotEmpty()) 1 else 0) +
+            (if (showPostApplyCtaPair) 1 else 0)
     LaunchedEffect(rowCount) {
         if (rowCount > 0) listState.animateScrollToItem(rowCount - 1)
     }
@@ -328,14 +344,37 @@ private fun CoachMessagesList(
             items = messages,
             key = { it.id },
         ) { msg ->
+            // Per Rishi 2026-06-12 evening — when the user has typed
+            // again since this proposal arrived (locked-by-send), the
+            // proposal is treated as stale for UI purposes: card
+            // collapses to its read-only form, no Apply button.
+            val effectiveStatus =
+                if (msg.id == activeProposalMessageId &&
+                    activeProposalLockedBySend &&
+                    msg.status == ProposalStatus.PENDING
+                ) {
+                    ProposalStatus.SUPERSEDED
+                } else {
+                    msg.status
+                }
             CoachMessageBubble(
                 message = msg,
+                effectiveStatus = effectiveStatus,
                 showProposalCard = msg.id == activeProposalMessageId,
+                onApplyClick = onApplyClick,
                 isCoachThinkingPlaceholder =
                     isCoachThinking &&
                         msg.role == CoachMessageRole.COACH &&
                         msg.content.isEmpty(),
             )
+        }
+        if (showPostApplyCtaPair) {
+            item(key = "post-apply-cta-pair") {
+                CoachPostApplyCtaRow(
+                    onContinueCoaching = onContinueCoaching,
+                    onImDoneForNow = onImDoneForNow,
+                )
+            }
         }
         if (openingSuggestions.isNotEmpty()) {
             item(key = "opening-suggestions") {
@@ -382,12 +421,23 @@ private fun CoachSuggestionChipsRow(
 @Composable
 private fun CoachMessageBubble(
     message: CoachMessage,
+    effectiveStatus: ProposalStatus,
     showProposalCard: Boolean,
+    onApplyClick: () -> Unit,
     isCoachThinkingPlaceholder: Boolean,
 ) {
     val isCreator = message.role == CoachMessageRole.CREATOR
     val alignment = if (isCreator) Alignment.TopEnd else Alignment.TopStart
-    val bubbleColor = if (isCreator) YralColors.Pink300 else YralColors.Neutral800
+    // Correction C — receipts render with a pink-bordered, neutral-bg
+    // bubble (slightly distinct from a regular coach reply) so the
+    // creator can visually distinguish "this is what just got saved"
+    // from "this is just chat."
+    val bubbleColor =
+        when {
+            isCreator -> YralColors.Pink300
+            message.isReceipt -> YralColors.Neutral900
+            else -> YralColors.Neutral800
+        }
     Box(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
         contentAlignment = alignment,
@@ -397,7 +447,17 @@ private fun CoachMessageBubble(
                 modifier =
                     Modifier
                         .background(color = bubbleColor, shape = RoundedCornerShape(16.dp))
-                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                        .then(
+                            if (message.isReceipt) {
+                                Modifier.border(
+                                    width = 1.dp,
+                                    color = YralColors.Pink300,
+                                    shape = RoundedCornerShape(16.dp),
+                                )
+                            } else {
+                                Modifier
+                            },
+                        ).padding(horizontal = 12.dp, vertical = 8.dp),
             ) {
                 if (isCoachThinkingPlaceholder) {
                     Text(
@@ -415,26 +475,35 @@ private fun CoachMessageBubble(
             }
             if (showProposalCard) {
                 Spacer(modifier = Modifier.height(6.dp))
-                CoachProposalCard(reasoning = message.reasoning.orEmpty())
+                CoachProposalCard(
+                    reasoning = message.reasoning.orEmpty(),
+                    status = effectiveStatus,
+                    onApplyClick = onApplyClick,
+                )
             }
         }
     }
 }
 
 /**
- * Coach pivot 2026-06-11 (Bucket 1 Item 1) — render ONLY the plain-English
- * `reasoning` field, never the raw structured `proposedChanges` blob. The
- * structured changes are still on the domain model + used by the apply
- * call; we just don't show the JSON-y payload to the creator anymore.
- * The actual edit surface is moving to the Soul File page (Bucket 2).
+ * Coach pivot Item 1 + Corrections A + B:
+ *  - Renders the plain-English `reasoning` only (never raw
+ *    `proposedChanges`).
+ *  - Inline Apply button restored (rolled back the earlier
+ *    consolidation per Rishi 2026-06-12). Both this Apply and the
+ *    bottom Save button fire the same `/apply` with proposal_id.
+ *  - Apply state branches on PR-3's `status` field. PENDING shows
+ *    an active pink Apply; APPLIED shows a gray "Applied" label;
+ *    SUPERSEDED shows a gray disabled button + "Replaced by newer
+ *    proposal" subtitle. DISCARDED renders the disabled state too
+ *    for forward-compat with future Discard UX.
  */
 @Composable
-private fun CoachProposalCard(reasoning: String) {
-    // Coach pivot 2026-06-12 (Bucket 1 Items 2+3 unified) — card is
-    // now a read-only preview. The Apply action moved to the bottom
-    // Save button so there's a single save affordance. Applied state
-    // is communicated via the receipt message in chat + the Save
-    // button disappearing when pending_proposal_exists flips to false.
+private fun CoachProposalCard(
+    reasoning: String,
+    status: ProposalStatus,
+    onApplyClick: () -> Unit,
+) {
     Column(
         modifier =
             Modifier
@@ -458,40 +527,117 @@ private fun CoachProposalCard(reasoning: String) {
                 color = YralColors.NeutralTextPrimary,
             )
         }
+        // Per Rishi 2026-06-12 evening — Apply button ONLY when status
+        // is PENDING. APPLIED / SUPERSEDED / DISCARDED states drop the
+        // button entirely and replace it with a short subtitle so the
+        // creator's eye doesn't snag on a dead-looking button. Card
+        // stays visible so the creator can still read what was
+        // proposed; the action just isn't available anymore.
+        when (status) {
+            ProposalStatus.PENDING -> {
+                Spacer(modifier = Modifier.height(10.dp))
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .background(
+                                color = YralColors.Pink300,
+                                shape = RoundedCornerShape(20.dp),
+                            ).clickable(onClick = onApplyClick)
+                            .padding(vertical = 10.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(Res.string.coach_proposal_apply_cta),
+                        style = LocalAppTopography.current.baseSemiBold,
+                        color = YralColors.Neutral0,
+                    )
+                }
+            }
+            ProposalStatus.APPLIED -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(Res.string.coach_proposal_applied),
+                    style = LocalAppTopography.current.smSemiBold,
+                    color = YralColors.NeutralTextSecondary,
+                )
+            }
+            ProposalStatus.SUPERSEDED -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(Res.string.coach_proposal_superseded_subtitle),
+                    style = LocalAppTopography.current.smRegular,
+                    color = YralColors.NeutralTextSecondary,
+                )
+            }
+            ProposalStatus.DISCARDED -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(Res.string.coach_proposal_discarded_apply),
+                    style = LocalAppTopography.current.smRegular,
+                    color = YralColors.NeutralTextSecondary,
+                )
+            }
+            ProposalStatus.NA -> {
+                // Shouldn't reach for a real proposal card; no
+                // footer rendered. The card just shows title +
+                // reasoning above.
+            }
+        }
     }
 }
 
+/**
+ * Correction C — post-apply CTA pair rendered as a list row below the
+ * latest receipt message. Sits in the LazyColumn so it scrolls
+ * naturally with chat history; only ever visible when
+ * [CoachViewState.showPostApplyCtaPair] is true.
+ */
 @Composable
-private fun CoachSaveButton(
-    botName: String?,
-    enabled: Boolean,
-    onSave: () -> Unit,
+private fun CoachPostApplyCtaRow(
+    onContinueCoaching: () -> Unit,
+    onImDoneForNow: () -> Unit,
 ) {
-    val label =
-        if (!botName.isNullOrBlank()) {
-            stringResource(Res.string.coach_save_cta, botName)
-        } else {
-            stringResource(Res.string.coach_save_cta_generic)
-        }
-    Box(
+    Row(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 4.dp)
-                .background(
-                    color = if (enabled) YralColors.Pink300 else YralColors.Neutral700,
-                    shape = RoundedCornerShape(24.dp),
-                ).clickable(enabled = enabled, onClick = onSave)
-                .padding(vertical = 12.dp),
-        contentAlignment = Alignment.Center,
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Text(
-            text = label,
-            style = LocalAppTopography.current.baseSemiBold,
-            color = YralColors.Neutral0,
-        )
+        Box(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .background(YralColors.Pink300, RoundedCornerShape(20.dp))
+                    .clickable(onClick = onContinueCoaching)
+                    .padding(vertical = 10.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(Res.string.coach_continue_coaching),
+                style = LocalAppTopography.current.baseSemiBold,
+                color = YralColors.Neutral0,
+            )
+        }
+        Box(
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .border(width = 1.dp, color = YralColors.Pink300, shape = RoundedCornerShape(20.dp))
+                    .clickable(onClick = onImDoneForNow)
+                    .padding(vertical = 10.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(Res.string.coach_im_done_for_now),
+                style = LocalAppTopography.current.baseSemiBold,
+                color = YralColors.Pink300,
+            )
+        }
     }
 }
+
 
 @Composable
 private fun CoachInputArea(

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
@@ -412,7 +412,6 @@ private fun CoachMessageBubble(
             if (showProposalCard) {
                 Spacer(modifier = Modifier.height(6.dp))
                 CoachProposalCard(
-                    proposedChanges = message.proposedChanges.orEmpty(),
                     reasoning = message.reasoning.orEmpty(),
                     applied = message.applied,
                     onApplyClick = onApplyClick,
@@ -422,9 +421,15 @@ private fun CoachMessageBubble(
     }
 }
 
+/**
+ * Coach pivot 2026-06-11 (Bucket 1 Item 1) — render ONLY the plain-English
+ * `reasoning` field, never the raw structured `proposedChanges` blob. The
+ * structured changes are still on the domain model + used by the apply
+ * call; we just don't show the JSON-y payload to the creator anymore.
+ * The actual edit surface is moving to the Soul File page (Bucket 2).
+ */
 @Composable
 private fun CoachProposalCard(
-    proposedChanges: String,
     reasoning: String,
     applied: Boolean,
     onApplyClick: () -> Unit,
@@ -449,17 +454,9 @@ private fun CoachProposalCard(
             Text(
                 text = reasoning,
                 style = LocalAppTopography.current.regRegular,
-                color = YralColors.NeutralTextSecondary,
+                color = YralColors.NeutralTextPrimary,
             )
-            Spacer(modifier = Modifier.height(8.dp))
         }
-        Text(
-            text = proposedChanges,
-            style = LocalAppTopography.current.regRegular,
-            color = YralColors.NeutralTextPrimary,
-            maxLines = 8,
-            overflow = TextOverflow.Ellipsis,
-        )
         Spacer(modifier = Modifier.height(10.dp))
         Box(
             modifier =

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
@@ -147,10 +147,16 @@ fun CoachScreen(
             CoachErrorBanner(error = err, onDismiss = { viewModel.clearError() })
         }
 
-        if (viewState.canRequestSave) {
+        // Coach pivot 2026-06-11 (Bucket 1 Item 2) — Save is now gated on
+        // the backend-computed `pending_proposal_exists` flag (PR-4),
+        // not on "any creator message exists." Before this, tapping Save
+        // when there was nothing actionable triggered a confusing
+        // LLM round-trip; now the button is hidden until there is
+        // something concrete to save.
+        if (viewState.pendingProposalExists) {
             CoachSaveButton(
                 botName = viewState.botName,
-                enabled = !viewState.isCoachThinking,
+                enabled = !viewState.isCoachThinking && !viewState.isApplying,
                 onSave = { viewModel.requestSaveProposal() },
             )
         }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/ui/CoachScreen.kt
@@ -137,7 +137,6 @@ fun CoachScreen(
                     isCoachThinking = viewState.isCoachThinking,
                     activeProposalMessageId = viewState.activeProposalMessage?.id,
                     openingSuggestions = viewState.openingSuggestions,
-                    onApplyClick = { viewModel.requestApplyProposal() },
                     onSuggestionTap = { suggestion -> viewModel.sendMessage(suggestion) },
                 )
             }
@@ -147,17 +146,19 @@ fun CoachScreen(
             CoachErrorBanner(error = err, onDismiss = { viewModel.clearError() })
         }
 
-        // Coach pivot 2026-06-11 (Bucket 1 Item 2) — Save is now gated on
-        // the backend-computed `pending_proposal_exists` flag (PR-4),
-        // not on "any creator message exists." Before this, tapping Save
-        // when there was nothing actionable triggered a confusing
-        // LLM round-trip; now the button is hidden until there is
-        // something concrete to save.
+        // Coach pivot 2026-06-12 (Bucket 1 Items 2 + 3 unified) — Save
+        // IS the apply now. Gated on backend-computed
+        // `pending_proposal_exists` (PR-4) so the button only shows
+        // when there's a concrete proposal to commit, and tapping it
+        // opens the existing apply-confirm dialog → /apply with the
+        // proposal_id of the active card (PR-3). The standalone Apply
+        // button that used to sit on the proposal card was removed in
+        // the same change — two-button confusion gone.
         if (viewState.pendingProposalExists) {
             CoachSaveButton(
                 botName = viewState.botName,
                 enabled = !viewState.isCoachThinking && !viewState.isApplying,
-                onSave = { viewModel.requestSaveProposal() },
+                onSave = { viewModel.requestApplyProposal() },
             )
         }
 
@@ -311,7 +312,6 @@ private fun CoachMessagesList(
     isCoachThinking: Boolean,
     activeProposalMessageId: String?,
     openingSuggestions: List<String>,
-    onApplyClick: () -> Unit,
     onSuggestionTap: (String) -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -331,7 +331,6 @@ private fun CoachMessagesList(
             CoachMessageBubble(
                 message = msg,
                 showProposalCard = msg.id == activeProposalMessageId,
-                onApplyClick = onApplyClick,
                 isCoachThinkingPlaceholder =
                     isCoachThinking &&
                         msg.role == CoachMessageRole.COACH &&
@@ -384,7 +383,6 @@ private fun CoachSuggestionChipsRow(
 private fun CoachMessageBubble(
     message: CoachMessage,
     showProposalCard: Boolean,
-    onApplyClick: () -> Unit,
     isCoachThinkingPlaceholder: Boolean,
 ) {
     val isCreator = message.role == CoachMessageRole.CREATOR
@@ -417,11 +415,7 @@ private fun CoachMessageBubble(
             }
             if (showProposalCard) {
                 Spacer(modifier = Modifier.height(6.dp))
-                CoachProposalCard(
-                    reasoning = message.reasoning.orEmpty(),
-                    applied = message.applied,
-                    onApplyClick = onApplyClick,
-                )
+                CoachProposalCard(reasoning = message.reasoning.orEmpty())
             }
         }
     }
@@ -435,11 +429,12 @@ private fun CoachMessageBubble(
  * The actual edit surface is moving to the Soul File page (Bucket 2).
  */
 @Composable
-private fun CoachProposalCard(
-    reasoning: String,
-    applied: Boolean,
-    onApplyClick: () -> Unit,
-) {
+private fun CoachProposalCard(reasoning: String) {
+    // Coach pivot 2026-06-12 (Bucket 1 Items 2+3 unified) — card is
+    // now a read-only preview. The Apply action moved to the bottom
+    // Save button so there's a single save affordance. Applied state
+    // is communicated via the receipt message in chat + the Save
+    // button disappearing when pending_proposal_exists flips to false.
     Column(
         modifier =
             Modifier
@@ -455,35 +450,12 @@ private fun CoachProposalCard(
             style = LocalAppTopography.current.smSemiBold,
             color = YralColors.Pink300,
         )
-        Spacer(modifier = Modifier.height(8.dp))
         if (reasoning.isNotBlank()) {
+            Spacer(modifier = Modifier.height(8.dp))
             Text(
                 text = reasoning,
                 style = LocalAppTopography.current.regRegular,
                 color = YralColors.NeutralTextPrimary,
-            )
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        color = if (applied) YralColors.Neutral700 else YralColors.Pink300,
-                        shape = RoundedCornerShape(20.dp),
-                    ).clickable(enabled = !applied, onClick = onApplyClick)
-                    .padding(vertical = 10.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text =
-                    if (applied) {
-                        stringResource(Res.string.coach_proposal_applied)
-                    } else {
-                        stringResource(Res.string.coach_proposal_apply_cta)
-                    },
-                style = LocalAppTopography.current.baseSemiBold,
-                color = YralColors.Neutral0,
             )
         }
     }

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
@@ -227,11 +227,28 @@ class CoachViewModel(
     }
 
     fun confirmApplyProposal() {
-        val convId = _viewState.value.coachConversationId ?: return
+        val state = _viewState.value
+        val convId = state.coachConversationId ?: return
+        // PR-3 (#356) — pass the specific proposal id the user is acting
+        // on. Today's UI only ever surfaces the latest unapplied proposal,
+        // so `activeProposalMessage.id` is the natural pick (matches the
+        // visible card). If we later add per-card Apply (e.g. scroll-up
+        // re-apply), this should switch to the tapped card's id instead.
+        // Guard: if there's no pending proposal somehow, bail rather than
+        // send an empty id (backend would 422 us).
+        val proposalId =
+            state.activeProposalMessage?.id ?: run {
+                Logger.e("CoachViewModel") { "confirmApplyProposal: no activeProposalMessage to apply" }
+                return
+            }
         _viewState.update { it.copy(isApplying = true, showApplyConfirm = false, error = null) }
         viewModelScope.launch {
-            applyCoachProposalUseCase(convId)
-                .onSuccess { result ->
+            applyCoachProposalUseCase(
+                ApplyCoachProposalUseCase.Params(
+                    coachConversationId = convId,
+                    proposalId = proposalId,
+                ),
+            ).onSuccess { result ->
                     _viewState.update { state ->
                         // Mark latest proposal as applied (ProposalCard becomes
                         // inert), then append the backend-issued receipt

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
@@ -74,6 +74,10 @@ class CoachViewModel(
                 showApplyConfirm = false,
                 showStartOverConfirm = false,
                 lastAppliedToastMessage = null,
+                // PR-4 — fresh session has no proposal until the backend
+                // says so; loadHistoryAndFinishLoading will set this from
+                // the list-messages response.
+                pendingProposalExists = false,
                 isSessionLoading = true,
                 error = null,
             )
@@ -107,13 +111,21 @@ class CoachViewModel(
 
     private suspend fun loadHistoryAndFinishLoading(coachConversationId: String) {
         listCoachMessagesUseCase(coachConversationId)
-            .onSuccess { messages ->
+            .onSuccess { page ->
                 _viewState.update {
                     // Guard against late responses after Start over.
                     if (it.coachConversationId != coachConversationId) {
                         it
                     } else {
-                        it.copy(pending = messages, isSessionLoading = false)
+                        it.copy(
+                            pending = page.messages,
+                            // PR-4 (2026-06-11) — session reload drives the
+                            // Save button gate. Without this, returning to
+                            // a conversation that has a pending proposal
+                            // would show no Save button until the next send.
+                            pendingProposalExists = page.pendingProposalExists,
+                            isSessionLoading = false,
+                        )
                     }
                 }
             }.onFailure { error ->
@@ -194,6 +206,10 @@ class CoachViewModel(
                         pending = mapped,
                         pendingCoachPlaceholderId = null,
                         isCoachThinking = false,
+                        // PR-4 (2026-06-11) — backend-computed against
+                        // post-turn state, so a proposal emitted this
+                        // turn flips the Save button on immediately.
+                        pendingProposalExists = result.pendingProposalExists,
                     )
                 }
             }.onFailure { error ->
@@ -232,6 +248,9 @@ class CoachViewModel(
                             pending = updatedPending,
                             isApplying = false,
                             lastAppliedToastMessage = "Updated ${state.botName ?: "your AI Influencer"}'s personality.",
+                            // PR-4 — apply succeeded, no more pending
+                            // proposal until the creator chats more.
+                            pendingProposalExists = false,
                         )
                     }
                 }.onFailure { error ->
@@ -288,6 +307,13 @@ data class CoachViewState(
     val showStartOverConfirm: Boolean = false,
     val isApplying: Boolean = false,
     val lastAppliedToastMessage: String? = null,
+    /**
+     * PR-4 (2026-06-11) — backend-computed flag from message-list and
+     * send-message responses. Drives the Save-button gate: button is
+     * hidden when false so the creator can't tap Save with nothing to
+     * save (which used to trigger a "mystery LLM round-trip").
+     */
+    val pendingProposalExists: Boolean = false,
     val error: CoachError? = null,
 ) {
     val activeProposalMessage: CoachMessage?
@@ -305,8 +331,6 @@ data class CoachViewState(
             return firstCoach?.suggestions.orEmpty()
         }
 
-    val canRequestSave: Boolean
-        get() = pending.any { it.role == CoachMessageRole.CREATOR }
 }
 
 sealed class CoachError {

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
@@ -142,16 +142,6 @@ class CoachViewModel(
         sendInternal(content = text, requestProposal = false)
     }
 
-    /**
-     * "Save changes to {bot}" — sends the accumulated coaching intent and
-     * asks the backend to force a structured proposal (request_proposal=true).
-     * The coach reply will populate proposedChanges, the existing ProposalCard
-     * renders, and the Apply confirm flow takes over unchanged.
-     */
-    fun requestSaveProposal() {
-        sendInternal(content = SAVE_PROMPT_TEXT, requestProposal = true)
-    }
-
     private fun sendInternal(
         content: String,
         requestProposal: Boolean,
@@ -357,10 +347,6 @@ class CoachViewModel(
      */
     fun dismissPostApplyCtas() {
         _viewState.update { it.copy(postApplyCtasDismissed = true) }
-    }
-
-    private companion object {
-        const val SAVE_PROMPT_TEXT = "Save these changes."
     }
 }
 

--- a/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
+++ b/shared/features/coach/src/commonMain/kotlin/com/yral/shared/features/coach/viewmodel/CoachViewModel.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.yral.shared.features.coach.domain.models.CoachMessage
 import com.yral.shared.features.coach.domain.models.CoachMessageRole
+import com.yral.shared.features.coach.domain.models.ProposalStatus
 import com.yral.shared.features.coach.domain.usecases.ApplyCoachProposalUseCase
 import com.yral.shared.features.coach.domain.usecases.CreateCoachSessionUseCase
 import com.yral.shared.features.coach.domain.usecases.ListCoachMessagesUseCase
@@ -78,6 +79,9 @@ class CoachViewModel(
                 // says so; loadHistoryAndFinishLoading will set this from
                 // the list-messages response.
                 pendingProposalExists = false,
+                // Correction C — entering a session is a clean slate;
+                // don't carry a prior session's CTA dismissal into this one.
+                postApplyCtasDismissed = false,
                 isSessionLoading = true,
                 error = null,
             )
@@ -182,6 +186,11 @@ class CoachViewModel(
                 pending = it.pending + creatorLocal + coachPlaceholder,
                 pendingCoachPlaceholderId = localCoachId,
                 isCoachThinking = true,
+                // Per Rishi — once the creator types again, the
+                // existing proposal's Apply hides. Only a fresh new
+                // proposal in the reply re-opens an Apply somewhere
+                // (on the new card).
+                activeProposalLockedBySend = true,
             )
         }
 
@@ -202,14 +211,23 @@ class CoachViewModel(
                                 else -> msg
                             }
                         }
+                    // Per Rishi — clear the lock ONLY when Coach's
+                    // reply itself is a new proposal. Otherwise the
+                    // older proposal stays locked (no Apply
+                    // re-appears) until the next send-and-propose
+                    // cycle. hasProposal looks at the new message's
+                    // proposed_changes.
+                    val replyIsNewProposal = result.coachMessage.hasProposal
                     state.copy(
                         pending = mapped,
                         pendingCoachPlaceholderId = null,
                         isCoachThinking = false,
                         // PR-4 (2026-06-11) — backend-computed against
-                        // post-turn state, so a proposal emitted this
-                        // turn flips the Save button on immediately.
+                        // post-turn state. Stays in sync with backend
+                        // for any UI that wants to know "is something
+                        // pending server-side."
                         pendingProposalExists = result.pendingProposalExists,
+                        activeProposalLockedBySend = !replyIsNewProposal,
                     )
                 }
             }.onFailure { error ->
@@ -254,12 +272,30 @@ class CoachViewModel(
                         // inert), then append the backend-issued receipt
                         // message so the creator sees a "✅ Saved" record
                         // without needing to re-list.
+                        // Mark the proposal we just applied as APPLIED
+                        // status (post-PR-3 the lifecycle is the source
+                        // of truth) and keep the legacy `applied` bool
+                        // synced for any callers still reading it.
+                        // Append the backend-issued receipt as the most
+                        // recent message — flagged `isReceipt=true` so
+                        // the screen renders it distinctly and shows
+                        // the post-apply CTA pair below it.
                         val updatedPending =
                             state.pending
                                 .map { msg ->
-                                    if (msg.hasProposal && !msg.applied) msg.copy(applied = true) else msg
+                                    if (msg.id == proposalId) {
+                                        msg.copy(
+                                            status = ProposalStatus.APPLIED,
+                                            applied = true,
+                                        )
+                                    } else {
+                                        msg
+                                    }
                                 }.let { withApplied ->
-                                    result.receiptMessage?.let { receipt -> withApplied + receipt } ?: withApplied
+                                    result.receiptMessage
+                                        ?.copy(isReceipt = true)
+                                        ?.let { receipt -> withApplied + receipt }
+                                        ?: withApplied
                                 }
                         state.copy(
                             pending = updatedPending,
@@ -268,6 +304,13 @@ class CoachViewModel(
                             // PR-4 — apply succeeded, no more pending
                             // proposal until the creator chats more.
                             pendingProposalExists = false,
+                            // Correction C — fresh receipt + dismiss
+                            // flag reset, so the CTA pair shows below
+                            // it until the user taps Continue.
+                            postApplyCtasDismissed = false,
+                            // Apply was just done — the lock is moot
+                            // because there's nothing pending anyway.
+                            activeProposalLockedBySend = false,
                         )
                     }
                 }.onFailure { error ->
@@ -306,6 +349,16 @@ class CoachViewModel(
         _viewState.update { it.copy(lastAppliedToastMessage = null) }
     }
 
+    /**
+     * Correction C — creator tapped "Continue coaching" on the
+     * post-apply CTA pair. Just hides the CTAs; the input area stays
+     * usable and the chat stays put. The CTAs only re-appear when a
+     * fresh receipt arrives via [confirmApplyProposal].
+     */
+    fun dismissPostApplyCtas() {
+        _viewState.update { it.copy(postApplyCtasDismissed = true) }
+    }
+
     private companion object {
         const val SAVE_PROMPT_TEXT = "Save these changes."
     }
@@ -331,10 +384,40 @@ data class CoachViewState(
      * save (which used to trigger a "mystery LLM round-trip").
      */
     val pendingProposalExists: Boolean = false,
+    /**
+     * Correction C — transient flag flipped TRUE when the creator taps
+     * "Continue coaching" on the post-apply CTA pair. Reset to FALSE
+     * when a fresh apply happens (so the CTAs come back for the next
+     * apply). Never persisted — re-entering Coach starts as FALSE.
+     */
+    val postApplyCtasDismissed: Boolean = false,
+    /**
+     * Per Rishi 2026-06-12 evening — the moment the creator starts
+     * typing again, the existing proposal's Apply becomes invisible.
+     * It only re-appears if Coach's NEXT reply carries a brand-new
+     * proposal. If Coach replies without a proposal, the older one
+     * stays disabled forever (forcing the creator to ask Coach to
+     * formalize the new idea before they can apply). This is mobile-
+     * local; backend should eventually mirror with supersede-on-send
+     * — flagged to Session 6.
+     */
+    val activeProposalLockedBySend: Boolean = false,
     val error: CoachError? = null,
 ) {
     val activeProposalMessage: CoachMessage?
         get() = pending.lastOrNull { it.hasProposal && !it.applied }
+
+    /**
+     * Correction C — show the "Continue coaching / I'm done for now"
+     * CTA pair below the latest message when the most recent message
+     * is a receipt AND there's nothing new to save AND the creator
+     * hasn't already dismissed the CTAs from this apply.
+     */
+    val showPostApplyCtaPair: Boolean
+        get() =
+            !postApplyCtasDismissed &&
+                !pendingProposalExists &&
+                pending.lastOrNull()?.isReceipt == true
 
     /**
      * Opening suggestion chips — drawn from the first coach message ONLY


### PR DESCRIPTION
## Summary

Coach pivot — Bucket 1 Items 2 + 3 coordinated ship, with four follow-up corrections from Rishi's Motorola feedback on 2026-06-12.

**Final UX (after corrections):**
- ONE save affordance: the **Apply button on the proposal card**
- No bottom Save button (removed entirely)
- Visible only while \`status == PENDING\` AND the creator hasn't typed again since the proposal arrived
- The moment the creator types again, the older proposal's Apply hides; only Coach's next reply containing a NEW proposal re-enables Apply (on the new card)
- Tapping Apply opens the apply-confirm dialog → \`/apply\` with explicit \`proposal_id\` (PR-3 contract)

## Wire path (PR-3 / proposal_id binding)

- New \`ApplyCoachProposalRequestDto { proposal_id }\`
- \`CoachDataSource.applyProposal\` + \`CoachRemoteDataSource\` send body on \`POST /api/v1/creator/coach/conversations/{id}/apply\`
- \`CoachRepository.applyProposal\` takes \`proposalId\`
- \`ApplyCoachProposalUseCase.Params { coachConversationId, proposalId }\`
- \`CoachViewModel.confirmApplyProposal\` reads \`state.activeProposalMessage?.id\` (the latest unapplied — what the visible card represents) and passes it. Bails with \`Logger.e\` if there's no pending — backend would 422 us otherwise.

## Wire path (PR-4 / pending_proposal_exists)

- DTO additions on \`SendCoachMessageResponseDto\` + \`ListCoachMessagesResponseDto\` (defaults \`false\` for back-compat)
- New \`CoachMessagesPage\` wrapper for list-messages — \`List<CoachMessage>\` couldn't carry the flag
- \`CoachViewState.pendingProposalExists\` — set on send-success / list-success / apply-success / fresh-session entry
- Used internally by the ViewModel to track session state; the Save button it originally gated no longer exists per Rishi's preference.

## Status-aware proposal card (PR-3 / status field)

PR-3 ships \`status\` (\`'pending' | 'applied' | 'superseded' | 'discarded' | 'na'\`) + \`status_changed_at\` on every coach_message. Mobile reads both; \`CoachProposalCard\` branches:

- **PENDING** → active pink Apply button
- **APPLIED** → "Applied" subtitle, no button
- **SUPERSEDED** → "Replaced by a newer proposal" subtitle, no button
- **DISCARDED** → "Discarded" subtitle, no button

Plus a mobile-local \`activeProposalLockedBySend\` flag that locks the active proposal's Apply on every \`sendInternal\`, cleared only when Coach's next reply contains a fresh proposal (\`result.coachMessage.hasProposal\`). Renders identically to SUPERSEDED while locked.

## Post-apply CTA pair + input area hides

After an Apply succeeds, the backend appends a receipt message. Mobile flags it locally with \`isReceipt: Boolean = true\` (set only on the \`receiptMessage\` mapping in \`confirmApplyProposal\`). The receipt renders with a pink-bordered bubble (distinct from regular coach replies).

Below the latest receipt, a CTA row appears:

\`\`\`
[Continue coaching]  [I'm done for now]
\`\`\`

- **Continue coaching** → dismisses the CTAs, restores the input area, lets the creator keep typing
- **I'm done for now** → \`component.onBack()\` (navigates back to bot profile)

**The input area is HIDDEN while the CTAs are visible** — forced decision moment, no competing affordance (Rishi: ADHD-friendly, matches \`feedback_adhd_observability\` operating model).

\`postApplyCtasDismissed: Boolean\` resets to FALSE on every fresh apply so the CTAs return for the next decision.

## Override-proposal handling (Coach Fix 1 PR-B)

Coach Fix 1 PR-B (backend #333) emits proposals on \`proposed_global_rule_override\` instead of \`proposed_changes\` when the creator's request conflicts with a platform-default rule (\`response_length\`, \`language_mirror\`). Pre-fix \`CoachMessageDto\` didn't map this field, so the proposal card never rendered for override turns — Apply button was invisible.

**Fix:**
- Add \`proposed_global_rule_override: JsonElement?\` to \`CoachMessageDto\`
- Derive \`hasOverrideProposal: Boolean\` on the domain model
- OR into \`hasProposal\` so the same card + Apply flow handles both types

Backend dispatches the correct write on \`/apply\` based on which field is set. Verified end-to-end: \`SELECT global_rule_overrides FROM ai_influencers WHERE display_name ILIKE '%anastasia%'\` returns \`{"response_length": "default"}\` after Rishi's "make replies default length" apply.

## Override apply MissingFieldException fix

Backend's apply response shape varies by proposal type:

| Proposal type | Response carries |
|---|---|
| personality (\`proposed_changes\`) | \`previous_instructions\` + \`new_instructions\` (full text) |
| override (\`proposed_global_rule_override\`) | \`override_key\` + \`override_value\`, omits previous/new_instructions |
| section change (Bucket 2) | section-specific, also omits previous/new_instructions |

Pre-fix mobile declared \`previous_instructions\` / \`new_instructions\` as non-nullable Strings. Override-apply returned 200 OK without those fields → \`kotlinx.serialization.MissingFieldException\` thrown at deserialize → mobile surfaced "could not apply" → creator tapped again → got 409 because backend had ALREADY flipped \`status='applied'\`.

**Fix:** \`previousInstructions\` / \`newInstructions\` / \`appliedAt\` all nullable with null defaults on both \`ApplyCoachProposalResponseDto\` and the domain \`ApplyCoachProposalResult\`. Mobile only ever reads \`receiptMessage\`; the omitted fields are harmless.

## Coach LLM timeout bump (re-applied)

Per-call 90s timeout on \`/messages\` and \`/apply\` via Ktor \`timeout { requestTimeoutMillis = COACH_LLM_TIMEOUT_MS }\`. Coach LLM calls routinely take 30-60s; the global HttpClient 30s default was cutting them off mid-reply. Stays until Session 6 ships streaming.

## Test plan (verified on Motorola today, all 6 chat flags flipped on locally)

- [x] **T1** — Single Apply button on the proposal card. No Save button anywhere on the screen.
- [x] **T2** — Lock-on-send: typing after a proposal arrives hides its Apply mid-send. Re-appears only if Coach's reply contains a fresh proposal.
- [x] **T3** — Stale "Replaced by newer proposal" subtitle for \`status='superseded'\`.
- [x] **T4** — Apply → confirm → receipt bubble (pink border) + CTA pair appears + input box hides.
- [x] **T5** — "Continue coaching" → CTAs hide, input returns, can keep typing.
- [x] **T6** — "I'm done for now" → navigates back to bot profile.
- [x] **T7** — Override apply: "make her replies longer / shorter / default" works end-to-end. DB confirms \`global_rule_overrides\` updated.
- [x] **T8** — Personality apply: "make her funnier" / "more sarcastic" still works.
- [x] **T9** — Compiles clean (\`./gradlew :androidApp:assembleProdDebug\`).

## Flag posture

All chat/agent flags remain \`defaultValue=false\` on this PR (cutover-gate rule). Local flips used only for the Motorola test; reverted before commit. Pre-commit hook would block any flag flip from landing.

## Out of scope (parked)

- The preview-before-apply diff view in the confirm dialog (parked until Bucket 2 section data model — section-level Before/After is the right shape)
- \`requestSaveProposal()\` left as an orphan in \`CoachViewModel\` — no UI calls it. Removable in a follow-up cleanup.

## Related

- **Item 1**: PR #1191 (\`proposedChanges\` blob removal)
- **Bucket 2 data layer**: PR #1193 (Soul File DTO + endpoints + section_hint plumbing)
- **Backend**: PR-3 #356, PR-4 #350, parser fixes #347 #349, Sentry capture #351, override JSONB fix #370, Bucket 2 PR-2/PR-3 #366/#367

🤖 Generated with [Claude Code](https://claude.com/claude-code)