### PR TITLE
feat(nav): bottom-nav swap — Discover first, Video feed second (21γ.P16)

### DIFF
--- a/shared/app/src/commonMain/composeResources/drawable/video_feed_nav_selected.xml
+++ b/shared/app/src/commonMain/composeResources/drawable/video_feed_nav_selected.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <!--
+      "Smart display" / Reels-style glyph: rounded rectangle frame + a
+      centered play triangle. Solid white fill (#FAFAFA) for the
+      selected state, matching the existing nav-icon weight.
+    -->
+    <path
+        android:fillColor="#FAFAFA"
+        android:pathData="M9,5 L23,5 A4,4 0 0 1 27,9 L27,23 A4,4 0 0 1 23,27 L9,27 A4,4 0 0 1 5,23 L5,9 A4,4 0 0 1 9,5 Z M14,11.2 L14,20.8 L21.6,16 Z" />
+</vector>

--- a/shared/app/src/commonMain/composeResources/drawable/video_feed_nav_unselected.xml
+++ b/shared/app/src/commonMain/composeResources/drawable/video_feed_nav_unselected.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+    <!--
+      Unselected variant: outlined rounded rectangle frame + filled
+      play triangle. Stroke + triangle both #FAFAFA, lighter weight
+      to match other unselected nav icons.
+    -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FAFAFA"
+        android:strokeWidth="2"
+        android:strokeLineJoin="round"
+        android:pathData="M9,5 L23,5 A4,4 0 0 1 27,9 L27,23 A4,4 0 0 1 23,27 L9,27 A4,4 0 0 1 5,23 L5,9 A4,4 0 0 1 9,5 Z" />
+    <path
+        android:fillColor="#FAFAFA"
+        android:pathData="M14,11.2 L14,20.8 L21.6,16 Z" />
+</vector>

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/DefaultRootComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/DefaultRootComponent.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import co.touchlab.kermit.Logger
+import com.yral.featureflag.FeatureFlagManager
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.router.slot.SlotNavigation
@@ -66,6 +67,7 @@ class DefaultRootComponent(
 
     // ==================== Dependencies ====================
     private val sessionManager: SessionManager = koinInstance.get()
+    private val featureFlagManager: FeatureFlagManager = koinInstance.get()
     override val loginViewModel: LoginViewModel = koinInstance.get()
     override val rootViewModel: RootViewModel = koinInstance.get()
 
@@ -121,6 +123,7 @@ class DefaultRootComponent(
             loginCoordinator = this,
             setHomeComponent = { homeComponent = it },
             showAlertsOnDialog = ::showAlertsSlot,
+            featureFlagManager = featureFlagManager,
         )
 
     // ==================== Navigation Stacks ====================

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/factories/ComponentFactory.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/factories/ComponentFactory.kt
@@ -1,6 +1,7 @@
 package com.yral.shared.app.nav.factories
 
 import com.arkivanov.decompose.ComponentContext
+import com.yral.featureflag.FeatureFlagManager
 import com.yral.shared.analytics.events.BotCreationSource
 import com.yral.shared.app.nav.Config
 import com.yral.shared.app.nav.RootComponent
@@ -35,6 +36,7 @@ internal class ComponentFactory(
     private val loginCoordinator: LoginCoordinator,
     private val setHomeComponent: (HomeComponent) -> Unit,
     private val showAlertsOnDialog: (AlertsRequestType) -> Unit,
+    private val featureFlagManager: FeatureFlagManager,
 ) {
     fun createSplash(componentContext: ComponentContext): SplashComponent =
         SplashComponent(
@@ -58,6 +60,7 @@ internal class ComponentFactory(
                     rootComponent.rootViewModel.switchToMainAccount(onComplete)
                 },
                 showAlertsOnDialog = showAlertsOnDialog,
+                featureFlagManager = featureFlagManager,
             )
         setHomeComponent(component)
         return component

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/HomeScreen.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/HomeScreen.kt
@@ -44,6 +44,7 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.arkivanov.decompose.extensions.compose.stack.Children
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.yral.featureflag.AppFeatureFlags
 import com.yral.featureflag.FeatureFlagManager
 import com.yral.shared.analytics.events.CategoryName
 import com.yral.shared.analytics.events.SignupPageName
@@ -97,6 +98,8 @@ import yral_mobile.shared.app.generated.resources.profile_nav_selected
 import yral_mobile.shared.app.generated.resources.profile_nav_unselected
 import yral_mobile.shared.app.generated.resources.upload_video_nav_selected
 import yral_mobile.shared.app.generated.resources.upload_video_nav_unselected
+import yral_mobile.shared.app.generated.resources.video_feed_nav_selected
+import yral_mobile.shared.app.generated.resources.video_feed_nav_unselected
 import yral_mobile.shared.app.generated.resources.wallet_nav
 import yral_mobile.shared.app.generated.resources.wallet_nav_unselected
 import yral_mobile.shared.libs.designsystem.generated.resources.account_nav
@@ -362,9 +365,21 @@ private fun getProfileVideos(
 private fun getVisibleTabs(): List<HomeTab> {
     val flagManager = koinInject<FeatureFlagManager>()
     val chatWalletConfig = flagManager.getWalletConfig()
+    val swapNav = flagManager.isEnabled(AppFeatureFlags.Common.BottomNavSwapEnabled)
     return buildList {
-        add(HomeTab.HOME)
-        if (chatWalletConfig.first) add(HomeTab.CHAT)
+        // 21γ.P16 — when the swap flag is ON AND Chat is in the visible
+        // set (i.e. wallet-vs-chat resolved Chat), put CHAT in position 1
+        // and HOME in position 2. Visually the slot 1 icon stays the
+        // home glyph (handled in NavBarIconWithBadge) and slot 2 gets a
+        // Reels-style play glyph. When the flag is OFF, or Chat is not
+        // visible at all, the order is exactly today's.
+        if (swapNav && chatWalletConfig.first) {
+            add(HomeTab.CHAT)
+            add(HomeTab.HOME)
+        } else {
+            add(HomeTab.HOME)
+            if (chatWalletConfig.first) add(HomeTab.CHAT)
+        }
         add(HomeTab.UPLOAD_VIDEO)
         add(HomeTab.WALLET)
         add(HomeTab.PROFILE)
@@ -378,6 +393,9 @@ private fun HomeNavigationBar(
     updateCurrentTab: (tab: HomeTab) -> Unit,
     bottomNavigationClicked: (categoryName: CategoryName) -> Unit,
 ) {
+    val flagManager = koinInject<FeatureFlagManager>()
+    val navSwapEnabled =
+        remember(flagManager) { flagManager.isEnabled(AppFeatureFlags.Common.BottomNavSwapEnabled) }
     var playSound by remember { mutableStateOf(false) }
     val tabs = getVisibleTabs()
     val insetHeightPx = NavigationBarDefaults.windowInsets.getBottom(LocalDensity.current)
@@ -402,6 +420,7 @@ private fun HomeNavigationBar(
                         isSelected = currentTab == tab,
                         tab = tab,
                         badgeCount = if (tab == HomeTab.CHAT) chatUnreadCount else 0,
+                        navSwapEnabled = navSwapEnabled,
                     )
                 },
                 colors =
@@ -426,6 +445,7 @@ private fun NavBarIcon(
     isSelected: Boolean,
     tab: HomeTab,
     badgeCount: Int,
+    navSwapEnabled: Boolean = false,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -451,6 +471,7 @@ private fun NavBarIcon(
             tab = tab,
             isSelected = isSelected,
             badgeCount = badgeCount,
+            navSwapEnabled = navSwapEnabled,
         )
     }
 }
@@ -460,6 +481,7 @@ private fun NewTaggedColumn(
     tab: HomeTab,
     isSelected: Boolean,
     badgeCount: Int,
+    navSwapEnabled: Boolean = false,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -489,14 +511,22 @@ private fun NewTaggedColumn(
             Spacer(modifier = Modifier.weight(1f))
         }
 
-        val icon =
-            if (isSelected) {
-                tab.icon
-            } else {
-                tab.unSelectedIcon
+        // 21γ.P16 — when the swap flag is ON the slot 1 icon (CHAT
+        // destination) shows the home glyph and the slot 2 icon (HOME
+        // destination, i.e. the video feed) shows the Reels-style play
+        // glyph. Tab destinations remain the canonical HomeTab values;
+        // only the glyph is swapped to match the new visual order.
+        val effectiveIcon =
+            when {
+                !navSwapEnabled -> if (isSelected) tab.icon else tab.unSelectedIcon
+                tab == HomeTab.CHAT && isSelected -> Res.drawable.home_nav_selected
+                tab == HomeTab.CHAT -> Res.drawable.home_nav_unselected
+                tab == HomeTab.HOME && isSelected -> Res.drawable.video_feed_nav_selected
+                tab == HomeTab.HOME -> Res.drawable.video_feed_nav_unselected
+                else -> if (isSelected) tab.icon else tab.unSelectedIcon
             }
         NavBarIconWithBadge(
-            icon = icon,
+            icon = effectiveIcon,
             title = tab.title,
             badgeText = chatUnreadBadgeText(badgeCount),
         )

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/DefaultHomeComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/DefaultHomeComponent.kt
@@ -2,6 +2,9 @@ package com.yral.shared.app.ui.screens.home.nav
 
 import co.touchlab.kermit.Logger
 import com.arkivanov.decompose.ComponentContext
+import com.yral.featureflag.AppFeatureFlags
+import com.yral.featureflag.ChatFeatureFlags
+import com.yral.featureflag.FeatureFlagManager
 import com.arkivanov.decompose.router.slot.ChildSlot
 import com.arkivanov.decompose.router.slot.SlotNavigation
 import com.arkivanov.decompose.router.slot.activate
@@ -61,6 +64,7 @@ internal class DefaultHomeComponent(
     private val openAccountSheet: () -> Unit,
     private val switchToMainProfile: (onComplete: (Boolean) -> Unit) -> Unit,
     override val showAlertsOnDialog: (type: AlertsRequestType) -> Unit,
+    private val featureFlagManager: FeatureFlagManager,
 ) : HomeComponent(),
     ComponentContext by componentContext {
     private val navigation = StackNavigation<Config>()
@@ -68,11 +72,24 @@ internal class DefaultHomeComponent(
     private var lastActiveConfig: Config? = null
     private var lastActiveProvider: HomeChildSnapshotProvider? = null
 
+    /**
+     * 21γ.P16 — when the bottom-nav swap flag is ON, the home root lands
+     * on the chat Discover/Inbox child (carrying the search bar from
+     * PR #1197) instead of the video feed. The flag is read once on
+     * construction so a mid-session flip doesn't re-route a user
+     * already navigating the stack.
+     */
+    private val landOnChatInitially: Boolean =
+        featureFlagManager.isEnabled(AppFeatureFlags.Common.BottomNavSwapEnabled) &&
+            featureFlagManager.isEnabled(ChatFeatureFlags.Chat.Enabled)
+
     override val stack: Value<ChildStack<*, Child>> =
         childStack(
             source = navigation,
             serializer = Config.serializer(),
-            initialConfiguration = Config.Feed,
+            initialConfiguration =
+                if (landOnChatInitially) Config.Chat(initialTab = InitialTab.DISCOVER)
+                else Config.Feed,
             handleBackButton = true,
             childFactory = ::child,
         ).also { stackValue ->

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/HomeComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/ui/screens/home/nav/HomeComponent.kt
@@ -90,6 +90,7 @@ abstract class HomeComponent {
             openAccountSheet: () -> Unit,
             switchToMainProfile: (onComplete: (Boolean) -> Unit) -> Unit,
             showAlertsOnDialog: (type: AlertsRequestType) -> Unit,
+            featureFlagManager: FeatureFlagManager,
         ): HomeComponent =
             DefaultHomeComponent(
                 componentContext,
@@ -104,6 +105,7 @@ abstract class HomeComponent {
                 openAccountSheet,
                 switchToMainProfile,
                 showAlertsOnDialog,
+                featureFlagManager,
             )
     }
 }

--- a/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/AppFeatureFlags.kt
+++ b/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/AppFeatureFlags.kt
@@ -30,6 +30,21 @@ object AppFeatureFlags {
                 description = "Require users to sign in before accessing the app",
                 defaultValue = false,
             )
+        val BottomNavSwapEnabled: FeatureFlag<Boolean> =
+            boolean(
+                keySuffix = "bottomNavSwapEnabled",
+                name = "Bottom-nav swap (Discover first, Video feed second)",
+                description = "When ON, swaps bottom-nav positions 1 and 2 so the chat " +
+                    "Discover / Inbox tab (the one carrying the search bar from PR #1197) " +
+                    "becomes the default landing — position 1 keeps the home-icon glyph but " +
+                    "now opens Discover. The video feed moves to position 2 with a Reels-" +
+                    "style play icon. Other nav slots (Upload, Wallet, Profile, Account) are " +
+                    "untouched. When OFF, the nav order and default landing are exactly as " +
+                    "today (Feed in position 1). Alpha-team-first rollout per 21γ.P16; instant " +
+                    "rollback is a server-side flag flip. PR keeps defaultValue = false until " +
+                    "alpha sign-off + ramp.",
+                defaultValue = false,
+            )
     }
 
     object Android :


### PR DESCRIPTION
## Summary

Flag-gated swap of bottom-nav slots 1 and 2. When `BottomNavSwapEnabled` is ON, the chat Discover / Inbox tab becomes the default landing — slot 1 keeps the home-glyph but now opens Chat, slot 2 gets a new Reels-style play glyph and opens the video feed. When OFF, the order and default landing are exactly as today. Pure UI; no backend changes.

## Decisions worth flagging

- **Flag-gated** even though the change touches no agent endpoints. Same instant-rollback story as the discovery-feed work — alpha team flips → ramp → 100%. Server-side flip back to `false` reverses everything within minutes; no app update needed.
- **The home glyph stays in slot 1.** Rishi confirmed this on the brief. Only the destination behind it changes (from Feed to Chat). Slot 2 gets a brand-new vector (`video_feed_nav_*.xml`) — rounded-rectangle frame + filled play triangle, 32dp/`#FAFAFA`, matching the existing nav-icon weight.
- **Flag read once at construction.** `DefaultHomeComponent.landOnChatInitially` is computed in the init block, not re-read per frame. A mid-session flip won't re-route a user already navigating the back-stack. Also gated on `Chat.Enabled` so the swap is a no-op when chat itself is off.
- **Independent of the PR #1197 flags** (`DiscoveryFeedV2Enabled`, `DiscoverySearchEnabled`). On the alpha rollout all three flip together to give the full intended UX; each can roll back independently.
- **Other slots untouched.** Upload, Wallet, Profile, Account behave exactly as today regardless of the flag.

## Wire surface

| Concern | File |
|---|---|
| Flag | `AppFeatureFlags.Common.BottomNavSwapEnabled` |
| Default landing | `DefaultHomeComponent.landOnChatInitially` + `initialConfiguration` switch |
| Tab order | `HomeScreen.getVisibleTabs` |
| Icon swap | `HomeScreen.NavBarIcon` + `NewTaggedColumn` (new `navSwapEnabled` param threaded from `HomeNavigationBar`) |
| Flag plumbing | `HomeComponent.invoke` → `DefaultHomeComponent` ctor → `ComponentFactory.createHome` → `DefaultRootComponent` (Koin) |
| New drawables | `video_feed_nav_selected.xml` + `video_feed_nav_unselected.xml` |

## Process checklist (lesson from PR #1197 round 2)

- [x] `./gradlew :shared:app:compileKotlinIosSimulatorArm64` clean (the iOS-target check that caught us last time)
- [x] `./gradlew detekt` clean
- [x] `./gradlew :androidApp:compileProdDebugKotlin` clean
- [x] My own Motorola pass with flag flipped local-only
- [x] Rishi's Motorola pass on bundled APK — explicit "go" 2026-06-19

## Test plan (verified end-to-end on Motorola)

- [x] **T1** — Cold-launch lands on the Chat tab (Discover sub-tab), not the video feed
- [x] **T2** — Slot 1 shows the home glyph (selected on landing); slot 2 shows the new Reels-style icon
- [x] **T3** — Tapping slot 2 navigates to the video feed; real content loads; pink underline follows
- [x] **T4** — Tapping slot 1 returns to Chat
- [x] **T5** — Upload, Wallet, Profile slots behave exactly as today
- [x] **T6** — Flag flipped back to `false` → order + landing revert to today's behaviour (verified locally before commit)

## Not in this PR

- Search bar on the Chat tab — `DiscoverySearchEnabled` from #1197; independent flag, alpha rollout flips both together
- Discovery v2 feed — `DiscoveryFeedV2Enabled` from #1197; same

## Rollback

`BottomNavSwapEnabled = false` via Remote Config. OFF path is byte-identical to pre-this-branch behaviour. No app update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)