### PR TITLE
feat(chat): login-on-first-send gate (RequireAuthBeforeFirstSend)

### DIFF
--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -292,7 +292,13 @@ fun ChatConversationScreen(
 
     val proDetails by component.subscriptionCoordinator.proDetails.collectAsStateWithLifecycle(ProDetails())
     val shouldPromptForLogin by derivedStateOf {
-        !viewState.isSocialSignedIn && totalMessageCount >= viewState.loginPromptMessageThreshold
+        // Two gates collapse here:
+        //  - Legacy: anonymous user past the ~10-message threshold.
+        //  - RequireAuthBeforeFirstSend: anonymous user, gate on every send/chip
+        //    so login lands on the first interaction instead of mid-conversation.
+        val isAnonymous = !viewState.isSocialSignedIn
+        val pastLegacyThreshold = totalMessageCount >= viewState.loginPromptMessageThreshold
+        isAnonymous && (viewState.requireAuthBeforeFirstSend || pastLegacyThreshold)
     }
     val hasChatAccess by derivedStateOf {
         proDetails.isProPurchased || viewState.isInfluencerSubscriptionPurchasedAndVerified
@@ -357,9 +363,14 @@ fun ChatConversationScreen(
             requestLoginFactory = component.requestLoginFactory,
             key = viewState.influencer,
         )
-    val promptLogin: () -> Unit =
+    // Auto-resume on success: the optional [onSuccess] runs after the user
+    // completes a real login. Cancel just dismisses the sheet — the typed
+    // draft / chip intent is never consumed, so the input keeps what was
+    // there. Login-on-first-send (RequireAuthBeforeFirstSend) uses this to
+    // re-fire the captured send so login feels like a 1-tap unlock.
+    val promptLogin: (() -> Unit) -> Unit =
         remember(viewState.influencer) {
-            {
+            { onSuccess ->
                 val influencer = viewState.influencer
                 val influencerName = influencer?.displayName ?: ""
                 val influencerAvatarUrl = influencer?.avatarUrl ?: ""
@@ -372,7 +383,7 @@ fun ChatConversationScreen(
                         ),
                     ),
                     LoginMode.BOTH,
-                    null,
+                    { onSuccess() },
                     null,
                 ) {}
             }
@@ -402,7 +413,15 @@ fun ChatConversationScreen(
                 }
 
                 shouldPromptForLogin -> {
-                    promptLogin()
+                    // Capture the intended send so successful login auto-resumes
+                    // it (chip-tap or typed draft both flow through this gate).
+                    // On cancel the callback never fires and the input stays as
+                    // typed because onBeforeSend (which clears the field) is
+                    // deferred until after the resumed send.
+                    promptLogin {
+                        onBeforeSend()
+                        viewModel.sendMessage(draft)
+                    }
                     true
                 }
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -146,6 +146,7 @@ class ConversationViewModel(
         MutableStateFlow(
             ConversationViewState(
                 loginPromptMessageThreshold = flagManager.get(ChatFeatureFlags.Chat.LoginPromptMessageThreshold),
+                requireAuthBeforeFirstSend = flagManager.isEnabled(ChatFeatureFlags.Chat.RequireAuthBeforeFirstSend),
                 subscriptionMandatoryThreshold = flagManager.get(ChatFeatureFlags.Chat.SubscriptionMandatoryThreshold),
                 isSubscriptionEnabled = flagManager.isEnabled(AppFeatureFlags.Common.EnableSubscription),
                 isChatAsHumanCreatorEnabled = flagManager.get(ChatFeatureFlags.Chat.ChatAsHumanCreatorEnabled),
@@ -1019,6 +1020,7 @@ class ConversationViewModel(
                 isSocialSignedIn = current.isSocialSignedIn,
                 influencerSource = current.influencerSource,
                 loginPromptMessageThreshold = current.loginPromptMessageThreshold,
+                requireAuthBeforeFirstSend = current.requireAuthBeforeFirstSend,
                 subscriptionMandatoryThreshold = current.subscriptionMandatoryThreshold,
                 isSubscriptionEnabled = current.isSubscriptionEnabled,
                 isChatAsHumanCreatorEnabled = current.isChatAsHumanCreatorEnabled,
@@ -2289,6 +2291,7 @@ data class ConversationViewState(
     val isSocialSignedIn: Boolean = false,
     val influencerSource: ConversationInfluencerSource = ConversationInfluencerSource.CARD,
     val loginPromptMessageThreshold: Int,
+    val requireAuthBeforeFirstSend: Boolean = false,
     val subscriptionMandatoryThreshold: Int,
     val isSubscriptionEnabled: Boolean,
     val isInfluencerSubscriptionPurchasedAndVerified: Boolean = false,

--- a/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
+++ b/shared/libs/feature-flag/src/commonMain/kotlin/com/yral/featureflag/ChatFeatureFlags.kt
@@ -132,6 +132,22 @@ object ChatFeatureFlags {
                     "— same shape as the other agent-API feature gates.",
                 defaultValue = false,
             )
+        val RequireAuthBeforeFirstSend: FeatureFlag<Boolean> =
+            boolean(
+                keySuffix = "requireAuthBeforeFirstSend",
+                name = "Require login before first send",
+                description = "When ON, the contextual login sheet is shown the very first time an " +
+                    "anonymous user sends a message in a bot conversation — either by typing + Send " +
+                    "or by tapping a starter chip — instead of waiting for the ~10-message threshold " +
+                    "(LoginPromptMessageThreshold). The sheet uses the existing CONVERSATION-flavoured " +
+                    "copy (bot name + avatar). Cancel returns to the bot profile with the typed draft " +
+                    "preserved in the input. Successful login auto-resumes the captured action so " +
+                    "login feels like a 1-tap unlock. Users already on a real identity " +
+                    "(Google / Apple / WhatsApp OTP) are unaffected. When OFF, the legacy " +
+                    "message-count threshold gate applies exactly as today. PR keeps defaultValue = " +
+                    "false until alpha sign-off + GA — same shape as the other agent-API feature gates.",
+                defaultValue = false,
+            )
         val DiscoverySearchEnabled: FeatureFlag<Boolean> =
             boolean(
                 keySuffix = "discoverySearchEnabled",


### PR DESCRIPTION
## Summary

- New `RequireAuthBeforeFirstSend` flag (defaultValue=false). When ON, the contextual login sheet fires the **first time** an anonymous user sends a message in a bot conversation — typed Send **or** chip-tap — instead of waiting for the ~10-message `LoginPromptMessageThreshold`.
- Successful login **auto-resumes** the captured intent (chip text or typed draft) so login feels like a 1-tap unlock.
- Cancel keeps the typed draft preserved in the input — `onBeforeSend` never runs when the gate fires, so the field is untouched.

## Behavior

| User state | Flag OFF | Flag ON |
|---|---|---|
| Real identity (Google / Apple / WhatsApp OTP) | sends normally | sends normally (no change) |
| Anonymous, < 10 msgs | sends normally | login sheet on **first** send |
| Anonymous, ≥ 10 msgs | login sheet (legacy) | login sheet (legacy still works) |

Rollback is a server-side flag flip.

## Implementation

- `ChatFeatureFlags.RequireAuthBeforeFirstSend` — defaultValue=false on origin; alpha ramp via Remote Config.
- `ConversationViewState.requireAuthBeforeFirstSend` carries the flag value; also carried through `resetState()`.
- `shouldPromptForLogin` collapses two gates: `isAnonymous && (requireAuthBeforeFirstSend || pastLegacyThreshold)`.
- `promptLogin` now takes an `onSuccess` callback wired to `loginState.requestLogin(..., onSuccess, onDismiss, ...)`. Sheet copy already passes bot name + avatar (`LoginBottomSheetType.CONVERSATION`).
- One gate point (`sendMessageIfAllowed`) covers typed Send, chip-tap, audio send, and image-preview send.

3 files, 43 insertions, 5 deletions.

## Test plan

- [x] Android compile clean (`:shared:features:chat:compileDebugKotlinAndroid`, `:shared:libs:feature-flag:compileDebugKotlinAndroid`)
- [x] iOS native compile clean (`:shared:features:chat:compileKotlinIosSimulatorArm64`)
- [x] detekt clean (`:shared:features:chat:detekt`, `:shared:libs:feature-flag:detekt`)
- [x] Rishi Motorola pass — verified 4 paths:
  - Real-user chip → sends normally (no sheet)
  - Real-user typed → sends normally (no sheet)
  - Anon cancel → sheet shows with bot name+avatar, dismiss preserves typed draft
  - Anon complete-login → sheet shows, login completes, captured action auto-fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)