### PR TITLE
feat(chat): add isBlur to message DTO and blurred image unlock UI

### DIFF
--- a/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/data/ChatAccessBillingDataSource.android.kt
+++ b/shared/features/chat/src/androidMain/kotlin/com/yral/shared/features/chat/data/ChatAccessBillingDataSource.android.kt
@@ -1,3 +1,5 @@
 package com.yral.shared.features.chat.data
 
 internal actual fun getGrantChatAccessEndpoint(): String = "google/chat-access/grant"
+
+internal actual fun getBotSubscriptionGrantEndpoint(): String = "google/bot-subscription/verify"

--- a/shared/features/chat/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/chat/src/commonMain/composeResources/values/strings.xml
@@ -21,6 +21,8 @@
     <string name="camera">Camera</string>
     <string name="photo_library">Photo Library</string>
     <string name="voice_message">Voice message</string>
+    <string name="request_image">Request Image</string>
+    <string name="request_image_message">Requested an image</string>
     <string name="voice_message_permission_denied">Microphone access needed to record voice messages. Enable it in app settings.</string>
     <string name="send">Send</string>
     <string name="switch_to_human_profile_to_chat">Switch to your human profile to chat with this influencer.</string>

--- a/shared/features/chat/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/chat/src/commonMain/composeResources/values/strings.xml
@@ -23,6 +23,13 @@
     <string name="voice_message">Voice message</string>
     <string name="request_image">Request Image</string>
     <string name="request_image_message">Requested an image</string>
+
+    <!-- Collage (Request Images) -->
+    <string name="collage_generating_message">%1$s is putting together some photos… 📸</string>
+    <string name="collage_subscribe_cta">Subscribe to view %1$s\'s photos</string>
+    <string name="collage_unavailable">These photos are no longer available</string>
+    <string name="collage_request_failed_toast">Couldn\'t get photos. Please try again.</string>
+    <string name="collage_quota_used_toast">You\'ve already requested photos today</string>
     <string name="voice_message_permission_denied">Microphone access needed to record voice messages. Enable it in app settings.</string>
     <string name="send">Send</string>
     <string name="switch_to_human_profile_to_chat">Switch to your human profile to chat with this influencer.</string>

--- a/shared/features/chat/src/commonMain/composeResources/values/strings.xml
+++ b/shared/features/chat/src/commonMain/composeResources/values/strings.xml
@@ -44,6 +44,9 @@
     <string name="message_optional">Message (optional)</string>
     <string name="close">Close</string>
 
+    <!-- Blurred (paid) image -->
+    <string name="blurred_image_unlock_cta">Unlock</string>
+
     <!-- Influencer subscription card (replaces ChatInputArea when at threshold) -->
     <string name="influencer_subscription_limited_time_offer">Limited Time Offer</string>
     <string name="influencer_subscription_plan_title">1 Day Plan</string>

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatAccessBillingDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatAccessBillingDataSource.kt
@@ -17,9 +17,19 @@ import kotlinx.serialization.json.Json
 
 internal expect fun getGrantChatAccessEndpoint(): String
 
+internal expect fun getBotSubscriptionGrantEndpoint(): String
+
 interface ChatAccessBillingDataSource {
     val packageName: String
     suspend fun grantChatAccess(request: GrantChatAccessRequestDto): GrantResult
+
+    /**
+     * Verifies/records a per-bot auto-renewing subscription purchase
+     * ("bot_sub_*" products). Same request shape as [grantChatAccess];
+     * the backend acknowledges the Google subscription server-side.
+     */
+    suspend fun grantBotSubscription(request: GrantChatAccessRequestDto): GrantResult
+
     suspend fun checkChatAccess(
         userId: String,
         botId: String,
@@ -37,19 +47,37 @@ class ChatAccessBillingRemoteDataSource(
         private const val CHECK_ENDPOINT = "google/chat-access/check"
     }
 
-    override suspend fun grantChatAccess(request: GrantChatAccessRequestDto): GrantResult {
-        Logger.d(TAG) { "grantChatAccess request: botId=${request.botId}, productId=${request.productId}" }
+    override suspend fun grantChatAccess(request: GrantChatAccessRequestDto): GrantResult =
+        postGrant(
+            endpoint = getGrantChatAccessEndpoint(),
+            request = request,
+            logLabel = "grantChatAccess",
+        )
+
+    override suspend fun grantBotSubscription(request: GrantChatAccessRequestDto): GrantResult =
+        postGrant(
+            endpoint = getBotSubscriptionGrantEndpoint(),
+            request = request,
+            logLabel = "grantBotSubscription",
+        )
+
+    private suspend fun postGrant(
+        endpoint: String,
+        request: GrantChatAccessRequestDto,
+        logLabel: String,
+    ): GrantResult {
+        Logger.d(TAG) { "$logLabel request: botId=${request.botId}, productId=${request.productId}" }
         val response =
             httpClient.post {
                 expectSuccess = false
                 url {
                     host = billingBaseUrl
-                    path(getGrantChatAccessEndpoint())
+                    path(endpoint)
                 }
                 setBody(request.toPlatformGrantRequestBody())
             }
         val body = response.bodyAsText()
-        Logger.d(TAG) { "grantChatAccess status=${response.status}, response: $body" }
+        Logger.d(TAG) { "$logLabel status=${response.status}, response: $body" }
         return GrantResult(
             httpStatus = response.status.value,
             apiResponse = json.decodeFromString<ChatAccessApiResponse>(body),

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
@@ -55,12 +55,15 @@ interface ChatDataSource {
     ): CollageResponseDto
 
     /**
-     * GET /api/v1/influencers/{id}/collage?is_subscribed= — idempotent
-     * render-time read; 404 while today's collage isn't generated yet.
+     * GET /api/v1/influencers/{id}/collage — idempotent render-time read.
+     * Lookup precedence server-side: collage_id > date > today. 404 when the
+     * requested collage doesn't exist (e.g. today's not generated yet).
      */
     suspend fun getInfluencerCollage(
         influencerId: String,
         isSubscribed: Boolean,
+        collageId: String?,
+        date: String?,
     ): CollageResponseDto
 
     // ---------- Coach pivot Bucket 2 — View full prompt page ----------

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatDataSource.kt
@@ -2,21 +2,22 @@ package com.yral.shared.features.chat.data
 
 import com.yral.shared.features.chat.attachments.ChatAttachment
 import com.yral.shared.features.chat.data.models.ChatMessageDto
+import com.yral.shared.features.chat.data.models.CollageResponseDto
 import com.yral.shared.features.chat.data.models.ConversationDto
 import com.yral.shared.features.chat.data.models.ConversationMessagesResponseDto
 import com.yral.shared.features.chat.data.models.ConversationsResponseDto
 import com.yral.shared.features.chat.data.models.DeleteConversationResponseDto
-import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
-import com.yral.shared.features.chat.data.models.InfluencerDto
 import com.yral.shared.features.chat.data.models.DiscoverySearchResponseDto
+import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
 import com.yral.shared.features.chat.data.models.InboxSearchResponseDto
-import com.yral.shared.features.chat.data.models.SystemPromptPreviewResponseDto
+import com.yral.shared.features.chat.data.models.InfluencerDto
 import com.yral.shared.features.chat.data.models.InfluencersResponseDto
 import com.yral.shared.features.chat.data.models.ReleaseHumanCreatorTakeoverResponseDto
 import com.yral.shared.features.chat.data.models.SendHumanCreatorMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageResponseDto
 import com.yral.shared.features.chat.data.models.StartHumanCreatorTakeoverResponseDto
+import com.yral.shared.features.chat.data.models.SystemPromptPreviewResponseDto
 import com.yral.shared.features.chat.data.models.UploadResponseDto
 
 @Suppress("TooManyFunctions")
@@ -42,6 +43,25 @@ interface ChatDataSource {
     ): InboxSearchResponseDto
 
     suspend fun getInfluencer(id: String): InfluencerDto
+
+    /**
+     * POST /api/v1/influencers/{id}/request-images — consumes today's quota
+     * and returns the collage payload. Cold path (no pre-gen yet) can take
+     * 45–65 s, hence the extended per-request timeout in the impl.
+     */
+    suspend fun requestInfluencerImages(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): CollageResponseDto
+
+    /**
+     * GET /api/v1/influencers/{id}/collage?is_subscribed= — idempotent
+     * render-time read; 404 while today's collage isn't generated yet.
+     */
+    suspend fun getInfluencerCollage(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): CollageResponseDto
 
     // ---------- Coach pivot Bucket 2 — View full prompt page ----------
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
@@ -245,6 +245,8 @@ class ChatRemoteDataSource(
     override suspend fun getInfluencerCollage(
         influencerId: String,
         isSubscribed: Boolean,
+        collageId: String?,
+        date: String?,
     ): CollageResponseDto {
         val idToken = getIdToken()
         return httpGet(
@@ -255,6 +257,10 @@ class ChatRemoteDataSource(
                 host = chatBaseUrl
                 path(INFLUENCERS_PATH, influencerId, COLLAGE_SUBPATH)
                 parameters.append("is_subscribed", isSubscribed.toString())
+                // Server precedence: collage_id > date > today. Both are sent
+                // when known so legacy (id-less) references keep resolving.
+                collageId?.let { parameters.append("collage_id", it) }
+                date?.let { parameters.append("date", it) }
             }
             headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
         }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRemoteDataSource.kt
@@ -7,24 +7,26 @@ import com.yral.shared.core.exceptions.YralException
 import com.yral.shared.features.chat.attachments.ChatAttachment
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
 import com.yral.shared.features.chat.data.models.ChatMessageDto
+import com.yral.shared.features.chat.data.models.CollageResponseDto
 import com.yral.shared.features.chat.data.models.ConversationDto
 import com.yral.shared.features.chat.data.models.ConversationMessagesResponseDto
 import com.yral.shared.features.chat.data.models.ConversationsResponseDto
 import com.yral.shared.features.chat.data.models.CreateConversationRequestDto
 import com.yral.shared.features.chat.data.models.CreateHumanConversationRequestDto
 import com.yral.shared.features.chat.data.models.DeleteConversationResponseDto
+import com.yral.shared.features.chat.data.models.DiscoverySearchResponseDto
 import com.yral.shared.features.chat.data.models.HumanCreatorTakeoverStatusDto
+import com.yral.shared.features.chat.data.models.InboxSearchResponseDto
 import com.yral.shared.features.chat.data.models.InfluencerDto
 import com.yral.shared.features.chat.data.models.InfluencerFeedResponseDto
 import com.yral.shared.features.chat.data.models.InfluencersResponseDto
-import com.yral.shared.features.chat.data.models.DiscoverySearchResponseDto
-import com.yral.shared.features.chat.data.models.InboxSearchResponseDto
-import com.yral.shared.features.chat.data.models.SystemPromptPreviewResponseDto
 import com.yral.shared.features.chat.data.models.ReleaseHumanCreatorTakeoverResponseDto
+import com.yral.shared.features.chat.data.models.RequestImagesRequestDto
 import com.yral.shared.features.chat.data.models.SendHumanCreatorMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageRequestDto
 import com.yral.shared.features.chat.data.models.SendMessageResponseDto
 import com.yral.shared.features.chat.data.models.StartHumanCreatorTakeoverResponseDto
+import com.yral.shared.features.chat.data.models.SystemPromptPreviewResponseDto
 import com.yral.shared.features.chat.data.models.UploadResponseDto
 import com.yral.shared.features.chat.data.models.toInfluencersResponseDto
 import com.yral.shared.http.UPLOAD_FILE_TIME_OUT
@@ -211,6 +213,48 @@ class ChatRemoteDataSource(
             url {
                 host = chatBaseUrl
                 path(INFLUENCERS_PATH, botId, SYSTEM_PROMPT_PREVIEW_SUBPATH)
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun requestInfluencerImages(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): CollageResponseDto {
+        val idToken = getIdToken()
+        return httpPost(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(INFLUENCERS_PATH, influencerId, REQUEST_IMAGES_SUBPATH)
+            }
+            setBody(RequestImagesRequestDto(isSubscribed = isSubscribed))
+            // On-demand generation (no pre-gen row yet) takes 45–65 s;
+            // the client-wide 30 s default would abort mid-generation.
+            timeout {
+                requestTimeoutMillis = COLLAGE_REQUEST_TIME_OUT
+                socketTimeoutMillis = COLLAGE_REQUEST_TIME_OUT
+            }
+            headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
+        }
+    }
+
+    override suspend fun getInfluencerCollage(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): CollageResponseDto {
+        val idToken = getIdToken()
+        return httpGet(
+            httpClient = httpClient,
+            json = json,
+        ) {
+            url {
+                host = chatBaseUrl
+                path(INFLUENCERS_PATH, influencerId, COLLAGE_SUBPATH)
+                parameters.append("is_subscribed", isSubscribed.toString())
             }
             headers { append(HttpHeaders.Authorization, "Bearer $idToken") }
         }
@@ -523,8 +567,7 @@ class ChatRemoteDataSource(
      * isn't, so the call site needs to suppress the throw on missing
      * token rather than treat it as an auth error.
      */
-    private suspend fun getIdTokenOrNull() =
-        preferences.getString(PrefKeys.ID_TOKEN.name)
+    private suspend fun getIdTokenOrNull() = preferences.getString(PrefKeys.ID_TOKEN.name)
 
     private fun ChatAttachment.readUploadBytes(): ByteArray =
         when (this) {
@@ -540,6 +583,9 @@ class ChatRemoteDataSource(
         private const val DISCOVERY_SEARCH_PATH = "api/v2/discovery/search"
         private const val INBOX_SEARCH_PATH = "api/v2/chat/conversations/search"
         private const val SYSTEM_PROMPT_PREVIEW_SUBPATH = "system-prompt-preview"
+        private const val REQUEST_IMAGES_SUBPATH = "request-images"
+        private const val COLLAGE_SUBPATH = "collage"
+        private const val COLLAGE_REQUEST_TIME_OUT = 90_000L
         private const val CONVERSATIONS_PATH = "api/v1/chat/conversations"
         private const val HUMAN_CONVERSATIONS_PATH = "api/v1/chat/human/conversations"
         private const val CONVERSATIONS_LIST_PATH = "api/v2/chat/conversations"

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
@@ -11,15 +11,15 @@ import com.yral.shared.features.chat.domain.models.Conversation
 import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResult
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.DiscoverySearchResult
 import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
+import com.yral.shared.features.chat.domain.models.InboxSearchResult
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencersPageResult
-import com.yral.shared.features.chat.domain.models.DiscoverySearchResult
-import com.yral.shared.features.chat.domain.models.InboxSearchResult
-import com.yral.shared.features.chat.domain.models.SystemPromptPreview
 import com.yral.shared.features.chat.domain.models.SendMessageDraft
 import com.yral.shared.features.chat.domain.models.SendMessageResult
 import com.yral.shared.features.chat.domain.models.StreamEvent
+import com.yral.shared.features.chat.domain.models.SystemPromptPreview
 import com.yral.shared.features.chat.domain.models.totalUnreadConversationBadgeCount
 import kotlinx.coroutines.flow.Flow
 
@@ -149,6 +149,7 @@ class ChatRepositoryImpl(
                         mediaUrls = mediaUrls,
                         audioUrl = audioUrl,
                         audioDurationSeconds = draft.audioDurationSeconds,
+                        isBlur = draft.isBlur.takeIf { it },
                     ),
             )
         return response.toDomain(conversationIdFallback = conversationId)
@@ -222,6 +223,7 @@ class ChatRepositoryImpl(
                         mediaUrls = mediaUrls,
                         audioUrl = audioUrl,
                         audioDurationSeconds = draft.audioDurationSeconds,
+                        isBlur = draft.isBlur.takeIf { it },
                     ),
             )
         return response.toDomain(conversationIdFallback = conversationId)
@@ -240,6 +242,7 @@ class ChatRepositoryImpl(
                     mediaUrls = null,
                     audioUrl = null,
                     audioDurationSeconds = null,
+                    isBlur = draft.isBlur.takeIf { it },
                 ),
         )
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
@@ -111,10 +111,16 @@ class ChatRepositoryImpl(
     override suspend fun getInfluencerCollage(
         influencerId: String,
         isSubscribed: Boolean,
+        collageId: String?,
+        date: String?,
     ): Collage =
         dataSource
-            .getInfluencerCollage(influencerId = influencerId, isSubscribed = isSubscribed)
-            .toDomain()
+            .getInfluencerCollage(
+                influencerId = influencerId,
+                isSubscribed = isSubscribed,
+                collageId = collageId,
+                date = date,
+            ).toDomain()
 
     override suspend fun createConversation(influencerId: String): Conversation =
         dataSource
@@ -239,6 +245,7 @@ class ChatRepositoryImpl(
                         mediaUrls = mediaUrls,
                         audioUrl = audioUrl,
                         audioDurationSeconds = draft.audioDurationSeconds,
+                        collageId = draft.collageId,
                         collageBotId = draft.collageBotId,
                         collageDate = draft.collageDate,
                     ),

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/ChatRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.yral.shared.features.chat.data.models.toDomainActiveOnly
 import com.yral.shared.features.chat.domain.ChatRepository
 import com.yral.shared.features.chat.domain.models.ChatMessage
 import com.yral.shared.features.chat.domain.models.ChatMessageType
+import com.yral.shared.features.chat.domain.models.Collage
 import com.yral.shared.features.chat.domain.models.Conversation
 import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResult
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
@@ -99,6 +100,22 @@ class ChatRepositoryImpl(
             .getSystemPromptPreview(botId)
             .toDomain()
 
+    override suspend fun requestInfluencerImages(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): Collage =
+        dataSource
+            .requestInfluencerImages(influencerId = influencerId, isSubscribed = isSubscribed)
+            .toDomain()
+
+    override suspend fun getInfluencerCollage(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): Collage =
+        dataSource
+            .getInfluencerCollage(influencerId = influencerId, isSubscribed = isSubscribed)
+            .toDomain()
+
     override suspend fun createConversation(influencerId: String): Conversation =
         dataSource
             .createConversation(influencerId)
@@ -149,7 +166,6 @@ class ChatRepositoryImpl(
                         mediaUrls = mediaUrls,
                         audioUrl = audioUrl,
                         audioDurationSeconds = draft.audioDurationSeconds,
-                        isBlur = draft.isBlur.takeIf { it },
                     ),
             )
         return response.toDomain(conversationIdFallback = conversationId)
@@ -223,7 +239,8 @@ class ChatRepositoryImpl(
                         mediaUrls = mediaUrls,
                         audioUrl = audioUrl,
                         audioDurationSeconds = draft.audioDurationSeconds,
-                        isBlur = draft.isBlur.takeIf { it },
+                        collageBotId = draft.collageBotId,
+                        collageDate = draft.collageDate,
                     ),
             )
         return response.toDomain(conversationIdFallback = conversationId)
@@ -242,7 +259,6 @@ class ChatRepositoryImpl(
                     mediaUrls = null,
                     audioUrl = null,
                     audioDurationSeconds = null,
-                    isBlur = draft.isBlur.takeIf { it },
                 ),
         )
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/CollageCache.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/CollageCache.kt
@@ -1,0 +1,60 @@
+package com.yral.shared.features.chat.data
+
+import com.yral.shared.features.chat.domain.models.Collage
+
+/**
+ * In-memory LRU cache for daily collage payloads, keyed by
+ * (botId, date, isSubscribed) so a subscription flip is a natural cache
+ * miss — the refetch with the new state returns the other URL set
+ * (clear vs pre-blurred) and every collage bubble self-heals.
+ *
+ * Same multiplatform constraints as [ConversationContentCache]: plain
+ * LinkedHashMap with manual recency bumps (the JVM accessOrder overload
+ * doesn't exist on iOS Native) and no `synchronized` (JVM-only). All call
+ * sites run on `viewModelScope` (Main dispatcher), so access is
+ * thread-confined in practice.
+ *
+ * In-memory only, by design: URLs must never outlive the subscription
+ * state they were fetched under.
+ */
+class CollageCache(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+) {
+    private val cache = LinkedHashMap<String, Collage>()
+
+    fun read(
+        botId: String,
+        date: String,
+        isSubscribed: Boolean,
+    ): Collage? {
+        val key = key(botId, date, isSubscribed)
+        val value = cache[key] ?: return null
+        // Bump recency by removing + re-inserting at the tail.
+        cache.remove(key)
+        cache[key] = value
+        return value
+    }
+
+    fun write(
+        collage: Collage,
+        isSubscribed: Boolean,
+    ) {
+        val key = key(collage.botId, collage.date, isSubscribed)
+        cache.remove(key)
+        cache[key] = collage
+        while (cache.size > maxEntries) {
+            val eldest = cache.keys.iterator().next()
+            cache.remove(eldest)
+        }
+    }
+
+    private fun key(
+        botId: String,
+        date: String,
+        isSubscribed: Boolean,
+    ): String = "$botId|$date|$isSubscribed"
+
+    private companion object {
+        private const val DEFAULT_MAX_ENTRIES = 30
+    }
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
@@ -38,4 +38,11 @@ data class ChatMessageDto(
     // field keep deserializing.
     @SerialName("is_blur")
     val isBlur: Boolean? = null,
+    // Collage messages carry only this reference — the image URLs are fetched
+    // at render time from GET /influencers/{bot}/collage so blur state always
+    // reflects the CURRENT subscription, never what it was at send time.
+    @SerialName("collage_bot_id")
+    val collageBotId: String? = null,
+    @SerialName("collage_date")
+    val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
@@ -41,6 +41,10 @@ data class ChatMessageDto(
     // Collage messages carry only this reference — the image URLs are fetched
     // at render time from GET /influencers/{bot}/collage so blur state always
     // reflects the CURRENT subscription, never what it was at send time.
+    // collage_id is the preferred fetch handle; legacy messages predate it
+    // and resolve via (bot_id, date) instead.
+    @SerialName("collage_id")
+    val collageId: String? = null,
     @SerialName("collage_bot_id")
     val collageBotId: String? = null,
     @SerialName("collage_date")

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatMessageDto.kt
@@ -33,4 +33,9 @@ data class ChatMessageDto(
     // AI path (where role is authoritative) parse without breaking.
     @SerialName("sender_id")
     val senderId: String? = null,
+    // When true, image attachments on this message must be blurred until the
+    // user pays to unlock them. Nullable so wire payloads that don't send the
+    // field keep deserializing.
+    @SerialName("is_blur")
+    val isBlur: Boolean? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/CollageDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/CollageDto.kt
@@ -1,0 +1,33 @@
+package com.yral.shared.features.chat.data.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RequestImagesRequestDto(
+    // Backend picks the URL set from this (clear vs pre-blurred); without it
+    // it falls back to a YRAL-team-only stub, so real clients always send it.
+    @SerialName("is_subscribed")
+    val isSubscribed: Boolean,
+)
+
+/**
+ * Shared response shape of POST /influencers/{id}/request-images and
+ * GET /influencers/{id}/collage. `images` carries clear URLs for
+ * subscribers and pre-blurred ones otherwise — the client never blurs.
+ */
+@Serializable
+data class CollageResponseDto(
+    @SerialName("images")
+    val images: List<String> = emptyList(),
+    @SerialName("is_blurred")
+    val isBlurred: Boolean = false,
+    @SerialName("theme")
+    val theme: String? = null,
+    @SerialName("generated_at")
+    val generatedAt: String? = null,
+    @SerialName("collage_bot_id")
+    val collageBotId: String,
+    @SerialName("collage_date")
+    val collageDate: String,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/CollageDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/CollageDto.kt
@@ -26,6 +26,10 @@ data class CollageResponseDto(
     val theme: String? = null,
     @SerialName("generated_at")
     val generatedAt: String? = null,
+    // Preferred fetch handle for GET /collage; nullable in case a lagging
+    // backend deploy still omits it (falls back to bot_id + date).
+    @SerialName("collage_id")
+    val collageId: String? = null,
     @SerialName("collage_bot_id")
     val collageBotId: String,
     @SerialName("collage_date")

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -1,5 +1,6 @@
 package com.yral.shared.features.chat.data.models
 
+import co.touchlab.kermit.Logger
 import com.yral.shared.core.exceptions.YralException
 import com.yral.shared.core.utils.resolveUsername
 import com.yral.shared.features.chat.domain.models.ChatMessage
@@ -188,6 +189,15 @@ fun ChatMessageDto.toDomain(conversationIdFallback: String? = null): ChatMessage
     val resolvedConversationId =
         conversationId ?: conversationIdFallback
             ?: error("ChatMessage requires a valid conversationId")
+    if (ChatMessageType.fromApi(messageType) == ChatMessageType.COLLAGE) {
+        // Diagnostic: proves whether the backend persists/returns the collage
+        // reference on messages (history + send echo). Collage rows are rare,
+        // so this stays quiet in normal operation.
+        Logger.d("CollageX") {
+            "message row id=$id type=$messageType collageId=$collageId " +
+                "botId=$collageBotId date=$collageDate hasContent=${!content.isNullOrBlank()}"
+        }
+    }
     return ChatMessage(
         id = id,
         conversationId = resolvedConversationId,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -12,19 +12,19 @@ import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResul
 import com.yral.shared.features.chat.domain.models.ConversationUser
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.DiscoverySearchResult
+import com.yral.shared.features.chat.domain.models.EnabledSkill
+import com.yral.shared.features.chat.domain.models.EngagementSchedule
+import com.yral.shared.features.chat.domain.models.FirstTurnNudge
 import com.yral.shared.features.chat.domain.models.HUMAN_CHAT_CONVERSATION_TYPE
 import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
+import com.yral.shared.features.chat.domain.models.InactivityProactive
+import com.yral.shared.features.chat.domain.models.InboxSearchResult
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencerStatus
 import com.yral.shared.features.chat.domain.models.InfluencersPageResult
-import com.yral.shared.features.chat.domain.models.SendMessageResult
-import com.yral.shared.features.chat.domain.models.DiscoverySearchResult
-import com.yral.shared.features.chat.domain.models.EnabledSkill
-import com.yral.shared.features.chat.domain.models.InboxSearchResult
 import com.yral.shared.features.chat.domain.models.SearchResultKind
-import com.yral.shared.features.chat.domain.models.EngagementSchedule
-import com.yral.shared.features.chat.domain.models.FirstTurnNudge
-import com.yral.shared.features.chat.domain.models.InactivityProactive
+import com.yral.shared.features.chat.domain.models.SendMessageResult
 import com.yral.shared.features.chat.domain.models.SkillCheckins
 import com.yral.shared.features.chat.domain.models.SystemPromptLayers
 import com.yral.shared.features.chat.domain.models.SystemPromptPreview
@@ -199,6 +199,7 @@ fun ChatMessageDto.toDomain(conversationIdFallback: String? = null): ChatMessage
         tokenCount = tokenCount,
         createdAt = createdAt,
         senderId = senderId,
+        isBlur = isBlur ?: false,
     )
 }
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -201,6 +201,7 @@ fun ChatMessageDto.toDomain(conversationIdFallback: String? = null): ChatMessage
         createdAt = createdAt,
         senderId = senderId,
         isBlur = isBlur ?: false,
+        collageId = collageId,
         collageBotId = collageBotId,
         collageDate = collageDate,
     )
@@ -208,6 +209,7 @@ fun ChatMessageDto.toDomain(conversationIdFallback: String? = null): ChatMessage
 
 fun CollageResponseDto.toDomain(): Collage =
     Collage(
+        id = collageId,
         botId = collageBotId,
         date = collageDate,
         images = images,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/Mappers.kt
@@ -4,6 +4,7 @@ import com.yral.shared.core.exceptions.YralException
 import com.yral.shared.core.utils.resolveUsername
 import com.yral.shared.features.chat.domain.models.ChatMessage
 import com.yral.shared.features.chat.domain.models.ChatMessageType
+import com.yral.shared.features.chat.domain.models.Collage
 import com.yral.shared.features.chat.domain.models.Conversation
 import com.yral.shared.features.chat.domain.models.ConversationInfluencer
 import com.yral.shared.features.chat.domain.models.ConversationLastMessage
@@ -200,8 +201,20 @@ fun ChatMessageDto.toDomain(conversationIdFallback: String? = null): ChatMessage
         createdAt = createdAt,
         senderId = senderId,
         isBlur = isBlur ?: false,
+        collageBotId = collageBotId,
+        collageDate = collageDate,
     )
 }
+
+fun CollageResponseDto.toDomain(): Collage =
+    Collage(
+        botId = collageBotId,
+        date = collageDate,
+        images = images,
+        isBlurred = isBlurred,
+        theme = theme,
+        generatedAt = generatedAt,
+    )
 
 fun ConversationMessagesResponseDto.toDomain(): ConversationMessagesPageResult {
     val rawCount = messages.size

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendMessageRequestDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendMessageRequestDto.kt
@@ -17,7 +17,10 @@ data class SendMessageRequestDto(
     val audioDurationSeconds: Int? = null,
     // Collage sends store only this reference — never image URLs — so the
     // bubble can refetch with the current subscription state forever after.
-    // Nullable so both are omitted from the JSON for ordinary sends.
+    // collage_id is the primary handle; bot_id + date stay for legacy/debug.
+    // Nullable so all three are omitted from the JSON for ordinary sends.
+    @SerialName("collage_id")
+    val collageId: String? = null,
     @SerialName("collage_bot_id")
     val collageBotId: String? = null,
     @SerialName("collage_date")

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendMessageRequestDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendMessageRequestDto.kt
@@ -15,8 +15,11 @@ data class SendMessageRequestDto(
     val audioUrl: String? = null,
     @SerialName("audio_duration_seconds")
     val audioDurationSeconds: Int? = null,
-    // When true, asks the peer for a paid image that arrives blurred until
-    // unlocked. Nullable so it's omitted from the JSON for ordinary sends.
-    @SerialName("is_blur")
-    val isBlur: Boolean? = null,
+    // Collage sends store only this reference — never image URLs — so the
+    // bubble can refetch with the current subscription state forever after.
+    // Nullable so both are omitted from the JSON for ordinary sends.
+    @SerialName("collage_bot_id")
+    val collageBotId: String? = null,
+    @SerialName("collage_date")
+    val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendMessageRequestDto.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/SendMessageRequestDto.kt
@@ -15,4 +15,8 @@ data class SendMessageRequestDto(
     val audioUrl: String? = null,
     @SerialName("audio_duration_seconds")
     val audioDurationSeconds: Int? = null,
+    // When true, asks the peer for a paid image that arrives blurred until
+    // unlocked. Nullable so it's omitted from the JSON for ordinary sends.
+    @SerialName("is_blur")
+    val isBlur: Boolean? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/di/ChatModule.kt
@@ -10,6 +10,7 @@ import com.yral.shared.features.chat.data.ChatDataSource
 import com.yral.shared.features.chat.data.ChatRemoteDataSource
 import com.yral.shared.features.chat.data.ChatRepositoryImpl
 import com.yral.shared.features.chat.data.ChatStreamingDataSource
+import com.yral.shared.features.chat.data.CollageCache
 import com.yral.shared.features.chat.data.ConversationContentCache
 import com.yral.shared.features.chat.domain.ChatErrorMapper
 import com.yral.shared.features.chat.domain.ChatRepository
@@ -18,11 +19,13 @@ import com.yral.shared.features.chat.domain.usecases.CreateConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.CreateHumanConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.DeleteConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.GetHumanCreatorTakeoverStatusUseCase
+import com.yral.shared.features.chat.domain.usecases.GetInfluencerCollageUseCase
 import com.yral.shared.features.chat.domain.usecases.GetInfluencerUseCase
 import com.yral.shared.features.chat.domain.usecases.GetSystemPromptPreviewUseCase
 import com.yral.shared.features.chat.domain.usecases.GrantChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.MarkConversationAsReadUseCase
 import com.yral.shared.features.chat.domain.usecases.ReleaseHumanCreatorTakeoverUseCase
+import com.yral.shared.features.chat.domain.usecases.RequestInfluencerImagesUseCase
 import com.yral.shared.features.chat.domain.usecases.SearchDiscoveryUseCase
 import com.yral.shared.features.chat.domain.usecases.SearchInboxUseCase
 import com.yral.shared.features.chat.domain.usecases.SendHumanCreatorMessageUseCase
@@ -78,6 +81,8 @@ val chatModule =
         factoryOf(::CreateHumanConversationUseCase)
         factoryOf(::DeleteConversationUseCase)
         factoryOf(::GetInfluencerUseCase)
+        factoryOf(::GetInfluencerCollageUseCase)
+        factoryOf(::RequestInfluencerImagesUseCase)
         factoryOf(::GetSystemPromptPreviewUseCase)
         factoryOf(::SearchDiscoveryUseCase)
         factoryOf(::SearchInboxUseCase)
@@ -95,6 +100,7 @@ val chatModule =
         // primitive defaults (Int). `singleOf` would try to resolve Int from the
         // Koin graph and crash with NoDefinitionFoundException.
         single { ConversationContentCache() }
+        single { CollageCache() }
         viewModelOf(::ChatWallViewModel)
         viewModelOf(::DiscoverySearchViewModel)
         viewModelOf(::InboxSearchViewModel)
@@ -125,6 +131,9 @@ val chatModule =
                 sendHumanCreatorMessageUseCase = get(),
                 getHumanCreatorTakeoverStatusUseCase = get(),
                 conversationContentCache = get(),
+                requestInfluencerImagesUseCase = get(),
+                getInfluencerCollageUseCase = get(),
+                collageCache = get(),
             )
         }
         viewModelOf(::InboxViewModel)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/BotSubscriptionCatalog.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/BotSubscriptionCatalog.kt
@@ -1,0 +1,26 @@
+package com.yral.shared.features.chat.domain
+
+import com.yral.shared.iap.core.model.ProductId
+
+/**
+ * Client-side source of truth for which bots use the per-bot auto-renewing
+ * subscription flow instead of the one-time [ProductId.DAILY_CHAT] product.
+ * The billing backend has no per-bot catalog endpoint — it only verifies
+ * whatever product the client sends (routing on the "bot_sub" id prefix) —
+ * so the bot→product mapping lives here.
+ *
+ * Subscription bots are also the only ones with the Request Image (photo
+ * collage) feature.
+ */
+object BotSubscriptionCatalog {
+    // Tara. Observed on the agent.rishi.yral.com chat backend — confirm the
+    // prod environment serves the same principal before a prod release.
+    private const val TARA_BOT_ID = "qi6gd-esmrx-v2oyd-7fwhm-ibfs5-trflm-xm3iy-xq6d3-3hmwu-jb7tk-5qe"
+
+    fun usesBotSubscription(botId: String?): Boolean = botId == TARA_BOT_ID
+
+    fun chatProductFor(botId: String?): ProductId {
+        val product = if (usesBotSubscription(botId)) ProductId.BOT_SUB_TARA else ProductId.DAILY_CHAT
+        return product
+    }
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
@@ -1,19 +1,20 @@
 package com.yral.shared.features.chat.domain
 
 import com.yral.shared.features.chat.domain.models.ChatMessage
+import com.yral.shared.features.chat.domain.models.Collage
 import com.yral.shared.features.chat.domain.models.Conversation
 import com.yral.shared.features.chat.domain.models.ConversationMessagesPageResult
 import com.yral.shared.features.chat.domain.models.ConversationsPageResult
 import com.yral.shared.features.chat.domain.models.DeleteConversationResult
+import com.yral.shared.features.chat.domain.models.DiscoverySearchResult
 import com.yral.shared.features.chat.domain.models.HumanCreatorTakeoverStatus
+import com.yral.shared.features.chat.domain.models.InboxSearchResult
 import com.yral.shared.features.chat.domain.models.Influencer
 import com.yral.shared.features.chat.domain.models.InfluencersPageResult
-import com.yral.shared.features.chat.domain.models.DiscoverySearchResult
-import com.yral.shared.features.chat.domain.models.InboxSearchResult
-import com.yral.shared.features.chat.domain.models.SystemPromptPreview
 import com.yral.shared.features.chat.domain.models.SendMessageDraft
 import com.yral.shared.features.chat.domain.models.SendMessageResult
 import com.yral.shared.features.chat.domain.models.StreamEvent
+import com.yral.shared.features.chat.domain.models.SystemPromptPreview
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("TooManyFunctions")
@@ -31,6 +32,26 @@ interface ChatRepository {
     ): InfluencersPageResult
 
     suspend fun getInfluencer(id: String): Influencer
+
+    /**
+     * Requests today's photo collage for [influencerId], consuming the
+     * user's daily quota. Returns the payload directly; the caller sends
+     * only the (botId, date) reference into the conversation.
+     */
+    suspend fun requestInfluencerImages(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): Collage
+
+    /**
+     * Render-time read of today's collage; [isSubscribed] decides whether
+     * the returned URLs are clear or pre-blurred. Throws with 404 while
+     * today's collage hasn't been generated yet.
+     */
+    suspend fun getInfluencerCollage(
+        influencerId: String,
+        isSubscribed: Boolean,
+    ): Collage
 
     /**
      * Discovery search — fuzzy match across name/category/archetype/

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/ChatRepository.kt
@@ -44,13 +44,17 @@ interface ChatRepository {
     ): Collage
 
     /**
-     * Render-time read of today's collage; [isSubscribed] decides whether
-     * the returned URLs are clear or pre-blurred. Throws with 404 while
-     * today's collage hasn't been generated yet.
+     * Render-time read of a collage; [isSubscribed] decides whether the
+     * returned URLs are clear or pre-blurred. [collageId] is the preferred
+     * handle (any date); [date] is the fallback for legacy references;
+     * with neither the server serves today. Throws with 404 when the
+     * requested collage doesn't exist.
      */
     suspend fun getInfluencerCollage(
         influencerId: String,
         isSubscribed: Boolean,
+        collageId: String?,
+        date: String?,
     ): Collage
 
     /**

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/HttpStatus.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/HttpStatus.kt
@@ -1,0 +1,16 @@
+package com.yral.shared.features.chat.domain
+
+import com.yral.shared.http.exception.NetworkException
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
+
+/**
+ * HTTP status of a failed chat API call, if the failure was an HTTP error.
+ * [NetworkException] wraps the Ktor [ResponseException] as its cause
+ * (NetworkHelper.handleException); anything else — timeouts, decode
+ * failures, missing auth — has no status and returns null.
+ */
+internal fun Throwable.httpStatusOrNull(): HttpStatusCode? {
+    val responseException = (this as? NetworkException)?.cause as? ResponseException
+    return responseException?.response?.status
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
@@ -19,6 +19,10 @@ data class ChatMessage(
     // When true, image attachments are shown blurred behind a pay-to-unlock
     // overlay until the user purchases access to them.
     val isBlur: Boolean = false,
+    // COLLAGE messages store only this reference (never URLs); the bubble
+    // fetches the image set at render time with the current subscription state.
+    val collageBotId: String? = null,
+    val collageDate: String? = null,
 )
 
 /**

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
@@ -21,6 +21,8 @@ data class ChatMessage(
     val isBlur: Boolean = false,
     // COLLAGE messages store only this reference (never URLs); the bubble
     // fetches the image set at render time with the current subscription state.
+    // collageId is the preferred handle; legacy messages only have bot + date.
+    val collageId: String? = null,
     val collageBotId: String? = null,
     val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessage.kt
@@ -16,6 +16,9 @@ data class ChatMessage(
     // [isFromCurrentUser]'s null-fallback). For AI chats this carries
     // through but isn't load-bearing — role alone is authoritative there.
     val senderId: String? = null,
+    // When true, image attachments are shown blurred behind a pay-to-unlock
+    // overlay until the user purchases access to them.
+    val isBlur: Boolean = false,
 )
 
 /**

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessageType.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/ChatMessageType.kt
@@ -7,37 +7,16 @@ enum class ChatMessageType(
     IMAGE("image"),
     MULTIMODAL("multimodal"),
     AUDIO("audio"),
+    COLLAGE("collage"),
     ;
 
     companion object {
-        fun fromApi(value: String): ChatMessageType =
-            when (value.trim().lowercase()) {
-                TEXT.apiValue -> TEXT
-
-                IMAGE.apiValue -> IMAGE
-
-                MULTIMODAL.apiValue -> MULTIMODAL
-
-                AUDIO.apiValue -> AUDIO
-
-                // backend returns uppercase sometimes; normalize
-                "text" -> TEXT
-
-                "image" -> IMAGE
-
-                "multimodal" -> MULTIMODAL
-
-                "audio" -> AUDIO
-
-                "TEXT".lowercase() -> TEXT
-
-                "IMAGE".lowercase() -> IMAGE
-
-                "MULTIMODAL".lowercase() -> MULTIMODAL
-
-                "AUDIO".lowercase() -> AUDIO
-
-                else -> TEXT
-            }
+        // Lowercasing also normalizes the uppercase variants the backend
+        // sometimes returns. Unknown types degrade to TEXT so old payloads
+        // (and new server-side types) render the content string, not crash.
+        fun fromApi(value: String): ChatMessageType {
+            val normalized = value.trim().lowercase()
+            return entries.firstOrNull { it.apiValue == normalized } ?: TEXT
+        }
     }
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Collage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Collage.kt
@@ -1,0 +1,15 @@
+package com.yral.shared.features.chat.domain.models
+
+/**
+ * An influencer's daily photo collage, fetched at render time so [isBlurred]
+ * always reflects the viewer's CURRENT subscription state. Chat messages only
+ * store the ([botId], [date]) reference — never these URLs.
+ */
+data class Collage(
+    val botId: String,
+    val date: String,
+    val images: List<String>,
+    val isBlurred: Boolean,
+    val theme: String?,
+    val generatedAt: String?,
+)

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Collage.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/Collage.kt
@@ -3,9 +3,11 @@ package com.yral.shared.features.chat.domain.models
 /**
  * An influencer's daily photo collage, fetched at render time so [isBlurred]
  * always reflects the viewer's CURRENT subscription state. Chat messages only
- * store the ([botId], [date]) reference — never these URLs.
+ * store the reference — [id] as the primary handle, plus ([botId], [date])
+ * for legacy messages — never these URLs.
  */
 data class Collage(
+    val id: String?,
     val botId: String,
     val date: String,
     val images: List<String>,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/SendMessageDraft.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/SendMessageDraft.kt
@@ -8,4 +8,6 @@ data class SendMessageDraft(
     val mediaAttachments: List<ChatAttachment> = emptyList(),
     val audioAttachment: ChatAttachment? = null,
     val audioDurationSeconds: Int? = null,
+    // "Request image" sends: the peer's reply image arrives blurred until paid for.
+    val isBlur: Boolean = false,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/SendMessageDraft.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/SendMessageDraft.kt
@@ -8,6 +8,8 @@ data class SendMessageDraft(
     val mediaAttachments: List<ChatAttachment> = emptyList(),
     val audioAttachment: ChatAttachment? = null,
     val audioDurationSeconds: Int? = null,
-    // "Request image" sends: the peer's reply image arrives blurred until paid for.
-    val isBlur: Boolean = false,
+    // COLLAGE drafts: reference to the influencer photo collage being shared.
+    // The message never carries image URLs (hard backend requirement).
+    val collageBotId: String? = null,
+    val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/SendMessageDraft.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/models/SendMessageDraft.kt
@@ -10,6 +10,7 @@ data class SendMessageDraft(
     val audioDurationSeconds: Int? = null,
     // COLLAGE drafts: reference to the influencer photo collage being shared.
     // The message never carries image URLs (hard backend requirement).
+    val collageId: String? = null,
     val collageBotId: String? = null,
     val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetInfluencerCollageUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetInfluencerCollageUseCase.kt
@@ -1,0 +1,27 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.Collage
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+class GetInfluencerCollageUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<GetInfluencerCollageUseCase.Params, Collage>(appDispatchers.network, useCaseFailureListener) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: Params): Collage =
+        chatRepository.getInfluencerCollage(
+            influencerId = parameter.influencerId,
+            isSubscribed = parameter.isSubscribed,
+        )
+
+    data class Params(
+        val influencerId: String,
+        val isSubscribed: Boolean,
+    )
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetInfluencerCollageUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GetInfluencerCollageUseCase.kt
@@ -18,10 +18,14 @@ class GetInfluencerCollageUseCase(
         chatRepository.getInfluencerCollage(
             influencerId = parameter.influencerId,
             isSubscribed = parameter.isSubscribed,
+            collageId = parameter.collageId,
+            date = parameter.date,
         )
 
     data class Params(
         val influencerId: String,
         val isSubscribed: Boolean,
+        val collageId: String?,
+        val date: String?,
     )
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GrantChatAccessUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/GrantChatAccessUseCase.kt
@@ -5,6 +5,8 @@ import com.yral.shared.features.chat.data.ChatAccessBillingDataSource
 import com.yral.shared.features.chat.data.models.GrantChatAccessRequestDto
 import com.yral.shared.features.chat.domain.models.ChatAccessStatus
 import com.yral.shared.features.chat.domain.models.GrantError
+import com.yral.shared.iap.core.model.ProductId
+import com.yral.shared.iap.core.model.ProductType
 import com.yral.shared.libs.arch.domain.SuspendUseCase
 import com.yral.shared.libs.arch.domain.UseCaseFailureListener
 import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
@@ -33,7 +35,15 @@ class GrantChatAccessUseCase(
                 purchaseToken = parameter.purchaseToken,
                 botId = parameter.botId,
             )
-        val result = dataSource.grantChatAccess(request)
+        // Per-bot subscriptions ("bot_sub_*") verify against a dedicated
+        // billing endpoint; the one-time daily_chat keeps the original grant.
+        val isBotSubscription = ProductId.fromString(parameter.productId)?.productType == ProductType.SUBS
+        val result =
+            if (isBotSubscription) {
+                dataSource.grantBotSubscription(request)
+            } else {
+                dataSource.grantChatAccess(request)
+            }
         val httpStatus = result.httpStatus
         val response = result.apiResponse
 
@@ -41,7 +51,9 @@ class GrantChatAccessUseCase(
             httpStatus in HTTP_OK_RANGE && response.success -> {
                 val data = response.data
                 return ChatAccessStatus(
-                    hasAccess = data?.hasAccess == true,
+                    // The subscription verify response has an empty data
+                    // payload — a 2xx success IS the access confirmation.
+                    hasAccess = isBotSubscription || data?.hasAccess == true,
                     expiresAtMs = data?.expiresAt?.let { parseIso8601ToEpochMs(it) },
                 )
             }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/RequestInfluencerImagesUseCase.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/domain/usecases/RequestInfluencerImagesUseCase.kt
@@ -1,0 +1,27 @@
+package com.yral.shared.features.chat.domain.usecases
+
+import com.yral.shared.crashlytics.core.ExceptionType
+import com.yral.shared.features.chat.domain.ChatRepository
+import com.yral.shared.features.chat.domain.models.Collage
+import com.yral.shared.libs.arch.domain.SuspendUseCase
+import com.yral.shared.libs.arch.domain.UseCaseFailureListener
+import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
+
+class RequestInfluencerImagesUseCase(
+    private val chatRepository: ChatRepository,
+    appDispatchers: AppDispatchers,
+    useCaseFailureListener: UseCaseFailureListener,
+) : SuspendUseCase<RequestInfluencerImagesUseCase.Params, Collage>(appDispatchers.network, useCaseFailureListener) {
+    override val exceptionType: String = ExceptionType.CHAT.name
+
+    override suspend fun execute(parameter: Params): Collage =
+        chatRepository.requestInfluencerImages(
+            influencerId = parameter.influencerId,
+            isSubscribed = parameter.isSubscribed,
+        )
+
+    data class Params(
+        val influencerId: String,
+        val isSubscribed: Boolean,
+    )
+}

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -70,6 +70,7 @@ import yral_mobile.shared.features.chat.generated.resources.Res
 import yral_mobile.shared.features.chat.generated.resources.access_activated_overlay_message
 import yral_mobile.shared.features.chat.generated.resources.ai_influencer_read_only_chat
 import yral_mobile.shared.features.chat.generated.resources.chat_background_inverted
+import yral_mobile.shared.features.chat.generated.resources.request_image_message
 import yral_mobile.shared.features.chat.generated.resources.subscription_card_overlay_message
 import yral_mobile.shared.features.chat.generated.resources.switch_profile
 import yral_mobile.shared.features.chat.generated.resources.switch_profile_failed
@@ -393,6 +394,7 @@ fun ChatConversationScreen(
     val aiInfluencerReadOnlyMessage = stringResource(Res.string.ai_influencer_read_only_chat)
     val switchProfileButtonText = stringResource(Res.string.switch_profile)
     val switchProfileFailedMessage = stringResource(Res.string.switch_profile_failed)
+    val requestImageMessage = stringResource(Res.string.request_image_message)
     val bottomAreaState by derivedStateOf {
         resolveConversationBottomAreaState(
             isBotAccount = viewState.isBotAccount,
@@ -749,6 +751,25 @@ fun ChatConversationScreen(
                                             },
                                             onCameraClick = imageCaptureLauncher,
                                             onGalleryClick = imagePickerLauncher,
+                                            // Paid image requests are an AI-influencer feature;
+                                            // H2H peers can't fulfil them, so hide the option there.
+                                            onRequestImageClick =
+                                                if (!viewState.isHumanChat) {
+                                                    {
+                                                        sendMessageIfAllowed(
+                                                            SendMessageDraft(
+                                                                messageType = ChatMessageType.TEXT,
+                                                                content = requestImageMessage,
+                                                                isBlur = true,
+                                                            ),
+                                                        )
+                                                    }
+                                                } else {
+                                                    null
+                                                },
+                                            // Cooldown source lands with the end-to-end
+                                            // integration; option stays enabled until then.
+                                            requestImageRemainingSeconds = null,
                                             // Mic button is gated on AudioRecordingEnabled (kill-switch +
                                             // GA pacing) AND not-an-H2H-chat. Voice messages aren't
                                             // supported on H2H peer chats — the H2H send route doesn't

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -550,6 +550,10 @@ fun ChatConversationScreen(
                             onImageClick = { imageUrl ->
                                 activeImagePreview = ChatImagePreviewSource.Message(imageUrl)
                             },
+                            onUnlockImage = { _ ->
+                                // Image-unlock payment flow gets wired here once the
+                                // end-to-end integration lands; UI-only for now.
+                            },
                             onRetry = { localId -> viewModel.retry(localId) },
                         )
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -564,6 +564,7 @@ fun ChatConversationScreen(
                             collageConfig =
                                 CollageListConfig(
                                     states = collageStates,
+                                    botId = viewState.influencer?.id.orEmpty(),
                                     influencerDisplayName =
                                         viewState.influencer
                                             ?.displayName

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -70,7 +70,6 @@ import yral_mobile.shared.features.chat.generated.resources.Res
 import yral_mobile.shared.features.chat.generated.resources.access_activated_overlay_message
 import yral_mobile.shared.features.chat.generated.resources.ai_influencer_read_only_chat
 import yral_mobile.shared.features.chat.generated.resources.chat_background_inverted
-import yral_mobile.shared.features.chat.generated.resources.request_image_message
 import yral_mobile.shared.features.chat.generated.resources.subscription_card_overlay_message
 import yral_mobile.shared.features.chat.generated.resources.switch_profile
 import yral_mobile.shared.features.chat.generated.resources.switch_profile_failed
@@ -304,6 +303,13 @@ fun ChatConversationScreen(
     val hasChatAccess by derivedStateOf {
         proDetails.isProPurchased || viewState.isInfluencerSubscriptionPurchasedAndVerified
     }
+    val collageStates by viewModel.collageStates.collectAsStateWithLifecycle()
+    val requestImageCooldown by viewModel.requestImageCooldownSeconds.collectAsStateWithLifecycle()
+    // Collage bubbles fetch with the CURRENT subscription state; pushing the
+    // composed gate (Pro OR per-influencer access) into the VM makes every
+    // collage refetch on a flip — historical blurred bubbles turn clear the
+    // moment a purchase verifies, and vice versa on lapse.
+    LaunchedEffect(hasChatAccess) { viewModel.setHasChatAccess(hasChatAccess) }
     val atSubscriptionThreshold by derivedStateOf {
         totalMessageCount >= viewState.subscriptionMandatoryThreshold
     }
@@ -394,7 +400,6 @@ fun ChatConversationScreen(
     val aiInfluencerReadOnlyMessage = stringResource(Res.string.ai_influencer_read_only_chat)
     val switchProfileButtonText = stringResource(Res.string.switch_profile)
     val switchProfileFailedMessage = stringResource(Res.string.switch_profile_failed)
-    val requestImageMessage = stringResource(Res.string.request_image_message)
     val bottomAreaState by derivedStateOf {
         resolveConversationBottomAreaState(
             isBotAccount = viewState.isBotAccount,
@@ -404,10 +409,11 @@ fun ChatConversationScreen(
         )
     }
 
-    fun sendMessageIfAllowed(
-        draft: SendMessageDraft,
-        onBeforeSend: () -> Unit = {},
-    ) {
+    // Shared send gates (bot account, login prompt, subscription card,
+    // purchase unavailable). Runs [onAllowed] only when nothing blocks —
+    // used by both draft sends and the quota-consuming collage request,
+    // so the gates always fire BEFORE any server side effect.
+    fun runIfSendAllowed(onAllowed: () -> Unit) {
         val blocked =
             when {
                 viewState.isBotAccount -> {
@@ -415,15 +421,11 @@ fun ChatConversationScreen(
                 }
 
                 shouldPromptForLogin -> {
-                    // Capture the intended send so successful login auto-resumes
-                    // it (chip-tap or typed draft both flow through this gate).
-                    // On cancel the callback never fires and the input stays as
-                    // typed because onBeforeSend (which clears the field) is
-                    // deferred until after the resumed send.
-                    promptLogin {
-                        onBeforeSend()
-                        viewModel.sendMessage(draft)
-                    }
+                    // Capture the intended action so successful login
+                    // auto-resumes it (chip-tap, typed draft, or collage
+                    // request all flow through this gate). On cancel the
+                    // callback never fires, so e.g. the typed input stays.
+                    promptLogin { onAllowed() }
                     true
                 }
 
@@ -442,6 +444,15 @@ fun ChatConversationScreen(
                 }
             }
         if (!blocked) {
+            onAllowed()
+        }
+    }
+
+    fun sendMessageIfAllowed(
+        draft: SendMessageDraft,
+        onBeforeSend: () -> Unit = {},
+    ) {
+        runIfSendAllowed {
             onBeforeSend()
             viewModel.sendMessage(draft)
         }
@@ -549,6 +560,21 @@ fun ChatConversationScreen(
                             streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
                             assistantError = assistantError,
                             onAssistantErrorRetry = { viewModel.retryFailedAssistantReply() },
+                            collageConfig =
+                                CollageListConfig(
+                                    states = collageStates,
+                                    influencerDisplayName =
+                                        viewState.influencer
+                                            ?.displayName
+                                            ?.ifBlank { viewState.influencer?.name }
+                                            .orEmpty(),
+                                    onLoad = viewModel::loadCollage,
+                                    onSubscribeClick = {
+                                        purchaseContext?.let {
+                                            viewModel.launchInfluencerSubscriptionPurchase(it)
+                                        }
+                                    },
+                                ),
                             onImageClick = { imageUrl ->
                                 activeImagePreview = ChatImagePreviewSource.Message(imageUrl)
                             },
@@ -751,25 +777,15 @@ fun ChatConversationScreen(
                                             },
                                             onCameraClick = imageCaptureLauncher,
                                             onGalleryClick = imagePickerLauncher,
-                                            // Paid image requests are an AI-influencer feature;
+                                            // Photo collages are an AI-influencer feature;
                                             // H2H peers can't fulfil them, so hide the option there.
                                             onRequestImageClick =
                                                 if (!viewState.isHumanChat) {
-                                                    {
-                                                        sendMessageIfAllowed(
-                                                            SendMessageDraft(
-                                                                messageType = ChatMessageType.TEXT,
-                                                                content = requestImageMessage,
-                                                                isBlur = true,
-                                                            ),
-                                                        )
-                                                    }
+                                                    { runIfSendAllowed { viewModel.requestCollageImages() } }
                                                 } else {
                                                     null
                                                 },
-                                            // Cooldown source lands with the end-to-end
-                                            // integration; option stays enabled until then.
-                                            requestImageRemainingSeconds = null,
+                                            requestImageRemainingSeconds = requestImageCooldown,
                                             // Mic button is gated on AudioRecordingEnabled (kill-switch +
                                             // GA pacing) AND not-an-H2H-chat. Voice messages aren't
                                             // supported on H2H peer chats — the H2H send route doesn't

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ChatConversationScreen.kt
@@ -41,6 +41,7 @@ import com.yral.shared.features.auth.ui.LoginMode
 import com.yral.shared.features.auth.ui.LoginScreenType
 import com.yral.shared.features.auth.ui.rememberLoginInfo
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import com.yral.shared.features.chat.domain.BotSubscriptionCatalog
 import com.yral.shared.features.chat.domain.models.ChatMessageType
 import com.yral.shared.features.chat.domain.models.ConversationMessageRole
 import com.yral.shared.features.chat.domain.models.SendMessageDraft
@@ -777,10 +778,14 @@ fun ChatConversationScreen(
                                             },
                                             onCameraClick = imageCaptureLauncher,
                                             onGalleryClick = imagePickerLauncher,
-                                            // Photo collages are an AI-influencer feature;
-                                            // H2H peers can't fulfil them, so hide the option there.
+                                            // Photo collages are exclusive to subscription bots
+                                            // (Tara) — hidden for every other bot and for H2H
+                                            // peers, who can't fulfil them.
                                             onRequestImageClick =
-                                                if (!viewState.isHumanChat) {
+                                                if (
+                                                    !viewState.isHumanChat &&
+                                                    BotSubscriptionCatalog.usesBotSubscription(viewState.influencer?.id)
+                                                ) {
                                                     { runIfSendAllowed { viewModel.requestCollageImages() } }
                                                 } else {
                                                     null

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CollageMessageBubble.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CollageMessageBubble.kt
@@ -1,0 +1,232 @@
+package com.yral.shared.features.chat.ui.conversation
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.yral.shared.features.chat.viewmodel.CollageUiState
+import com.yral.shared.libs.designsystem.component.YralLoadingDots
+import com.yral.shared.libs.designsystem.theme.LocalAppTopography
+import com.yral.shared.libs.designsystem.theme.YralColors
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+import yral_mobile.shared.features.chat.generated.resources.Res
+import yral_mobile.shared.features.chat.generated.resources.collage_generating_message
+import yral_mobile.shared.features.chat.generated.resources.collage_subscribe_cta
+import yral_mobile.shared.features.chat.generated.resources.collage_unavailable
+import yral_mobile.shared.libs.designsystem.generated.resources.ic_thunder
+import yral_mobile.shared.libs.designsystem.generated.resources.Res as DesignRes
+
+/**
+ * Shimmer bubble shown while POST /request-images is generating (rare cold
+ * path takes 45–65 s; the pre-gen'd common case replaces it near-instantly).
+ */
+@Composable
+internal fun CollageGeneratingBubble(influencerName: String) {
+    MessageInBubble {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.collage_generating_message, influencerName),
+                style = LocalAppTopography.current.baseRegular,
+                color = YralColors.NeutralTextPrimary,
+            )
+            YralLoadingDots()
+        }
+    }
+}
+
+/**
+ * A collage message. The message itself carries only (botId, date) — this
+ * bubble asks the ViewModel to resolve fresh image URLs at render time
+ * ([onLoad]), so what's shown always matches the CURRENT subscription state:
+ * pre-blurred URLs + subscribe CTA for non-subscribers, clear otherwise.
+ */
+@Composable
+internal fun CollageBubble(
+    botId: String,
+    date: String,
+    state: CollageUiState?,
+    influencerName: String,
+    onLoad: () -> Unit,
+    onImageClick: (String) -> Unit,
+    onSubscribeClick: () -> Unit,
+    maxWidth: Dp,
+) {
+    LaunchedEffect(botId, date) { onLoad() }
+    when (state) {
+        is CollageUiState.Ready ->
+            CollageGrid(
+                images = state.collage.images,
+                isBlurred = state.collage.isBlurred,
+                influencerName = influencerName,
+                onImageClick = onImageClick,
+                onSubscribeClick = onSubscribeClick,
+                maxWidth = maxWidth,
+            )
+
+        CollageUiState.Unavailable ->
+            MessageInBubble {
+                Text(
+                    text = stringResource(Res.string.collage_unavailable),
+                    style = LocalAppTopography.current.baseRegular,
+                    color = YralColors.NeutralTextSecondary,
+                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                )
+            }
+
+        CollageUiState.Loading, null -> CollageLoadingGrid(maxWidth = maxWidth)
+    }
+}
+
+@Composable
+private fun CollageLoadingGrid(maxWidth: Dp) {
+    val cellSize = collageCellSize(maxWidth)
+    Column(verticalArrangement = Arrangement.spacedBy(COLLAGE_GRID_SPACING)) {
+        repeat(COLLAGE_PLACEHOLDER_ROWS) {
+            Row(horizontalArrangement = Arrangement.spacedBy(COLLAGE_GRID_SPACING)) {
+                repeat(COLLAGE_COLUMNS) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(cellSize)
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(YralColors.Neutral900),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CollageGrid(
+    images: List<String>,
+    isBlurred: Boolean,
+    influencerName: String,
+    onImageClick: (String) -> Unit,
+    onSubscribeClick: () -> Unit,
+    maxWidth: Dp,
+) {
+    if (images.isEmpty()) return
+    val cellSize = collageCellSize(maxWidth)
+    Box {
+        Column(verticalArrangement = Arrangement.spacedBy(COLLAGE_GRID_SPACING)) {
+            images.chunked(COLLAGE_COLUMNS).forEach { rowImages ->
+                Row(horizontalArrangement = Arrangement.spacedBy(COLLAGE_GRID_SPACING)) {
+                    rowImages.forEach { imageUrl ->
+                        CollageCell(
+                            imageUrl = imageUrl,
+                            cellSize = cellSize,
+                            // Locked grid: taps route to the subscribe CTA, not the preview.
+                            onClick = if (isBlurred) null else ({ onImageClick(imageUrl) }),
+                        )
+                    }
+                }
+            }
+        }
+        if (isBlurred) {
+            // Images arrive pre-blurred from the server — the scrim just gives
+            // the subscribe pill contrast and swallows cell taps.
+            Box(
+                modifier =
+                    Modifier
+                        .matchParentSize()
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(Color.Black.copy(alpha = COLLAGE_SCRIM_ALPHA))
+                        .clickable(onClick = onSubscribeClick),
+                contentAlignment = Alignment.Center,
+            ) {
+                CollageSubscribePill(
+                    influencerName = influencerName,
+                    onClick = onSubscribeClick,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CollageCell(
+    imageUrl: String,
+    cellSize: Dp,
+    onClick: (() -> Unit)?,
+) {
+    AsyncImage(
+        model = rememberChatImageModel(imageUrl),
+        contentDescription = "collage image",
+        contentScale = ContentScale.Crop,
+        modifier =
+            Modifier
+                .size(cellSize)
+                .clip(RoundedCornerShape(6.dp))
+                .background(YralColors.Neutral900)
+                .let { base -> if (onClick != null) base.clickable(onClick = onClick) else base },
+    )
+}
+
+// Mirrors UnlockImagePill (ConversationMessageBubble.kt) — same Yellow400
+// pill + thunder icon, but routing to the influencer subscription purchase.
+@Composable
+private fun CollageSubscribePill(
+    influencerName: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.height(SUBSCRIBE_PILL_HEIGHT),
+        shape = RoundedCornerShape(4.dp),
+        color = YralColors.Yellow400,
+        border = BorderStroke(1.dp, YralColors.Yellow200),
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = SUBSCRIBE_PILL_HORIZONTAL_PADDING),
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.collage_subscribe_cta, influencerName),
+                style = LocalAppTopography.current.regSemiBold,
+                color = YralColors.Yellow200,
+            )
+            Image(
+                painter = painterResource(DesignRes.drawable.ic_thunder),
+                contentDescription = null,
+                contentScale = ContentScale.Inside,
+                modifier = Modifier.size(SUBSCRIBE_PILL_ICON_SIZE),
+            )
+        }
+    }
+}
+
+private fun collageCellSize(maxWidth: Dp): Dp = (maxWidth - COLLAGE_GRID_SPACING) / COLLAGE_COLUMNS
+
+private const val COLLAGE_COLUMNS = 2
+private const val COLLAGE_PLACEHOLDER_ROWS = 2
+private val COLLAGE_GRID_SPACING = 4.dp
+private const val COLLAGE_SCRIM_ALPHA = 0.4f
+private val SUBSCRIBE_PILL_HEIGHT = 40.dp
+private val SUBSCRIBE_PILL_HORIZONTAL_PADDING = 12.dp
+private val SUBSCRIBE_PILL_ICON_SIZE = 14.dp

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CollageMessageBubble.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CollageMessageBubble.kt
@@ -59,7 +59,8 @@ internal fun CollageGeneratingBubble(influencerName: String) {
 }
 
 /**
- * A collage message. The message itself carries only (botId, date) — this
+ * A collage message. The message itself carries only a reference (collageId
+ * when present, plus botId + date — never image URLs) — this
  * bubble asks the ViewModel to resolve fresh image URLs at render time
  * ([onLoad]), so what's shown always matches the CURRENT subscription state:
  * pre-blurred URLs + subscribe CTA for non-subscribers, clear otherwise.

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
@@ -34,6 +34,7 @@ import yral_mobile.shared.features.chat.generated.resources.Res
 import yral_mobile.shared.features.chat.generated.resources.camera
 import yral_mobile.shared.features.chat.generated.resources.message_placeholder
 import yral_mobile.shared.features.chat.generated.resources.photo_library
+import yral_mobile.shared.features.chat.generated.resources.request_image
 import yral_mobile.shared.features.chat.generated.resources.send
 import yral_mobile.shared.features.chat.generated.resources.voice_message
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_camera
@@ -42,6 +43,7 @@ import yral_mobile.shared.libs.designsystem.generated.resources.ic_microphone
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_plus_circle
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_send
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_send_disabled
+import yral_mobile.shared.libs.designsystem.generated.resources.ic_thunder
 import yral_mobile.shared.libs.designsystem.generated.resources.Res as DesignRes
 
 private const val MAX_CHARACTER_LIMIT = 4000
@@ -54,6 +56,9 @@ internal fun ChatInputArea(
     onSendClick: () -> Unit,
     onCameraClick: (() -> Unit)? = null,
     onGalleryClick: (() -> Unit)? = null,
+    onRequestImageClick: (() -> Unit)? = null,
+    // Non-null disables the Request Image option and shows this cooldown.
+    requestImageRemainingSeconds: Int? = null,
     onMicClick: (() -> Unit)? = null,
     showAttachmentMenu: Boolean = true,
     placeholder: String? = null,
@@ -111,6 +116,8 @@ internal fun ChatInputArea(
             showAttachmentMenu,
             onCameraClick,
             onGalleryClick,
+            onRequestImageClick,
+            requestImageRemainingSeconds,
             onMicClick,
             hasWaitingAssistant,
         )
@@ -124,6 +131,8 @@ private fun InputActions(
     showAttachmentMenu: Boolean,
     onCameraClick: (() -> Unit)?,
     onGalleryClick: (() -> Unit)?,
+    onRequestImageClick: (() -> Unit)?,
+    requestImageRemainingSeconds: Int?,
     onMicClick: (() -> Unit)?,
     hasWaitingAssistant: Boolean,
 ) {
@@ -142,18 +151,35 @@ private fun InputActions(
                 // Show attachment menu (camera/gallery) when both callbacks provided
                 YralContextMenu(
                     items =
-                        listOf(
-                            YralContextMenuItem(
-                                text = stringResource(Res.string.camera),
-                                icon = DesignRes.drawable.ic_camera,
-                                onClick = onCameraClick,
-                            ),
-                            YralContextMenuItem(
-                                text = stringResource(Res.string.photo_library),
-                                icon = DesignRes.drawable.ic_gallery,
-                                onClick = onGalleryClick,
-                            ),
-                        ),
+                        buildList {
+                            add(
+                                YralContextMenuItem(
+                                    text = stringResource(Res.string.camera),
+                                    icon = DesignRes.drawable.ic_camera,
+                                    onClick = onCameraClick,
+                                ),
+                            )
+                            add(
+                                YralContextMenuItem(
+                                    text = stringResource(Res.string.photo_library),
+                                    icon = DesignRes.drawable.ic_gallery,
+                                    onClick = onGalleryClick,
+                                ),
+                            )
+                            if (onRequestImageClick != null) {
+                                add(
+                                    YralContextMenuItem(
+                                        text = stringResource(Res.string.request_image),
+                                        icon = DesignRes.drawable.ic_thunder,
+                                        onClick = onRequestImageClick,
+                                        enabled = requestImageRemainingSeconds == null,
+                                        trailingText =
+                                            requestImageRemainingSeconds
+                                                ?.let(::formatRemainingMmSs),
+                                    ),
+                                )
+                            }
+                        },
                     triggerIcon = DesignRes.drawable.ic_plus_circle,
                     triggerSize = 24.dp,
                     menuIconSize = 20.dp,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationInputArea.kt
@@ -48,6 +48,22 @@ import yral_mobile.shared.libs.designsystem.generated.resources.Res as DesignRes
 
 private const val MAX_CHARACTER_LIMIT = 4000
 private const val MAX_LINES = 5
+private const val SECONDS_PER_HOUR = 3600
+private const val SECONDS_PER_MINUTE = 60
+private const val TIMER_DIGITS = 2
+
+// The collage-request cooldown counts down to the next 04:00 UTC pre-gen —
+// up to a full day — so include hours; the m:ss formatter alone would
+// render e.g. "1439:59".
+private fun formatRequestImageCooldown(totalSeconds: Int): String {
+    val hours = totalSeconds.coerceAtLeast(0) / SECONDS_PER_HOUR
+    if (hours <= 0) return formatRemainingMmSs(totalSeconds)
+    val minutes = (totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
+    val seconds = totalSeconds % SECONDS_PER_MINUTE
+    val minutesStr = minutes.toString().padStart(TIMER_DIGITS, '0')
+    val secondsStr = seconds.toString().padStart(TIMER_DIGITS, '0')
+    return "$hours:$minutesStr:$secondsStr"
+}
 
 @Composable
 internal fun ChatInputArea(
@@ -175,7 +191,7 @@ private fun InputActions(
                                         enabled = requestImageRemainingSeconds == null,
                                         trailingText =
                                             requestImageRemainingSeconds
-                                                ?.let(::formatRemainingMmSs),
+                                                ?.let(::formatRequestImageCooldown),
                                     ),
                                 )
                             }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt
@@ -267,7 +267,7 @@ private fun markDownColors(textColor: Color): DefaultMarkdownColors =
     }
 
 @Composable
-private fun MessageInBubble(
+internal fun MessageInBubble(
     isUser: Boolean = false,
     isFailed: Boolean = false,
     isOnlyMedia: Boolean = false,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessageBubble.kt
@@ -1,5 +1,6 @@
 package com.yral.shared.features.chat.ui.conversation
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -15,8 +16,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -25,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.BottomEnd
 import androidx.compose.ui.Alignment.Companion.BottomStart
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -45,13 +49,17 @@ import com.yral.shared.libs.designsystem.component.getLocalImageModel
 import com.yral.shared.libs.designsystem.theme.AppTopography
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
+import com.yral.shared.libs.designsystem.theme.appTypoGraphy
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import yral_mobile.shared.features.chat.generated.resources.Res
+import yral_mobile.shared.features.chat.generated.resources.blurred_image_unlock_cta
 import yral_mobile.shared.features.chat.generated.resources.message_failed_tap_to_resend
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_bubble_tip_black
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_bubble_tip_pink
 import yral_mobile.shared.libs.designsystem.generated.resources.ic_exclamation_circle
+import yral_mobile.shared.libs.designsystem.generated.resources.ic_thunder
 import yral_mobile.shared.libs.designsystem.generated.resources.Res as DesignRes
 
 @Composable
@@ -66,6 +74,8 @@ internal fun MessageContent(
     isStreaming: Boolean = false,
     markdownLockedOverride: Boolean? = null,
     onRetry: (() -> Unit)? = null,
+    isBlurred: Boolean = false,
+    onUnlockClick: (() -> Unit)? = null,
 ) {
     MessageBubble(
         content = content,
@@ -78,6 +88,8 @@ internal fun MessageContent(
         isStreaming = isStreaming,
         markdownLockedOverride = markdownLockedOverride,
         onRetry = onRetry,
+        isBlurred = isBlurred,
+        onUnlockClick = onUnlockClick,
     )
 }
 
@@ -93,6 +105,8 @@ internal fun MessageBubble(
     isStreaming: Boolean,
     markdownLockedOverride: Boolean?,
     onRetry: (() -> Unit)?,
+    isBlurred: Boolean,
+    onUnlockClick: (() -> Unit)?,
 ) {
     val baseModifier = Modifier.widthIn(max = maxWidth)
     val clickableModifier =
@@ -116,6 +130,8 @@ internal fun MessageBubble(
                 isFailed = isFailed,
                 isStreaming = isStreaming,
                 markdownLockedOverride = markdownLockedOverride,
+                isBlurred = isBlurred,
+                onUnlockClick = onUnlockClick,
             )
         }
     }
@@ -140,6 +156,8 @@ private fun RegularBubble(
     isFailed: Boolean,
     isStreaming: Boolean = false,
     markdownLockedOverride: Boolean? = null,
+    isBlurred: Boolean = false,
+    onUnlockClick: (() -> Unit)? = null,
 ) {
     // Phase 5c rendering contract (do not regress):
     //   1. Path lock — `markdownLockedOverride` pins Markdown vs Text for the full
@@ -198,6 +216,8 @@ private fun RegularBubble(
             mediaUrls = mediaUrls,
             onImageClick = onImageClick,
             maxWidth = maxWidth,
+            isBlurred = isBlurred,
+            onUnlockClick = onUnlockClick,
         )
     }
 }
@@ -320,6 +340,8 @@ private fun MessageImages(
     mediaUrls: List<String>,
     onImageClick: ((String) -> Unit)?,
     maxWidth: Dp,
+    isBlurred: Boolean = false,
+    onUnlockClick: (() -> Unit)? = null,
 ) {
     if (mediaUrls.isEmpty()) return
 
@@ -329,6 +351,8 @@ private fun MessageImages(
             imageUrl = imageUrl,
             onImageClick = onImageClick,
             maxWidth = maxWidth,
+            isBlurred = isBlurred,
+            onUnlockClick = onUnlockClick,
         )
     }
 }
@@ -338,6 +362,8 @@ private fun ChatMessageImage(
     imageUrl: String,
     onImageClick: ((String) -> Unit)?,
     maxWidth: Dp,
+    isBlurred: Boolean = false,
+    onUnlockClick: (() -> Unit)? = null,
 ) {
     val density = LocalDensity.current
     val imageModel = rememberChatImageModel(imageUrl)
@@ -359,10 +385,12 @@ private fun ChatMessageImage(
                 .height(imageContainerSize.heightPx.toDp())
         }.clip(RoundedCornerShape(6.dp))
             .let { baseModifier ->
-                if (onImageClick != null) {
-                    baseModifier.clickable { onImageClick(imageUrl) }
-                } else {
-                    baseModifier
+                when {
+                    // Locked image: no full-screen preview — tapping anywhere
+                    // routes to the unlock flow instead.
+                    isBlurred -> baseModifier.clickable { onUnlockClick?.invoke() }
+                    onImageClick != null -> baseModifier.clickable { onImageClick(imageUrl) }
+                    else -> baseModifier
                 }
             }
 
@@ -373,7 +401,10 @@ private fun ChatMessageImage(
         AsyncImage(
             model = imageModel,
             contentDescription = "image",
-            modifier = Modifier.fillMaxSize(),
+            modifier =
+                Modifier.fillMaxSize().let { baseModifier ->
+                    if (isBlurred) baseModifier.blur(BLURRED_IMAGE_BLUR_RADIUS) else baseModifier
+                },
             contentScale = ContentScale.Fit,
             onState = { state ->
                 isLoading = state !is AsyncImagePainter.State.Success && state !is AsyncImagePainter.State.Error
@@ -388,6 +419,51 @@ private fun ChatMessageImage(
 
         if (isLoading) {
             YralLoader()
+        }
+
+        if (isBlurred) {
+            // Scrim doubles as the hide layer on platforms where Modifier.blur
+            // is a no-op (Android < 12) and gives the pill contrast elsewhere.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = BLURRED_IMAGE_SCRIM_ALPHA)),
+                contentAlignment = Alignment.Center,
+            ) {
+                UnlockImagePill(onClick = { onUnlockClick?.invoke() })
+            }
+        }
+    }
+}
+
+// Mirrors the SubscribeButton pill in the design system (AccountInfoView.kt):
+// Yellow400 fill, Yellow200 border/text, thunder icon.
+@Composable
+private fun UnlockImagePill(onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier.height(UNLOCK_PILL_HEIGHT),
+        shape = RoundedCornerShape(4.dp),
+        color = YralColors.Yellow400,
+        border = BorderStroke(1.dp, YralColors.Yellow200),
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = UNLOCK_PILL_HORIZONTAL_PADDING),
+            horizontalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.blurred_image_unlock_cta),
+                style = LocalAppTopography.current.regSemiBold,
+                color = YralColors.Yellow200,
+            )
+            Image(
+                painter = painterResource(DesignRes.drawable.ic_thunder),
+                contentDescription = null,
+                contentScale = ContentScale.Inside,
+                modifier = Modifier.size(UNLOCK_PILL_ICON_SIZE),
+            )
         }
     }
 }
@@ -407,6 +483,26 @@ internal fun localChatImageFilePathOrNull(imageUrl: String): String? =
 
 internal fun String.shouldRenderAsMarkdown(): Boolean = all { it.code <= ASCII_MAX_CODE }
 
+@Suppress("UnusedPrivateMember")
+@Preview
+@Composable
+private fun BlurredChatMessageImagePreview() {
+    CompositionLocalProvider(LocalAppTopography provides appTypoGraphy()) {
+        ChatMessageImage(
+            imageUrl = "https://example.com/image.jpg",
+            onImageClick = null,
+            maxWidth = 280.dp,
+            isBlurred = true,
+            onUnlockClick = {},
+        )
+    }
+}
+
 private const val FILE_URL_PREFIX = "file://"
 private const val ABSOLUTE_PATH_PREFIX = "/"
 private const val ASCII_MAX_CODE = 0x7F
+private val BLURRED_IMAGE_BLUR_RADIUS = 16.dp
+private const val BLURRED_IMAGE_SCRIM_ALPHA = 0.4f
+private val UNLOCK_PILL_HEIGHT = 40.dp
+private val UNLOCK_PILL_HORIZONTAL_PADDING = 12.dp
+private val UNLOCK_PILL_ICON_SIZE = 14.dp

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -209,7 +209,7 @@ private fun MessageRow(
 internal data class CollageListConfig(
     val states: Map<String, CollageUiState> = emptyMap(),
     val influencerDisplayName: String = "",
-    val onLoad: (botId: String, date: String) -> Unit = { _, _ -> },
+    val onLoad: (botId: String, date: String, collageId: String?) -> Unit = { _, _, _ -> },
     val onSubscribeClick: () -> Unit = {},
 )
 
@@ -234,7 +234,7 @@ private fun CollageMessageRow(
                     // Key format mirrors ConversationViewModel.collageKey.
                     state = config.states["${info.botId}|${info.date}"],
                     influencerName = config.influencerDisplayName,
-                    onLoad = { config.onLoad(info.botId, info.date) },
+                    onLoad = { config.onLoad(info.botId, info.date, info.collageId) },
                     onImageClick = onImageClick,
                     onSubscribeClick = config.onSubscribeClick,
                     maxWidth = maxWidth,
@@ -248,6 +248,8 @@ private data class CollageDisplayInfo(
     val isGenerating: Boolean,
     val botId: String?,
     val date: String?,
+    // Preferred fetch handle; null on legacy messages, which resolve by date.
+    val collageId: String?,
 )
 
 /**
@@ -261,7 +263,14 @@ private fun ConversationMessageItem.collageDisplayInfoOrNull(): CollageDisplayIn
             is ConversationMessageItem.Remote ->
                 message
                     .takeIf { it.messageType == ChatMessageType.COLLAGE }
-                    ?.let { CollageDisplayInfo(isGenerating = false, botId = it.collageBotId, date = it.collageDate) }
+                    ?.let {
+                        CollageDisplayInfo(
+                            isGenerating = false,
+                            botId = it.collageBotId,
+                            date = it.collageDate,
+                            collageId = it.collageId,
+                        )
+                    }
 
             is ConversationMessageItem.Local ->
                 message
@@ -271,6 +280,7 @@ private fun ConversationMessageItem.collageDisplayInfoOrNull(): CollageDisplayIn
                             isGenerating = it.isPlaceholder,
                             botId = it.collageBotId,
                             date = it.collageDate,
+                            collageId = it.collageId,
                         )
                     }
         } ?: return null

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -34,6 +34,7 @@ internal fun MessagesList(
     assistantError: AssistantErrorPresentation? = null,
     onAssistantErrorRetry: () -> Unit = {},
     onImageClick: (imageUrl: String) -> Unit,
+    onUnlockImage: (messageId: String) -> Unit,
     onRetry: (localId: String) -> Unit,
 ) {
     val overlayMessageIds = overlayMessageIdSet(overlayItems)
@@ -71,6 +72,7 @@ internal fun MessagesList(
                 isHumanChat = isHumanChat,
                 currentUserPrincipalId = currentUserPrincipalId,
                 onImageClick = onImageClick,
+                onUnlockImage = onUnlockImage,
                 onRetry = onRetry,
             )
         }
@@ -88,6 +90,7 @@ internal fun MessagesList(
                 isHumanChat = isHumanChat,
                 currentUserPrincipalId = currentUserPrincipalId,
                 onImageClick = onImageClick,
+                onUnlockImage = onUnlockImage,
                 onRetry = onRetry,
             )
         }
@@ -114,6 +117,7 @@ private fun MessageRow(
     isHumanChat: Boolean,
     currentUserPrincipalId: String?,
     onImageClick: (imageUrl: String) -> Unit,
+    onUnlockImage: (messageId: String) -> Unit,
     onRetry: (localId: String) -> Unit,
 ) {
     val screenWidth = LocalWindowInfo.current.containerSize.width
@@ -147,53 +151,12 @@ private fun MessageRow(
     // assistant message) lands at the same screen position; without a unified
     // slot, Compose tears down the Local subtree and creates a fresh Remote one
     // every time, producing a one-frame flicker.
-    //
-    // Cursor note: `renderContent` here is cursor-free (just the streamingBuffer
-    // or the message content). RegularBubble renders the cursor as a sibling
-    // composable, so the Markdown/Text renderer never sees the moving cursor.
-    val renderContent: String?
-    val renderMediaUrls: List<String>
-    val renderIsFailed: Boolean
-    val renderIsWaiting: Boolean
-    val renderIsStreaming: Boolean
-    val renderMarkdownLockedOverride: Boolean?
-    val renderOnRetry: (() -> Unit)?
-    when (item) {
-        is ConversationMessageItem.Remote -> {
-            renderContent = item.message.content
-            renderMediaUrls = item.message.mediaUrls
-            renderIsFailed = false
-            renderIsWaiting = false
-            renderIsStreaming = false
-            // Phase 5b: look up the persisted lock for this server message id. Present
-            // only for messages that arrived via streaming this VM session; absent for
-            // history-paged messages, which fall back to the default Markdown decision.
-            renderMarkdownLockedOverride = streamMarkdownLockedRemoteIds[item.message.id]
-            renderOnRetry = null
-        }
-
-        is ConversationMessageItem.Local -> {
-            val streamingBuffer = item.message.streamingBuffer
-            renderContent =
-                when {
-                    streamingBuffer != null -> streamingBuffer
-                    item.message.isPlaceholder -> "…"
-                    else -> item.message.content
-                }
-            renderMediaUrls = item.message.mediaUrls
-            renderIsFailed = item.message.status == LocalMessageStatus.FAILED
-            renderIsWaiting = item.isWaitingAssistant()
-            renderIsStreaming = streamingBuffer != null
-            // Phase 5b: streaming Local carries its own per-stream path lock.
-            renderMarkdownLockedOverride = item.message.useMarkdownLocked
-            renderOnRetry =
-                if (item.message.status == LocalMessageStatus.FAILED && !item.message.isPlaceholder) {
-                    { onRetry(item.message.localId) }
-                } else {
-                    null
-                }
-        }
-    }
+    val renderParams =
+        item.toRenderParams(
+            streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
+            onUnlockImage = onUnlockImage,
+            onRetry = onRetry,
+        )
 
     Box(
         modifier = Modifier.fillMaxWidth().padding(vertical = MESSAGE_VERTICAL_PADDING_DP),
@@ -201,18 +164,85 @@ private fun MessageRow(
     ) {
         MessageContent(
             isUser = isUser,
-            content = renderContent,
-            mediaUrls = renderMediaUrls,
+            content = renderParams.content,
+            mediaUrls = renderParams.mediaUrls,
             maxWidth = maxWidth,
             onImageClick = onImageClick,
-            isFailed = renderIsFailed,
-            isWaiting = renderIsWaiting,
-            isStreaming = renderIsStreaming,
-            markdownLockedOverride = renderMarkdownLockedOverride,
-            onRetry = renderOnRetry,
+            isFailed = renderParams.isFailed,
+            isWaiting = renderParams.isWaiting,
+            isStreaming = renderParams.isStreaming,
+            markdownLockedOverride = renderParams.markdownLockedOverride,
+            onRetry = renderParams.onRetry,
+            isBlurred = renderParams.isBlurred,
+            onUnlockClick = renderParams.onUnlockClick,
         )
     }
 }
+
+private data class MessageRenderParams(
+    val content: String?,
+    val mediaUrls: List<String>,
+    val isFailed: Boolean,
+    val isWaiting: Boolean,
+    val isStreaming: Boolean,
+    val markdownLockedOverride: Boolean?,
+    val onRetry: (() -> Unit)?,
+    val isBlurred: Boolean,
+    val onUnlockClick: (() -> Unit)?,
+)
+
+// Cursor note: `content` here is cursor-free (just the streamingBuffer
+// or the message content). RegularBubble renders the cursor as a sibling
+// composable, so the Markdown/Text renderer never sees the moving cursor.
+private fun ConversationMessageItem.toRenderParams(
+    streamMarkdownLockedRemoteIds: Map<String, Boolean>,
+    onUnlockImage: (messageId: String) -> Unit,
+    onRetry: (localId: String) -> Unit,
+): MessageRenderParams =
+    when (this) {
+        is ConversationMessageItem.Remote ->
+            MessageRenderParams(
+                content = message.content,
+                mediaUrls = message.mediaUrls,
+                isFailed = false,
+                isWaiting = false,
+                isStreaming = false,
+                // Phase 5b: look up the persisted lock for this server message id. Present
+                // only for messages that arrived via streaming this VM session; absent for
+                // history-paged messages, which fall back to the default Markdown decision.
+                markdownLockedOverride = streamMarkdownLockedRemoteIds[message.id],
+                onRetry = null,
+                isBlurred = message.isBlur,
+                onUnlockClick = { onUnlockImage(message.id) },
+            )
+
+        is ConversationMessageItem.Local -> {
+            val streamingBuffer = message.streamingBuffer
+            MessageRenderParams(
+                content =
+                    when {
+                        streamingBuffer != null -> streamingBuffer
+                        message.isPlaceholder -> "…"
+                        else -> message.content
+                    },
+                mediaUrls = message.mediaUrls,
+                isFailed = message.status == LocalMessageStatus.FAILED,
+                isWaiting = isWaitingAssistant(),
+                isStreaming = streamingBuffer != null,
+                // Phase 5b: streaming Local carries its own per-stream path lock.
+                markdownLockedOverride = message.useMarkdownLocked,
+                onRetry =
+                    if (message.status == LocalMessageStatus.FAILED && !message.isPlaceholder) {
+                        { onRetry(message.localId) }
+                    } else {
+                        null
+                    },
+                // Optimistic local sends are always the viewer's own images.
+                isBlurred = false,
+                onUnlockClick = null,
+            )
+        }
+    }
 
 private fun ConversationMessageItem.role(): ConversationMessageRole =
     when (this) {

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
@@ -12,14 +13,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import com.yral.shared.features.chat.domain.models.AssistantErrorPresentation
+import com.yral.shared.features.chat.domain.models.ChatMessageType
 import com.yral.shared.features.chat.domain.models.ConversationMessageRole
 import com.yral.shared.features.chat.domain.models.isFromCurrentUser
+import com.yral.shared.features.chat.viewmodel.CollageUiState
 import com.yral.shared.features.chat.viewmodel.ConversationMessageItem
 import com.yral.shared.features.chat.viewmodel.LocalMessageStatus
 
+// The list's feature surface (paging + overlay + streaming locks + assistant
+// errors + blur/unlock + collage) is inherently wide; related inputs are
+// already bundled (CollageListConfig, AssistantErrorPresentation).
+@Suppress("LongParameterList")
 @Composable
 internal fun MessagesList(
     modifier: Modifier,
@@ -33,6 +41,7 @@ internal fun MessagesList(
     streamMarkdownLockedRemoteIds: Map<String, Boolean> = emptyMap(),
     assistantError: AssistantErrorPresentation? = null,
     onAssistantErrorRetry: () -> Unit = {},
+    collageConfig: CollageListConfig = CollageListConfig(),
     onImageClick: (imageUrl: String) -> Unit,
     onUnlockImage: (messageId: String) -> Unit,
     onRetry: (localId: String) -> Unit,
@@ -71,6 +80,7 @@ internal fun MessagesList(
                 streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
                 isHumanChat = isHumanChat,
                 currentUserPrincipalId = currentUserPrincipalId,
+                collageConfig = collageConfig,
                 onImageClick = onImageClick,
                 onUnlockImage = onUnlockImage,
                 onRetry = onRetry,
@@ -89,6 +99,7 @@ internal fun MessagesList(
                 streamMarkdownLockedRemoteIds = streamMarkdownLockedRemoteIds,
                 isHumanChat = isHumanChat,
                 currentUserPrincipalId = currentUserPrincipalId,
+                collageConfig = collageConfig,
                 onImageClick = onImageClick,
                 onUnlockImage = onUnlockImage,
                 onRetry = onRetry,
@@ -116,6 +127,7 @@ private fun MessageRow(
     streamMarkdownLockedRemoteIds: Map<String, Boolean>,
     isHumanChat: Boolean,
     currentUserPrincipalId: String?,
+    collageConfig: CollageListConfig,
     onImageClick: (imageUrl: String) -> Unit,
     onUnlockImage: (messageId: String) -> Unit,
     onRetry: (localId: String) -> Unit,
@@ -127,6 +139,20 @@ private fun MessageRow(
         SystemBannerMessage(
             text = item.message.content.orEmpty(),
             modifier = Modifier.fillMaxWidth().padding(vertical = MESSAGE_VERTICAL_PADDING_DP),
+        )
+        return
+    }
+
+    // Collage messages render their own bubble: the (botId, date) reference is
+    // resolved at render time (see CollageBubble). Always left-aligned — the
+    // photos are the influencer's, whatever role the send endpoint stored.
+    val collageInfo = item.collageDisplayInfoOrNull()
+    if (collageInfo != null) {
+        CollageMessageRow(
+            info = collageInfo,
+            config = collageConfig,
+            onImageClick = onImageClick,
+            maxWidth = maxWidth,
         )
         return
     }
@@ -177,6 +203,79 @@ private fun MessageRow(
             onUnlockClick = renderParams.onUnlockClick,
         )
     }
+}
+
+/** Collage inputs bundled so the list/row signatures stay within detekt's parameter budget. */
+internal data class CollageListConfig(
+    val states: Map<String, CollageUiState> = emptyMap(),
+    val influencerDisplayName: String = "",
+    val onLoad: (botId: String, date: String) -> Unit = { _, _ -> },
+    val onSubscribeClick: () -> Unit = {},
+)
+
+@Composable
+private fun CollageMessageRow(
+    info: CollageDisplayInfo,
+    config: CollageListConfig,
+    onImageClick: (imageUrl: String) -> Unit,
+    maxWidth: Dp,
+) {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(vertical = MESSAGE_VERTICAL_PADDING_DP),
+        contentAlignment = Alignment.TopStart,
+    ) {
+        Box(modifier = Modifier.widthIn(max = maxWidth)) {
+            if (info.isGenerating || info.botId == null || info.date == null) {
+                CollageGeneratingBubble(influencerName = config.influencerDisplayName)
+            } else {
+                CollageBubble(
+                    botId = info.botId,
+                    date = info.date,
+                    // Key format mirrors ConversationViewModel.collageKey.
+                    state = config.states["${info.botId}|${info.date}"],
+                    influencerName = config.influencerDisplayName,
+                    onLoad = { config.onLoad(info.botId, info.date) },
+                    onImageClick = onImageClick,
+                    onSubscribeClick = config.onSubscribeClick,
+                    maxWidth = maxWidth,
+                )
+            }
+        }
+    }
+}
+
+private data class CollageDisplayInfo(
+    val isGenerating: Boolean,
+    val botId: String?,
+    val date: String?,
+)
+
+/**
+ * Non-null for COLLAGE messages that should render the collage bubble.
+ * A remote collage message missing its reference fields falls back to the
+ * regular text bubble (its content is the "Requested an image" fallback).
+ */
+private fun ConversationMessageItem.collageDisplayInfoOrNull(): CollageDisplayInfo? {
+    val info =
+        when (this) {
+            is ConversationMessageItem.Remote ->
+                message
+                    .takeIf { it.messageType == ChatMessageType.COLLAGE }
+                    ?.let { CollageDisplayInfo(isGenerating = false, botId = it.collageBotId, date = it.collageDate) }
+
+            is ConversationMessageItem.Local ->
+                message
+                    .takeIf { it.messageType == ChatMessageType.COLLAGE }
+                    ?.let {
+                        CollageDisplayInfo(
+                            isGenerating = it.isPlaceholder,
+                            botId = it.collageBotId,
+                            date = it.collageDate,
+                        )
+                    }
+        } ?: return null
+    val missingReference = !info.isGenerating && (info.botId == null || info.date == null)
+    return if (missingReference) null else info
 }
 
 private data class MessageRenderParams(

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/ConversationMessagesList.kt
@@ -23,6 +23,9 @@ import com.yral.shared.features.chat.domain.models.isFromCurrentUser
 import com.yral.shared.features.chat.viewmodel.CollageUiState
 import com.yral.shared.features.chat.viewmodel.ConversationMessageItem
 import com.yral.shared.features.chat.viewmodel.LocalMessageStatus
+import kotlinx.datetime.LocalDate
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 // The list's feature surface (paging + overlay + streaming locks + assistant
 // errors + blur/unlock + collage) is inherently wide; related inputs are
@@ -143,10 +146,10 @@ private fun MessageRow(
         return
     }
 
-    // Collage messages render their own bubble: the (botId, date) reference is
-    // resolved at render time (see CollageBubble). Always left-aligned — the
-    // photos are the influencer's, whatever role the send endpoint stored.
-    val collageInfo = item.collageDisplayInfoOrNull()
+    // Collage messages render their own bubble: the reference is resolved at
+    // render time (see CollageBubble). Always left-aligned — the photos are
+    // the influencer's, whatever role the send endpoint stored.
+    val collageInfo = item.collageDisplayInfoOrNull(fallbackBotId = collageConfig.botId)
     if (collageInfo != null) {
         CollageMessageRow(
             info = collageInfo,
@@ -208,6 +211,9 @@ private fun MessageRow(
 /** Collage inputs bundled so the list/row signatures stay within detekt's parameter budget. */
 internal data class CollageListConfig(
     val states: Map<String, CollageUiState> = emptyMap(),
+    // The conversation's influencer id — fallback bot for collage rows the
+    // backend stored without their reference fields.
+    val botId: String = "",
     val influencerDisplayName: String = "",
     val onLoad: (botId: String, date: String, collageId: String?) -> Unit = { _, _, _ -> },
     val onSubscribeClick: () -> Unit = {},
@@ -254,10 +260,14 @@ private data class CollageDisplayInfo(
 
 /**
  * Non-null for COLLAGE messages that should render the collage bubble.
- * A remote collage message missing its reference fields falls back to the
- * regular text bubble (its content is the "Requested an image" fallback).
+ *
+ * Remote rows the backend stored WITHOUT their reference fields (known gap)
+ * self-heal: the bot is the conversation's influencer ([fallbackBotId]) and
+ * the collage date is the message's own UTC send date — GET /collage?date=
+ * resolves both. Rows where even that fails fall back to the regular text
+ * bubble (their content is the "Requested an image" fallback).
  */
-private fun ConversationMessageItem.collageDisplayInfoOrNull(): CollageDisplayInfo? {
+private fun ConversationMessageItem.collageDisplayInfoOrNull(fallbackBotId: String?): CollageDisplayInfo? {
     val info =
         when (this) {
             is ConversationMessageItem.Remote ->
@@ -266,8 +276,8 @@ private fun ConversationMessageItem.collageDisplayInfoOrNull(): CollageDisplayIn
                     ?.let {
                         CollageDisplayInfo(
                             isGenerating = false,
-                            botId = it.collageBotId,
-                            date = it.collageDate,
+                            botId = it.collageBotId ?: fallbackBotId?.takeIf(String::isNotBlank),
+                            date = it.collageDate ?: utcDateStringOrNull(it.createdAt),
                             collageId = it.collageId,
                         )
                     }
@@ -287,6 +297,22 @@ private fun ConversationMessageItem.collageDisplayInfoOrNull(): CollageDisplayIn
     val missingReference = !info.isGenerating && (info.botId == null || info.date == null)
     return if (missingReference) null else info
 }
+
+/** UTC calendar date ("YYYY-MM-DD") of an ISO timestamp, null if unparseable. */
+@OptIn(ExperimentalTime::class)
+private fun utcDateStringOrNull(createdAt: String): String? =
+    runCatching {
+        val normalized =
+            if (createdAt.endsWith('Z') || createdAt.matches(Regex(".*[+-]\\d{2}:\\d{2}$"))) {
+                createdAt
+            } else {
+                "${createdAt}Z"
+            }
+        val epochDays = Instant.parse(normalized).toEpochMilliseconds().floorDiv(MS_PER_UTC_DAY)
+        LocalDate.fromEpochDays(epochDays.toInt()).toString()
+    }.getOrNull()
+
+private const val MS_PER_UTC_DAY = 86_400_000L
 
 private data class MessageRenderParams(
     val content: String?,

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/ui/conversation/CreatorTakeoverBar.kt
@@ -113,7 +113,7 @@ internal fun CreatorTakeoverBar(
     }
 }
 
-private fun formatRemainingMmSs(totalSeconds: Int): String {
+internal fun formatRemainingMmSs(totalSeconds: Int): String {
     val safe = totalSeconds.coerceAtLeast(0)
     val minutes = safe / SECONDS_PER_MINUTE
     val seconds = safe % SECONDS_PER_MINUTE

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -2018,6 +2018,7 @@ class ConversationViewModel(
         if (collageHasChatAccess == hasAccess) return
         collageHasChatAccess = hasAccess
         if (collageRefs.isEmpty()) return
+        Logger.d("CollageX") { "hasChatAccess -> $hasAccess, refetching ${collageRefs.size} collage(s)" }
         collageFetchJobs.values.forEach { it.cancel() }
         collageFetchJobs.clear()
         _collageStates.update { state -> state.mapValues { CollageUiState.Loading } }
@@ -2068,6 +2069,10 @@ class ConversationViewModel(
                 var terminal = false
                 while (!terminal) {
                     var retryAfterMs: Long? = null
+                    Logger.d("CollageX") {
+                        "fetch GET bot=${ref.botId} date=${ref.date} collageId=${ref.collageId} " +
+                            "isSubscribed=$isSubscribed attempt=$attempt"
+                    }
                     getInfluencerCollageUseCase(
                         GetInfluencerCollageUseCase.Params(
                             influencerId = ref.botId,
@@ -2077,6 +2082,10 @@ class ConversationViewModel(
                         ),
                     ).onSuccess { collage ->
                         terminal = true
+                        Logger.d("CollageX") {
+                            "fetch success key=$key collageId=${collage.id} date=${collage.date} " +
+                                "images=${collage.images.size} isBlurred=${collage.isBlurred}"
+                        }
                         collageCache.write(collage = collage, isSubscribed = isSubscribed)
                         _collageStates.update { it + (key to CollageUiState.Ready(collage)) }
                     }.onFailure { error ->
@@ -2090,6 +2099,11 @@ class ConversationViewModel(
                             error.httpStatusOrNull() == HttpStatusCode.NotFound &&
                                 ref.collageId == null &&
                                 ref.date == currentCollageDateString()
+                        Logger.e("CollageX", error) {
+                            "fetch failed key=$key status=${error.httpStatusOrNull()} " +
+                                "type=${error::class.simpleName} msg=${error.message} " +
+                                "stillGenerating=$stillGenerating attempt=$attempt"
+                        }
                         if (stillGenerating && attempt < COLLAGE_NOT_READY_RETRY_DELAYS_MS.size) {
                             retryAfterMs = COLLAGE_NOT_READY_RETRY_DELAYS_MS[attempt]
                         } else {
@@ -2119,6 +2133,7 @@ class ConversationViewModel(
         if (_viewState.value.isHumanChat) return
         if (isCollageRequestInFlight || _requestImageCooldownSeconds.value != null) return
         isCollageRequestInFlight = true
+        Logger.d("CollageX") { "requestImages start bot=${influencer.id} isSubscribed=$collageHasChatAccess" }
         val now = Clock.System.now().toEpochMilliseconds()
         val shimmer =
             LocalMessage(
@@ -2156,6 +2171,10 @@ class ConversationViewModel(
         shimmerLocalId: String,
         collage: Collage,
     ) {
+        Logger.d("CollageX") {
+            "requestImages success collageId=${collage.id} date=${collage.date} " +
+                "images=${collage.images.size} isBlurred=${collage.isBlurred} theme=${collage.theme}"
+        }
         collageCache.write(collage = collage, isSubscribed = collageHasChatAccess)
         // Pre-warm so the bubble renders instantly once the message lands.
         val ref = CollageRef(botId = collage.botId, date = collage.date, collageId = collage.id)
@@ -2200,6 +2219,9 @@ class ConversationViewModel(
         ).onSuccess { result ->
             handleCollageSendSuccess(result, userLocal.localId)
         }.onFailure { error ->
+            Logger.e("CollageX", error) {
+                "collage message send failed status=${error.httpStatusOrNull()} msg=${error.message}"
+            }
             handleSendFailure(error, userLocal.localId, assistantLocalId = "")
         }
     }
@@ -2221,6 +2243,10 @@ class ConversationViewModel(
         shimmerLocalId: String,
         error: Throwable,
     ) {
+        Logger.e("CollageX", error) {
+            "requestImages failed status=${error.httpStatusOrNull()} type=${error::class.simpleName} " +
+                "msg=${error.message} cause=${error.cause?.let { "${it::class.simpleName}: ${it.message}" }}"
+        }
         _overlay.update { state ->
             state.copy(pending = state.pending.filterNot { it.localId == shimmerLocalId })
         }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -1389,6 +1389,7 @@ class ConversationViewModel(
                 status = LocalMessageStatus.SENDING,
                 isPlaceholder = false,
                 draftForRetry = draft,
+                collageId = draft.collageId,
                 collageBotId = draft.collageBotId,
                 collageDate = draft.collageDate,
             )
@@ -1976,10 +1977,11 @@ class ConversationViewModel(
     }
 
     // ── Collage (Request Images) ─────────────────────────────────────────
-    // Chat messages carry only a (botId, date) reference; bubbles resolve it
-    // here at render time so the URLs always match the CURRENT subscription
-    // state (blurred for non-subscribers, clear after purchase — including
-    // for historical messages, which refetch on the flip).
+    // Chat messages carry only a reference (collageId when present, plus
+    // botId + date); bubbles resolve it here at render time so the URLs
+    // always match the CURRENT subscription state (blurred for
+    // non-subscribers, clear after purchase — including for historical
+    // messages, which refetch on the flip).
 
     private val _collageStates = MutableStateFlow<Map<String, CollageUiState>>(emptyMap())
     val collageStates: StateFlow<Map<String, CollageUiState>> = _collageStates.asStateFlow()
@@ -1988,14 +1990,23 @@ class ConversationViewModel(
     val requestImageCooldownSeconds: StateFlow<Int?> = _requestImageCooldownSeconds.asStateFlow()
 
     private val collageFetchJobs = mutableMapOf<String, Job>()
+
+    // Everything needed to (re)fetch a collage reference. collageId is the
+    // preferred server handle; legacy messages predate it and resolve via
+    // (botId, date). Client-side identity stays (botId, date) — one collage
+    // per bot per day — so both message shapes share one key space.
+    private data class CollageRef(
+        val botId: String,
+        val date: String,
+        val collageId: String?,
+    ) {
+        val key: String get() = "$botId|$date"
+    }
+
+    private val collageRefs = mutableMapOf<String, CollageRef>()
     private var collageCooldownJob: Job? = null
     private var collageHasChatAccess = false
     private var isCollageRequestInFlight = false
-
-    private fun collageKey(
-        botId: String,
-        date: String,
-    ) = "$botId|$date"
 
     /**
      * Pushed from the screen — the effective subscription gate (Pro OR
@@ -2006,17 +2017,11 @@ class ConversationViewModel(
     fun setHasChatAccess(hasAccess: Boolean) {
         if (collageHasChatAccess == hasAccess) return
         collageHasChatAccess = hasAccess
-        if (_collageStates.value.isEmpty()) return
+        if (collageRefs.isEmpty()) return
         collageFetchJobs.values.forEach { it.cancel() }
         collageFetchJobs.clear()
-        val keys = _collageStates.value.keys.toList()
         _collageStates.update { state -> state.mapValues { CollageUiState.Loading } }
-        keys.forEach { key ->
-            launchCollageFetch(
-                botId = key.substringBeforeLast('|'),
-                date = key.substringAfterLast('|'),
-            )
-        }
+        collageRefs.values.toList().forEach { launchCollageFetch(it) }
     }
 
     /** Render-time resolve of a collage reference; called from the bubble's LaunchedEffect. */
@@ -2025,6 +2030,7 @@ class ConversationViewModel(
     fun loadCollage(
         botId: String,
         date: String,
+        collageId: String?,
     ) {
         if (botId.isBlank() || date.isBlank()) return
         // Cooldown sighting: a collage dated today in this conversation means
@@ -2033,24 +2039,28 @@ class ConversationViewModel(
         if (date == currentCollageDateString()) {
             startCollageCooldown()
         }
-        val key = collageKey(botId, date)
-        if (_collageStates.value[key] is CollageUiState.Ready) return
-        if (collageFetchJobs[key]?.isActive == true) return
+        val ref = CollageRef(botId = botId, date = date, collageId = collageId)
+        // Keep the richest ref seen for this key: an id-less sighting (e.g.
+        // the optimistic Local echo racing the Remote row) must not erase a
+        // collageId already recorded for it.
+        val tracked = collageRefs[ref.key]
+        if (tracked == null || (tracked.collageId == null && collageId != null)) {
+            collageRefs[ref.key] = ref
+        }
+        if (_collageStates.value[ref.key] is CollageUiState.Ready) return
+        if (collageFetchJobs[ref.key]?.isActive == true) return
         val cached = collageCache.read(botId = botId, date = date, isSubscribed = collageHasChatAccess)
         if (cached != null) {
-            _collageStates.update { it + (key to CollageUiState.Ready(cached)) }
+            _collageStates.update { it + (ref.key to CollageUiState.Ready(cached)) }
             return
         }
-        _collageStates.update { it + (key to CollageUiState.Loading) }
-        launchCollageFetch(botId = botId, date = date)
+        _collageStates.update { it + (ref.key to CollageUiState.Loading) }
+        launchCollageFetch(collageRefs.getValue(ref.key))
     }
 
     @OptIn(ExperimentalTime::class)
-    private fun launchCollageFetch(
-        botId: String,
-        date: String,
-    ) {
-        val key = collageKey(botId, date)
+    private fun launchCollageFetch(ref: CollageRef) {
+        val key = ref.key
         collageFetchJobs[key] =
             viewModelScope.launch {
                 val isSubscribed = collageHasChatAccess
@@ -2059,18 +2069,27 @@ class ConversationViewModel(
                 while (!terminal) {
                     var retryAfterMs: Long? = null
                     getInfluencerCollageUseCase(
-                        GetInfluencerCollageUseCase.Params(influencerId = botId, isSubscribed = isSubscribed),
+                        GetInfluencerCollageUseCase.Params(
+                            influencerId = ref.botId,
+                            isSubscribed = isSubscribed,
+                            collageId = ref.collageId,
+                            date = ref.date,
+                        ),
                     ).onSuccess { collage ->
                         terminal = true
-                        applyFetchedCollage(key, date, isSubscribed, collage)
+                        collageCache.write(collage = collage, isSubscribed = isSubscribed)
+                        _collageStates.update { it + (key to CollageUiState.Ready(collage)) }
                     }.onFailure { error ->
-                        // 404 on today's reference = collage still generating
-                        // (cold-path race, e.g. another device just POSTed) —
-                        // retry briefly. Anything else degrades to Unavailable;
-                        // a scroll-back re-entry retriggers loadCollage.
+                        // 404 on an id-less reference dated today = collage
+                        // still generating (cold-path race, e.g. another device
+                        // just POSTed) — retry briefly. A reference WITH an id
+                        // means the collage already exists, so its 404 (like
+                        // any other error) degrades to Unavailable; a
+                        // scroll-back re-entry retriggers loadCollage.
                         val stillGenerating =
                             error.httpStatusOrNull() == HttpStatusCode.NotFound &&
-                                date == currentCollageDateString()
+                                ref.collageId == null &&
+                                ref.date == currentCollageDateString()
                         if (stillGenerating && attempt < COLLAGE_NOT_READY_RETRY_DELAYS_MS.size) {
                             retryAfterMs = COLLAGE_NOT_READY_RETRY_DELAYS_MS[attempt]
                         } else {
@@ -2084,22 +2103,6 @@ class ConversationViewModel(
                     }
                 }
             }
-    }
-
-    private fun applyFetchedCollage(
-        key: String,
-        expectedDate: String,
-        isSubscribed: Boolean,
-        collage: Collage,
-    ) {
-        // GET /collage serves only today's row; a date mismatch means this
-        // reference points at an older collage that can no longer be fetched.
-        if (collage.date != expectedDate) {
-            _collageStates.update { it + (key to CollageUiState.Unavailable) }
-            return
-        }
-        collageCache.write(collage = collage, isSubscribed = isSubscribed)
-        _collageStates.update { it + (key to CollageUiState.Ready(collage)) }
     }
 
     /**
@@ -2155,9 +2158,9 @@ class ConversationViewModel(
     ) {
         collageCache.write(collage = collage, isSubscribed = collageHasChatAccess)
         // Pre-warm so the bubble renders instantly once the message lands.
-        _collageStates.update {
-            it + (collageKey(collage.botId, collage.date) to CollageUiState.Ready(collage))
-        }
+        val ref = CollageRef(botId = collage.botId, date = collage.date, collageId = collage.id)
+        collageRefs[ref.key] = ref
+        _collageStates.update { it + (ref.key to CollageUiState.Ready(collage)) }
         startCollageCooldown()
         val draft =
             SendMessageDraft(
@@ -2165,6 +2168,7 @@ class ConversationViewModel(
                 // Fallback body: old clients degrade unknown types to TEXT
                 // and render this string instead of the grid.
                 content = getString(Res.string.request_image_message),
+                collageId = collage.id,
                 collageBotId = collage.botId,
                 collageDate = collage.date,
             )
@@ -2179,6 +2183,7 @@ class ConversationViewModel(
                 status = LocalMessageStatus.SENDING,
                 isPlaceholder = false,
                 draftForRetry = draft,
+                collageId = collage.id,
                 collageBotId = collage.botId,
                 collageDate = collage.date,
             )
@@ -2259,6 +2264,7 @@ class ConversationViewModel(
     private fun resetCollageState() {
         collageFetchJobs.values.forEach { it.cancel() }
         collageFetchJobs.clear()
+        collageRefs.clear()
         _collageStates.value = emptyMap()
         collageCooldownJob?.cancel()
         collageCooldownJob = null
@@ -2725,6 +2731,7 @@ data class LocalMessage(
     val useMarkdownLocked: Boolean? = null,
     // COLLAGE reference — the optimistic echo renders through the same
     // reference→GET path as Remote collage messages; URLs never live here.
+    val collageId: String? = null,
     val collageBotId: String? = null,
     val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -22,17 +22,20 @@ import com.yral.shared.data.domain.models.ConversationInfluencerSource
 import com.yral.shared.features.chat.analytics.ChatTelemetry
 import com.yral.shared.features.chat.attachments.ChatAttachment
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
+import com.yral.shared.features.chat.data.CollageCache
 import com.yral.shared.features.chat.data.ConversationContentCache
 import com.yral.shared.features.chat.domain.ChatErrorMapper
 import com.yral.shared.features.chat.domain.ChatRepository
 import com.yral.shared.features.chat.domain.ConversationMessagesPagingSource
 import com.yral.shared.features.chat.domain.EmptyMessagesPagingSource
+import com.yral.shared.features.chat.domain.httpStatusOrNull
 import com.yral.shared.features.chat.domain.models.AssistantError
 import com.yral.shared.features.chat.domain.models.AssistantErrorCode
 import com.yral.shared.features.chat.domain.models.AssistantErrorPresentation
 import com.yral.shared.features.chat.domain.models.ChatError
 import com.yral.shared.features.chat.domain.models.ChatMessage
 import com.yral.shared.features.chat.domain.models.ChatMessageType
+import com.yral.shared.features.chat.domain.models.Collage
 import com.yral.shared.features.chat.domain.models.ConversationInfluencer
 import com.yral.shared.features.chat.domain.models.ConversationMessageRole
 import com.yral.shared.features.chat.domain.models.GrantError
@@ -43,10 +46,12 @@ import com.yral.shared.features.chat.domain.usecases.CheckChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.CreateConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.DeleteConversationUseCase
 import com.yral.shared.features.chat.domain.usecases.GetHumanCreatorTakeoverStatusUseCase
+import com.yral.shared.features.chat.domain.usecases.GetInfluencerCollageUseCase
 import com.yral.shared.features.chat.domain.usecases.GrantChatAccessParams
 import com.yral.shared.features.chat.domain.usecases.GrantChatAccessUseCase
 import com.yral.shared.features.chat.domain.usecases.MarkConversationAsReadUseCase
 import com.yral.shared.features.chat.domain.usecases.ReleaseHumanCreatorTakeoverUseCase
+import com.yral.shared.features.chat.domain.usecases.RequestInfluencerImagesUseCase
 import com.yral.shared.features.chat.domain.usecases.SendHumanCreatorMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.SendHumanMessageUseCase
 import com.yral.shared.features.chat.domain.usecases.SendMessageUseCase
@@ -68,6 +73,7 @@ import com.yral.shared.libs.sharing.LinkInput
 import com.yral.shared.libs.sharing.ShareService
 import com.yral.shared.rust.service.utils.getUserInfoServiceCanister
 import com.yral.shared.rust.service.utils.propicFromPrincipal
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -90,14 +96,18 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.getString
 import yral_mobile.shared.features.chat.generated.resources.Res
 import yral_mobile.shared.features.chat.generated.resources.assistant_error_connection_timed_out
+import yral_mobile.shared.features.chat.generated.resources.collage_quota_used_toast
+import yral_mobile.shared.features.chat.generated.resources.collage_request_failed_toast
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_purchase_failed
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_purchase_pending
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_purchase_unavailable
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_unlocked_toast
 import yral_mobile.shared.features.chat.generated.resources.influencer_subscription_verification_pending
+import yral_mobile.shared.features.chat.generated.resources.request_image_message
 import yral_mobile.shared.libs.designsystem.generated.resources.msg_profile_share
 import yral_mobile.shared.libs.designsystem.generated.resources.msg_profile_share_desc
 import yral_mobile.shared.libs.designsystem.generated.resources.profile_share_default_name
@@ -135,6 +145,9 @@ class ConversationViewModel(
     private val sendHumanCreatorMessageUseCase: SendHumanCreatorMessageUseCase,
     private val getHumanCreatorTakeoverStatusUseCase: GetHumanCreatorTakeoverStatusUseCase,
     private val conversationContentCache: ConversationContentCache,
+    private val requestInfluencerImagesUseCase: RequestInfluencerImagesUseCase,
+    private val getInfluencerCollageUseCase: GetInfluencerCollageUseCase,
+    private val collageCache: CollageCache,
 ) : ViewModel() {
     /**
      * Message ordering:
@@ -809,6 +822,9 @@ class ConversationViewModel(
             // Phase 6: errors are scoped to the conversation that produced them.
             // Crossing the conversation boundary clears any in-flight error bubble.
             _assistantError.value = null
+            // Collage state (including the request-today cooldown) is per-bot;
+            // a stale cooldown must not disable Request Image for another bot.
+            resetCollageState()
         }
 
         // Merge incoming influencer with any existing data to preserve category from the wall
@@ -1373,6 +1389,8 @@ class ConversationViewModel(
                 status = LocalMessageStatus.SENDING,
                 isPlaceholder = false,
                 draftForRetry = draft,
+                collageBotId = draft.collageBotId,
+                collageDate = draft.collageDate,
             )
 
         _viewState.value.influencer?.let { influencer ->
@@ -1957,6 +1975,313 @@ class ConversationViewModel(
             }
     }
 
+    // ── Collage (Request Images) ─────────────────────────────────────────
+    // Chat messages carry only a (botId, date) reference; bubbles resolve it
+    // here at render time so the URLs always match the CURRENT subscription
+    // state (blurred for non-subscribers, clear after purchase — including
+    // for historical messages, which refetch on the flip).
+
+    private val _collageStates = MutableStateFlow<Map<String, CollageUiState>>(emptyMap())
+    val collageStates: StateFlow<Map<String, CollageUiState>> = _collageStates.asStateFlow()
+
+    private val _requestImageCooldownSeconds = MutableStateFlow<Int?>(null)
+    val requestImageCooldownSeconds: StateFlow<Int?> = _requestImageCooldownSeconds.asStateFlow()
+
+    private val collageFetchJobs = mutableMapOf<String, Job>()
+    private var collageCooldownJob: Job? = null
+    private var collageHasChatAccess = false
+    private var isCollageRequestInFlight = false
+
+    private fun collageKey(
+        botId: String,
+        date: String,
+    ) = "$botId|$date"
+
+    /**
+     * Pushed from the screen — the effective subscription gate (Pro OR
+     * per-influencer access) is composed there, outside this VM. A flip
+     * refetches every collage currently tracked with the new is_subscribed
+     * so blurred and clear bubbles never coexist in one conversation.
+     */
+    fun setHasChatAccess(hasAccess: Boolean) {
+        if (collageHasChatAccess == hasAccess) return
+        collageHasChatAccess = hasAccess
+        if (_collageStates.value.isEmpty()) return
+        collageFetchJobs.values.forEach { it.cancel() }
+        collageFetchJobs.clear()
+        val keys = _collageStates.value.keys.toList()
+        _collageStates.update { state -> state.mapValues { CollageUiState.Loading } }
+        keys.forEach { key ->
+            launchCollageFetch(
+                botId = key.substringBeforeLast('|'),
+                date = key.substringAfterLast('|'),
+            )
+        }
+    }
+
+    /** Render-time resolve of a collage reference; called from the bubble's LaunchedEffect. */
+    @OptIn(ExperimentalTime::class)
+    @Suppress("ReturnCount") // precondition gates: blank ref, already resolved, in flight
+    fun loadCollage(
+        botId: String,
+        date: String,
+    ) {
+        if (botId.isBlank() || date.isBlank()) return
+        // Cooldown sighting: a collage dated today in this conversation means
+        // today's request is already spent — the conversation history is the
+        // server-persisted record, so this survives reinstalls and devices.
+        if (date == currentCollageDateString()) {
+            startCollageCooldown()
+        }
+        val key = collageKey(botId, date)
+        if (_collageStates.value[key] is CollageUiState.Ready) return
+        if (collageFetchJobs[key]?.isActive == true) return
+        val cached = collageCache.read(botId = botId, date = date, isSubscribed = collageHasChatAccess)
+        if (cached != null) {
+            _collageStates.update { it + (key to CollageUiState.Ready(cached)) }
+            return
+        }
+        _collageStates.update { it + (key to CollageUiState.Loading) }
+        launchCollageFetch(botId = botId, date = date)
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private fun launchCollageFetch(
+        botId: String,
+        date: String,
+    ) {
+        val key = collageKey(botId, date)
+        collageFetchJobs[key] =
+            viewModelScope.launch {
+                val isSubscribed = collageHasChatAccess
+                var attempt = 0
+                var terminal = false
+                while (!terminal) {
+                    var retryAfterMs: Long? = null
+                    getInfluencerCollageUseCase(
+                        GetInfluencerCollageUseCase.Params(influencerId = botId, isSubscribed = isSubscribed),
+                    ).onSuccess { collage ->
+                        terminal = true
+                        applyFetchedCollage(key, date, isSubscribed, collage)
+                    }.onFailure { error ->
+                        // 404 on today's reference = collage still generating
+                        // (cold-path race, e.g. another device just POSTed) —
+                        // retry briefly. Anything else degrades to Unavailable;
+                        // a scroll-back re-entry retriggers loadCollage.
+                        val stillGenerating =
+                            error.httpStatusOrNull() == HttpStatusCode.NotFound &&
+                                date == currentCollageDateString()
+                        if (stillGenerating && attempt < COLLAGE_NOT_READY_RETRY_DELAYS_MS.size) {
+                            retryAfterMs = COLLAGE_NOT_READY_RETRY_DELAYS_MS[attempt]
+                        } else {
+                            terminal = true
+                            _collageStates.update { it + (key to CollageUiState.Unavailable) }
+                        }
+                    }
+                    retryAfterMs?.let {
+                        attempt++
+                        delay(it)
+                    }
+                }
+            }
+    }
+
+    private fun applyFetchedCollage(
+        key: String,
+        expectedDate: String,
+        isSubscribed: Boolean,
+        collage: Collage,
+    ) {
+        // GET /collage serves only today's row; a date mismatch means this
+        // reference points at an older collage that can no longer be fetched.
+        if (collage.date != expectedDate) {
+            _collageStates.update { it + (key to CollageUiState.Unavailable) }
+            return
+        }
+        collageCache.write(collage = collage, isSubscribed = isSubscribed)
+        _collageStates.update { it + (key to CollageUiState.Ready(collage)) }
+    }
+
+    /**
+     * "Request Image" tap: POST request-images (consumes today's quota; the
+     * rare cold path takes 45–65 s — shimmer placeholder meanwhile), then
+     * send the (botId, date) reference into the conversation as a collage
+     * message. The message never carries image URLs.
+     */
+    @OptIn(ExperimentalTime::class)
+    @Suppress("ReturnCount") // precondition gates: no conversation, no influencer, H2H, cooldown
+    fun requestCollageImages() {
+        val convId = conversationId ?: return
+        val influencer = _viewState.value.influencer ?: return
+        if (_viewState.value.isHumanChat) return
+        if (isCollageRequestInFlight || _requestImageCooldownSeconds.value != null) return
+        isCollageRequestInFlight = true
+        val now = Clock.System.now().toEpochMilliseconds()
+        val shimmer =
+            LocalMessage(
+                localId = "local-collage-shimmer-$now",
+                role = ConversationMessageRole.ASSISTANT,
+                content = null,
+                messageType = ChatMessageType.COLLAGE,
+                createdAtMs = now,
+                status = LocalMessageStatus.WAITING,
+                isPlaceholder = true,
+                draftForRetry = null,
+            )
+        _overlay.update { it.copy(pending = it.pending + shimmer) }
+        viewModelScope.launch {
+            try {
+                requestInfluencerImagesUseCase(
+                    RequestInfluencerImagesUseCase.Params(
+                        influencerId = influencer.id,
+                        isSubscribed = collageHasChatAccess,
+                    ),
+                ).onSuccess { collage ->
+                    onCollageRequestSucceeded(convId, shimmer.localId, collage)
+                }.onFailure { error ->
+                    onCollageRequestFailed(shimmer.localId, error)
+                }
+            } finally {
+                isCollageRequestInFlight = false
+            }
+        }
+    }
+
+    @OptIn(ExperimentalTime::class)
+    private suspend fun onCollageRequestSucceeded(
+        convId: String,
+        shimmerLocalId: String,
+        collage: Collage,
+    ) {
+        collageCache.write(collage = collage, isSubscribed = collageHasChatAccess)
+        // Pre-warm so the bubble renders instantly once the message lands.
+        _collageStates.update {
+            it + (collageKey(collage.botId, collage.date) to CollageUiState.Ready(collage))
+        }
+        startCollageCooldown()
+        val draft =
+            SendMessageDraft(
+                messageType = ChatMessageType.COLLAGE,
+                // Fallback body: old clients degrade unknown types to TEXT
+                // and render this string instead of the grid.
+                content = getString(Res.string.request_image_message),
+                collageBotId = collage.botId,
+                collageDate = collage.date,
+            )
+        val now = Clock.System.now().toEpochMilliseconds()
+        val userLocal =
+            LocalMessage(
+                localId = "local-user-$now",
+                role = ConversationMessageRole.USER,
+                content = draft.content,
+                messageType = ChatMessageType.COLLAGE,
+                createdAtMs = now,
+                status = LocalMessageStatus.SENDING,
+                isPlaceholder = false,
+                draftForRetry = draft,
+                collageBotId = collage.botId,
+                collageDate = collage.date,
+            )
+        _overlay.update { state ->
+            state.copy(pending = state.pending.filterNot { it.localId == shimmerLocalId } + userLocal)
+        }
+        // Direct send — the generic sendMessage() pipeline would add an
+        // assistant waiting placeholder + AI-reply telemetry, both wrong for
+        // a collage share. Send failure marks the Local FAILED with
+        // draftForRetry, so the existing tap-to-resend re-sends the reference
+        // only (the collage itself is already generated; no second POST).
+        sendMessageUseCase(
+            SendMessageUseCase.Params(conversationId = convId, draft = draft),
+        ).onSuccess { result ->
+            handleCollageSendSuccess(result, userLocal.localId)
+        }.onFailure { error ->
+            handleSendFailure(error, userLocal.localId, assistantLocalId = "")
+        }
+    }
+
+    private fun handleCollageSendSuccess(
+        result: SendMessageResult,
+        userLocalId: String,
+    ) {
+        val sentMessages = buildSentMessages(result.userMessage, result.assistantMessage)
+        _overlay.update { state ->
+            state.copy(
+                pending = state.pending.filterNot { it.localId == userLocalId },
+                sent = state.sent + sentMessages,
+            )
+        }
+    }
+
+    private suspend fun onCollageRequestFailed(
+        shimmerLocalId: String,
+        error: Throwable,
+    ) {
+        _overlay.update { state ->
+            state.copy(pending = state.pending.filterNot { it.localId == shimmerLocalId })
+        }
+        if (error.httpStatusOrNull() == HttpStatusCode.TooManyRequests) {
+            // Server says today's quota is already spent (e.g. requested from
+            // another device) — server stays authoritative over the local menu.
+            startCollageCooldown()
+            influencerSubscriptionToastChannel.trySend(
+                InfluencerSubscriptionToastEvent(
+                    ToastStatus.Info,
+                    getString(Res.string.collage_quota_used_toast),
+                ),
+            )
+        } else {
+            influencerSubscriptionToastChannel.trySend(
+                InfluencerSubscriptionToastEvent(
+                    ToastStatus.Error,
+                    getString(Res.string.collage_request_failed_toast),
+                ),
+            )
+        }
+    }
+
+    /** Idempotent: starts the disabled-until-next-04:00-UTC countdown once. */
+    @OptIn(ExperimentalTime::class)
+    private fun startCollageCooldown() {
+        if (collageCooldownJob?.isActive == true) return
+        collageCooldownJob =
+            viewModelScope.launch {
+                while (isActive) {
+                    val nowMs = Clock.System.now().toEpochMilliseconds()
+                    val remainingSeconds = ((nextCollageResetMs(nowMs) - nowMs) / MS_PER_SECOND).toInt()
+                    if (remainingSeconds <= 0) break
+                    _requestImageCooldownSeconds.value = remainingSeconds
+                    delay(1.seconds)
+                }
+                _requestImageCooldownSeconds.value = null
+            }
+    }
+
+    private fun resetCollageState() {
+        collageFetchJobs.values.forEach { it.cancel() }
+        collageFetchJobs.clear()
+        _collageStates.value = emptyMap()
+        collageCooldownJob?.cancel()
+        collageCooldownJob = null
+        _requestImageCooldownSeconds.value = null
+        isCollageRequestInFlight = false
+    }
+
+    // Collage-day arithmetic. The day rolls at the 04:00 UTC nightly pre-gen,
+    // matching the quota window the countdown targets.
+    private fun currentCollageDayIndex(nowMs: Long): Long = (nowMs - COLLAGE_DAY_ROLLOVER_UTC_MS).floorDiv(MS_PER_DAY)
+
+    private fun nextCollageResetMs(nowMs: Long): Long {
+        val nextDayIndex = currentCollageDayIndex(nowMs) + 1
+        return nextDayIndex * MS_PER_DAY + COLLAGE_DAY_ROLLOVER_UTC_MS
+    }
+
+    /** Today's collage_date ("YYYY-MM-DD"), for comparing against message references. */
+    @OptIn(ExperimentalTime::class)
+    private fun currentCollageDateString(): String =
+        LocalDate
+            .fromEpochDays(currentCollageDayIndex(Clock.System.now().toEpochMilliseconds()).toInt())
+            .toString()
+
     private data class OverlayState(
         val pending: List<LocalMessage> = emptyList(),
         val sent: List<SentMessage> = emptyList(),
@@ -2281,6 +2606,16 @@ class ConversationViewModel(
         // Status poll runs every Nth iteration of message poll: 3s × 2 ≈ 6s ≈ ~5s spec.
         private const val TAKEOVER_STATUS_POLL_EVERY_N = 2
         private const val TAKEOVER_POLL_PAGE_SIZE = 20
+
+        // Collage: the 04:00 UTC nightly pre-gen is the collage-day rollover
+        // the request cooldown counts down to.
+        private const val COLLAGE_DAY_ROLLOVER_UTC_MS = 4L * 60 * 60 * 1000
+        private const val MS_PER_DAY = 24L * 60 * 60 * 1000
+        private const val MS_PER_SECOND = 1000L
+
+        // GET /collage 404s while today's collage is still generating
+        // (cold-path race with another device's POST) — brief backoff.
+        private val COLLAGE_NOT_READY_RETRY_DELAYS_MS = listOf(5_000L, 15_000L)
     }
 }
 
@@ -2288,6 +2623,18 @@ data class InfluencerSubscriptionToastEvent(
     val status: ToastStatus,
     val message: String,
 )
+
+/** Render state of one collage reference, keyed by "botId|date" in [ConversationViewModel.collageStates]. */
+sealed class CollageUiState {
+    data object Loading : CollageUiState()
+
+    data class Ready(
+        val collage: Collage,
+    ) : CollageUiState()
+
+    /** Fetch failed terminally — older-than-today reference or exhausted retries. */
+    data object Unavailable : CollageUiState()
+}
 
 data class ConversationViewState(
     val isCreating: Boolean = false,
@@ -2376,4 +2723,8 @@ data class LocalMessage(
     // `done` so the Remote replacement renders with the same path — no Text↔Markdown
     // subtree swap.
     val useMarkdownLocked: Boolean? = null,
+    // COLLAGE reference — the optimistic echo renders through the same
+    // reference→GET path as Remote collage messages; URLs never live here.
+    val collageBotId: String? = null,
+    val collageDate: String? = null,
 )

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -2236,7 +2236,7 @@ class ConversationViewModel(
         sendMessageUseCase(
             SendMessageUseCase.Params(conversationId = convId, draft = draft),
         ).onSuccess { result ->
-            handleCollageSendSuccess(result, userLocal.localId)
+            handleCollageSendSuccess(result, userLocal.localId, collage)
         }.onFailure { error ->
             Logger.e("CollageX", error) {
                 "collage message send failed status=${error.httpStatusOrNull()} msg=${error.message}"
@@ -2245,11 +2245,51 @@ class ConversationViewModel(
         }
     }
 
+    @OptIn(ExperimentalTime::class)
     private fun handleCollageSendSuccess(
         result: SendMessageResult,
         userLocalId: String,
+        collage: Collage,
     ) {
-        val sentMessages = buildSentMessages(result.userMessage, result.assistantMessage)
+        Logger.d("CollageX") {
+            val echo = result.userMessage
+            "send echo id=${echo.id} type=${echo.messageType} collageId=${echo.collageId} " +
+                "botId=${echo.collageBotId} date=${echo.collageDate} " +
+                "hasContent=${!echo.content.isNullOrBlank()} createdAt=${echo.createdAt}"
+        }
+        // Self-heal the echo: the optimistic Local we're about to remove
+        // rendered the grid from its collage refs. If the send endpoint
+        // doesn't echo those refs (or the type) back, the swapped-in Remote
+        // would render as an empty text bubble — re-attach what we just sent.
+        // History rendering after a relaunch still needs the backend to
+        // persist the refs; the log above is the evidence either way.
+        val userMessage =
+            result.userMessage.let { echo ->
+                if (echo.collageBotId == null || echo.collageDate == null) {
+                    echo.copy(
+                        messageType = ChatMessageType.COLLAGE,
+                        collageId = collage.id,
+                        collageBotId = collage.botId,
+                        collageDate = collage.date,
+                    )
+                } else {
+                    echo
+                }
+            }
+        // buildSentMessages drops entries whose created_at fails to parse —
+        // for the collage echo, fall back to "now" instead of vanishing.
+        val userInsertedAtMs =
+            parseTimestampToEpochMs(userMessage.createdAt)
+                ?: Clock.System.now().toEpochMilliseconds()
+        val sentMessages =
+            buildList {
+                add(SentMessage(insertedAtMs = userInsertedAtMs, message = userMessage))
+                result.assistantMessage?.let { assistant ->
+                    parseTimestampToEpochMs(assistant.createdAt)?.let {
+                        add(SentMessage(insertedAtMs = it, message = assistant))
+                    }
+                }
+            }
         _overlay.update { state ->
             state.copy(
                 pending = state.pending.filterNot { it.localId == userLocalId },

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -2233,6 +2233,10 @@ class ConversationViewModel(
         // a collage share. Send failure marks the Local FAILED with
         // draftForRetry, so the existing tap-to-resend re-sends the reference
         // only (the collage itself is already generated; no second POST).
+        Logger.d("CollageX") {
+            "sending collage message convId=$convId collageId=${collage.id} " +
+                "botId=${collage.botId} date=${collage.date}"
+        }
         sendMessageUseCase(
             SendMessageUseCase.Params(conversationId = convId, draft = draft),
         ).onSuccess { result ->

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -2270,7 +2270,7 @@ class ConversationViewModel(
         }
     }
 
-    /** Idempotent: starts the disabled-until-next-04:00-UTC countdown once. */
+    /** Idempotent: starts the disabled-until-next-UTC-midnight countdown once. */
     @OptIn(ExperimentalTime::class)
     private fun startCollageCooldown() {
         if (collageCooldownJob?.isActive == true) return
@@ -2298,14 +2298,13 @@ class ConversationViewModel(
         isCollageRequestInFlight = false
     }
 
-    // Collage-day arithmetic. The day rolls at the 04:00 UTC nightly pre-gen,
-    // matching the quota window the countdown targets.
-    private fun currentCollageDayIndex(nowMs: Long): Long = (nowMs - COLLAGE_DAY_ROLLOVER_UTC_MS).floorDiv(MS_PER_DAY)
+    // Collage-day arithmetic. The server quota window is the UTC calendar
+    // day — its 429 says resets_at=T00:00:00+00:00 — and GET /collage
+    // defaults to "today's UTC calendar date". (The 04:00 UTC nightly
+    // pre-gen is only when generation runs, not the quota boundary.)
+    private fun currentCollageDayIndex(nowMs: Long): Long = nowMs.floorDiv(MS_PER_DAY)
 
-    private fun nextCollageResetMs(nowMs: Long): Long {
-        val nextDayIndex = currentCollageDayIndex(nowMs) + 1
-        return nextDayIndex * MS_PER_DAY + COLLAGE_DAY_ROLLOVER_UTC_MS
-    }
+    private fun nextCollageResetMs(nowMs: Long): Long = (currentCollageDayIndex(nowMs) + 1) * MS_PER_DAY
 
     /** Today's collage_date ("YYYY-MM-DD"), for comparing against message references. */
     @OptIn(ExperimentalTime::class)
@@ -2639,9 +2638,6 @@ class ConversationViewModel(
         private const val TAKEOVER_STATUS_POLL_EVERY_N = 2
         private const val TAKEOVER_POLL_PAGE_SIZE = 20
 
-        // Collage: the 04:00 UTC nightly pre-gen is the collage-day rollover
-        // the request cooldown counts down to.
-        private const val COLLAGE_DAY_ROLLOVER_UTC_MS = 4L * 60 * 60 * 1000
         private const val MS_PER_DAY = 24L * 60 * 60 * 1000
         private const val MS_PER_SECOND = 1000L
 

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/viewmodel/ConversationViewModel.kt
@@ -24,6 +24,7 @@ import com.yral.shared.features.chat.attachments.ChatAttachment
 import com.yral.shared.features.chat.attachments.FilePathChatAttachment
 import com.yral.shared.features.chat.data.CollageCache
 import com.yral.shared.features.chat.data.ConversationContentCache
+import com.yral.shared.features.chat.domain.BotSubscriptionCatalog
 import com.yral.shared.features.chat.domain.ChatErrorMapper
 import com.yral.shared.features.chat.domain.ChatRepository
 import com.yral.shared.features.chat.domain.ConversationMessagesPagingSource
@@ -61,6 +62,7 @@ import com.yral.shared.features.subscriptions.domain.FetchProductsUseCase
 import com.yral.shared.iap.IAPManager
 import com.yral.shared.iap.core.IAPError
 import com.yral.shared.iap.core.model.ProductId
+import com.yral.shared.iap.core.model.ProductType
 import com.yral.shared.iap.core.model.Purchase
 import com.yral.shared.iap.core.model.PurchaseState
 import com.yral.shared.iap.utils.PurchaseContext
@@ -482,7 +484,7 @@ class ConversationViewModel(
                             )
                         }
                     } else {
-                        retryUnconsumedDailyChatAccess(influencerId)
+                        retryUngrantedChatAccess(influencerId)
                     }
                 }.onFailure { error ->
                     Logger.e("SubscriptionX", error) { "checkChatAccess failed" }
@@ -492,26 +494,27 @@ class ConversationViewModel(
         }
     }
 
-    private suspend fun retryUnconsumedDailyChatAccess(botId: String) {
+    private suspend fun retryUngrantedChatAccess(botId: String) {
+        val product = BotSubscriptionCatalog.chatProductFor(botId)
         runSuspendCatching {
             iapManager.restorePurchases()
         }.onSuccess { restoreResult ->
             val purchases = restoreResult.getOrNull()?.purchases.orEmpty()
-            val unconsumedDailyChat =
+            val ungrantedPurchase =
                 purchases.firstOrNull { purchase ->
-                    purchase.productId == ProductId.DAILY_CHAT &&
+                    purchase.productId == product &&
                         purchase.state == PurchaseState.PURCHASED
                 }
 
-            if (unconsumedDailyChat?.purchaseToken != null) {
-                Logger.d("SubscriptionX") { "Found unconsumed daily_chat, retrying grant..." }
-                retryGrantAccess(botId, unconsumedDailyChat, ProductId.DAILY_CHAT.productId)
+            if (ungrantedPurchase?.purchaseToken != null) {
+                Logger.d("SubscriptionX") { "Found ungranted ${product.productId}, retrying grant..." }
+                retryGrantAccess(botId, ungrantedPurchase, product.productId)
             } else {
                 _viewState.update { it.copy(isChatAccessLoading = false) }
                 fetchInfluencerSubscriptionProducts()
             }
         }.onFailure {
-            Logger.e("SubscriptionX", it) { "Daily Chat restore failed" }
+            Logger.e("SubscriptionX", it) { "Chat access restore failed" }
             _viewState.update { it.copy(isChatAccessLoading = false) }
             fetchInfluencerSubscriptionProducts()
         }
@@ -541,7 +544,7 @@ class ConversationViewModel(
         }.onFailure { error ->
             Logger.e("SubscriptionX", error) { "Grant retry failed for $productId" }
             chatTelemetry.subscriptionFailed(botId, "grant_retry_${error.message}")
-            handleGrantFailure(error, purchaseToken, purchase.purchaseTime)
+            handleGrantFailure(error, purchaseToken, purchase.purchaseTime, productId)
         }
     }
 
@@ -549,12 +552,21 @@ class ConversationViewModel(
         error: Throwable,
         purchaseToken: String,
         purchaseTime: Long?,
+        productId: String,
     ) {
         when (error) {
             is GrantError.ClientError -> {
                 // 400: Token rejected (wrong bot, expired, cancelled). Consume to stop retry loop.
-                Logger.w("SubscriptionX") { "Grant rejected (400): ${error.errorMsg}. Consuming purchase." }
-                consumePurchaseInBackground(purchaseToken)
+                // Consuming is a consumable-only Play API — a rejected bot
+                // subscription token must be left alone (the store owns its
+                // lifecycle; retry/self-heal happens via the verify endpoint).
+                val isConsumable = ProductId.fromString(productId)?.productType == ProductType.ONE_TIME
+                Logger.w("SubscriptionX") {
+                    "Grant rejected (400): ${error.errorMsg}. ${if (isConsumable) "Consuming purchase." else ""}"
+                }
+                if (isConsumable) {
+                    consumePurchaseInBackground(purchaseToken)
+                }
                 _viewState.update {
                     it.copy(
                         isInfluencerSubscriptionPurchasedAndVerified = false,
@@ -585,18 +597,21 @@ class ConversationViewModel(
     }
 
     private fun fetchInfluencerSubscriptionProducts() {
+        // Tara sells an auto-renewing bot_sub subscription; every other bot
+        // sells the one-time daily_chat consumable.
+        val product = BotSubscriptionCatalog.chatProductFor(_viewState.value.influencer?.id)
         viewModelScope.launch {
             crashlyticsManager.logMessage(
-                "YRALIAP chat fetchProducts start ids=[${ProductId.DAILY_CHAT.productId}] " +
+                "YRALIAP chat fetchProducts start ids=[${product.productId}] " +
                     "subEnabled=${_viewState.value.isSubscriptionEnabled} " +
                     "hasAccess=${_viewState.value.isInfluencerSubscriptionPurchasedAndVerified}",
             )
-            fetchProductsUseCase(listOf(ProductId.DAILY_CHAT))
+            fetchProductsUseCase(listOf(product))
                 .onSuccess { products ->
-                    val influencerAvailable = ProductId.DAILY_CHAT.productId in products.map { it.id }.toSet()
+                    val influencerAvailable = product.productId in products.map { it.id }.toSet()
                     val influencerOfferPrice =
                         products
-                            .find { it.id == ProductId.DAILY_CHAT.productId }
+                            .find { it.id == product.productId }
                             ?.let { p -> p.offerPrice.ifBlank { p.price } }
                     _viewState.update {
                         it.copy(
@@ -606,7 +621,7 @@ class ConversationViewModel(
                     }
                     crashlyticsManager.logMessage(
                         "YRALIAP chat fetchProducts success valid=${products.map { it.id }} " +
-                            "dailyChatAvailable=$influencerAvailable price=$influencerOfferPrice",
+                            "${product.productId}Available=$influencerAvailable price=$influencerOfferPrice",
                     )
                 }.onFailure {
                     crashlyticsManager.logMessage(
@@ -664,18 +679,20 @@ class ConversationViewModel(
         purchaseContext: PurchaseContext,
         botId: String?,
     ) {
-        // Check for unconsumed DAILY_CHAT from a previous failed grant
-        val existingPurchase = findUnconsumedDailyChat()
+        val product = BotSubscriptionCatalog.chatProductFor(botId)
+        // Check for a purchase the billing service doesn't know about yet
+        // (failed grant / interrupted verify) before buying again.
+        val existingPurchase = findUngrantedChatPurchase(product)
         if (existingPurchase != null && botId != null) {
-            Logger.d("SubscriptionX") { "Found unconsumed DAILY_CHAT, retrying grant instead of new purchase" }
-            retryGrantAccess(botId, existingPurchase, ProductId.DAILY_CHAT.productId)
+            Logger.d("SubscriptionX") { "Found ungranted ${product.productId}, retrying grant instead of new purchase" }
+            retryGrantAccess(botId, existingPurchase, product.productId)
             _viewState.update { it.copy(isInfluencerSubscriptionPurchaseInProgress = false) }
             return
         }
 
         runSuspendCatching {
             iapManager.purchaseProduct(
-                productId = ProductId.DAILY_CHAT,
+                productId = product,
                 context = purchaseContext,
                 acknowledgePurchase = false,
                 verifyPurchase = false,
@@ -698,7 +715,7 @@ class ConversationViewModel(
                     GrantChatAccessParams(
                         botId = botId,
                         purchaseToken = purchaseToken,
-                        productId = ProductId.DAILY_CHAT.productId,
+                        productId = product.productId,
                     ),
                 ).onSuccess { grantStatus ->
                     Logger.d("SubscriptionX") {
@@ -711,7 +728,7 @@ class ConversationViewModel(
                 }.onFailure { grantError ->
                     Logger.e("SubscriptionX", grantError) { "Grant failed after purchase" }
                     botId.let { chatTelemetry.subscriptionFailed(it, "grant_${grantError.message}") }
-                    handleGrantFailure(grantError, purchaseToken, purchaseTime)
+                    handleGrantFailure(grantError, purchaseToken, purchaseTime, product.productId)
                 }
             } else {
                 Logger.w("SubscriptionX") { "No botId, using fallback 24h access" }
@@ -977,7 +994,7 @@ class ConversationViewModel(
         // appearing on H2H chats opened after browsing any other chat first.
         _viewState.update { it.copy(participantPrincipalId = participantPrincipalId) }
         // N1 gate: single call-site for the entire IAP cascade
-        // (checkChatAccessUseCase → retryUnconsumedDailyChatAccess →
+        // (checkChatAccessUseCase → retryUngrantedChatAccess →
         // fetchInfluencerSubscriptionProducts). All four fallback entry
         // points reach back through updateInfluencerSubscriptionProductState
         // so this one skip covers them all.
@@ -2131,6 +2148,8 @@ class ConversationViewModel(
         val convId = conversationId ?: return
         val influencer = _viewState.value.influencer ?: return
         if (_viewState.value.isHumanChat) return
+        // Photo collages are exclusive to subscription bots (Tara).
+        if (!BotSubscriptionCatalog.usesBotSubscription(influencer.id)) return
         if (isCollageRequestInFlight || _requestImageCooldownSeconds.value != null) return
         isCollageRequestInFlight = true
         Logger.d("CollageX") { "requestImages start bot=${influencer.id} isSubscribed=$collageHasChatAccess" }
@@ -2586,15 +2605,21 @@ class ConversationViewModel(
         }
     }
 
+    /**
+     * A restored purchase of [product] the billing service may not know
+     * about yet: an unconsumed daily_chat from a failed grant, or an active
+     * bot subscription missing its verify call. Retrying the grant instead
+     * of re-purchasing is safe — both backend flows are idempotent.
+     */
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun findUnconsumedDailyChat(): Purchase? =
+    private suspend fun findUngrantedChatPurchase(product: ProductId): Purchase? =
         try {
             iapManager
                 .restorePurchases()
                 .getOrNull()
                 ?.purchases
                 ?.firstOrNull { purchase ->
-                    purchase.productId == ProductId.DAILY_CHAT && purchase.state == PurchaseState.PURCHASED
+                    purchase.productId == product && purchase.state == PurchaseState.PURCHASED
                 }
         } catch (_: Exception) {
             null

--- a/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/data/ChatAccessBillingDataSource.ios.kt
+++ b/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/data/ChatAccessBillingDataSource.ios.kt
@@ -1,3 +1,5 @@
 package com.yral.shared.features.chat.data
 
 internal actual fun getGrantChatAccessEndpoint(): String = "apple/chat-access/grant"
+
+internal actual fun getBotSubscriptionGrantEndpoint(): String = "apple/bot-subscription/grant"

--- a/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralContextMenu.kt
+++ b/shared/libs/designsystem/src/commonMain/kotlin/com/yral/shared/libs/designsystem/component/YralContextMenu.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
@@ -26,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import com.yral.shared.libs.designsystem.component.YralContextMenuConstants.DEFAULT_MENU_ICON_SIZE
 import com.yral.shared.libs.designsystem.component.YralContextMenuConstants.DEFAULT_MENU_ITEM_MAX_HEIGHT
 import com.yral.shared.libs.designsystem.component.YralContextMenuConstants.DEFAULT_TRIGGER_SIZE
+import com.yral.shared.libs.designsystem.component.YralContextMenuConstants.DISABLED_ICON_ALPHA
 import com.yral.shared.libs.designsystem.theme.LocalAppTopography
 import com.yral.shared.libs.designsystem.theme.YralColors
 import org.jetbrains.compose.resources.DrawableResource
@@ -82,7 +84,12 @@ fun YralContextMenu(
                         Text(
                             text = item.text,
                             style = LocalAppTopography.current.baseRegular,
-                            color = YralColors.NeutralTextPrimary,
+                            color =
+                                if (item.enabled) {
+                                    YralColors.NeutralTextPrimary
+                                } else {
+                                    YralColors.NeutralTextSecondary
+                                },
                         )
                     },
                     leadingIcon =
@@ -91,11 +98,25 @@ fun YralContextMenu(
                                 Image(
                                     painter = painterResource(icon),
                                     contentDescription = null,
-                                    modifier = Modifier.size(menuIconSize),
+                                    modifier =
+                                        Modifier
+                                            .size(menuIconSize)
+                                            .alpha(if (item.enabled) 1f else DISABLED_ICON_ALPHA),
                                     contentScale = ContentScale.FillBounds,
                                 )
                             }
                         },
+                    trailingIcon =
+                        item.trailingText?.let { trailingText ->
+                            {
+                                Text(
+                                    text = trailingText,
+                                    style = LocalAppTopography.current.baseRegular,
+                                    color = YralColors.NeutralTextSecondary,
+                                )
+                            }
+                        },
+                    enabled = item.enabled,
                     onClick = {
                         showMenu = false
                         item.onClick()
@@ -115,10 +136,14 @@ data class YralContextMenuItem(
     val text: String,
     val icon: DrawableResource? = null,
     val onClick: () -> Unit,
+    val enabled: Boolean = true,
+    // Rendered after the label (e.g. a cooldown countdown for disabled items).
+    val trailingText: String? = null,
 )
 
 private object YralContextMenuConstants {
     const val DEFAULT_TRIGGER_SIZE = 20f
     const val DEFAULT_MENU_ICON_SIZE = 20f
     const val DEFAULT_MENU_ITEM_MAX_HEIGHT = 40f
+    const val DISABLED_ICON_ALPHA = 0.4f
 }

--- a/shared/libs/iap/core/src/commonMain/kotlin/com/yral/shared/iap/core/model/ProductId.kt
+++ b/shared/libs/iap/core/src/commonMain/kotlin/com/yral/shared/iap/core/model/ProductId.kt
@@ -12,12 +12,18 @@ enum class ProductId(
 
     @SerialName("daily_chat")
     DAILY_CHAT("daily_chat"),
+
+    // Per-bot auto-renewing chat subscription (Tara). The billing backend
+    // routes any "bot_sub"-prefixed product to its subscription flow; the
+    // intro offer (3 days ₹9 → ₹69/week) is configured in the stores.
+    @SerialName("bot_sub_tara")
+    BOT_SUB_TARA("bot_sub_tara"),
     ;
 
     val productType: ProductType
         get() =
             when (this) {
-                YRAL_PRO -> ProductType.SUBS
+                YRAL_PRO, BOT_SUB_TARA -> ProductType.SUBS
                 DAILY_CHAT -> ProductType.ONE_TIME
             }
 


### PR DESCRIPTION
Received messages can now carry an optional is_blur flag. When true, image attachments render blurred behind a dark scrim with a centered yellow Unlock pill (styled like the header SubscribeButton). Tapping the image or pill routes to a stubbed unlock callback; the payment integration lands separately.

Fixes https://github.com/dolr-ai/yral/issues/2202