### PR TITLE
feat(ios): enable chat billing (daily_chat + bot_sub_tara) on iOS

### DIFF
--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatAccessBillingModels.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/data/models/ChatAccessBillingModels.kt
@@ -16,6 +16,7 @@ data class GrantAppleChatAccessRequestDto(
     @SerialName("transaction_id") val transactionId: String,
     @SerialName("product_id") val productId: String,
     @SerialName("bot_id") val botId: String,
+    @SerialName("environment") val environment: String,
 )
 
 internal expect fun GrantChatAccessRequestDto.toPlatformGrantRequestBody(): Any

--- a/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/data/models/ChatAccessBillingModels.ios.kt
+++ b/shared/features/chat/src/iosMain/kotlin/com/yral/shared/features/chat/data/models/ChatAccessBillingModels.ios.kt
@@ -1,8 +1,20 @@
 package com.yral.shared.features.chat.data.models
 
+import platform.Foundation.NSBundle
+
 internal actual fun GrantChatAccessRequestDto.toPlatformGrantRequestBody(): Any =
     GrantAppleChatAccessRequestDto(
         transactionId = purchaseToken,
         productId = productId,
         botId = botId,
+        environment = appleStoreEnvironment(),
     )
+
+// Debug and TestFlight builds carry a "sandboxReceipt"; App Store builds carry "receipt".
+// The billing server looks the transaction up in the matching App Store Server API environment.
+private fun appleStoreEnvironment(): String =
+    if (NSBundle.mainBundle.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt") {
+        "sandbox"
+    } else {
+        "production"
+    }

--- a/shared/features/root/src/commonMain/kotlin/com/yral/shared/features/root/viewmodels/RootViewModel.kt
+++ b/shared/features/root/src/commonMain/kotlin/com/yral/shared/features/root/viewmodels/RootViewModel.kt
@@ -31,6 +31,7 @@ import com.yral.shared.features.root.domain.DailyStreakLaunchResult
 import com.yral.shared.features.subscriptions.domain.QueryPurchaseUseCase
 import com.yral.shared.iap.PurchaseResult
 import com.yral.shared.iap.core.model.ProductId
+import com.yral.shared.iap.utils.isProSubscriptionSupported
 import com.yral.shared.libs.arch.presentation.UiState
 import com.yral.shared.libs.coroutines.x.dispatchers.AppDispatchers
 import com.yral.shared.preferences.PrefKeys
@@ -1086,6 +1087,7 @@ class RootViewModel(
     ) {
         coroutineScope.launch {
             if (!flagManager.isEnabled(AppFeatureFlags.Common.EnableSubscription)) return@launch
+            if (!isProSubscriptionSupported()) return@launch
             val userPrincipal = sessionManager.userPrincipal
             if (userPrincipal == null) {
                 withContext(appDispatchers.main) { onError?.invoke() }

--- a/shared/libs/iap/core/src/iosMain/kotlin/com/yral/shared/iap/core/providers/ProductFetcher.kt
+++ b/shared/libs/iap/core/src/iosMain/kotlin/com/yral/shared/iap/core/providers/ProductFetcher.kt
@@ -79,6 +79,8 @@ internal class ProductFetcher {
                                 val priceString = priceFormatter.stringFromNumber(skProduct.price) ?: ""
                                 val priceAmountMicros =
                                     (skProduct.price.doubleValue * PRICE_TO_MICROS_FACTOR).roundToLong()
+                                val (offerPriceString, offerPriceMicros) =
+                                    introOfferPricing(skProduct, priceString, priceAmountMicros)
 
                                 val subscriptionPeriod = skProduct.subscriptionPeriod
                                 val productType =
@@ -92,8 +94,8 @@ internal class ProductFetcher {
                                         id = skProduct.productIdentifier,
                                         price = priceString,
                                         priceAmountMicros = priceAmountMicros,
-                                        offerPrice = priceString,
-                                        offerPriceAmountMicros = priceAmountMicros,
+                                        offerPrice = offerPriceString,
+                                        offerPriceAmountMicros = offerPriceMicros,
                                         currencyCode =
                                             skProduct.priceLocale
                                                 .objectForKey(NSLocaleCurrencyCode)
@@ -140,6 +142,26 @@ internal class ProductFetcher {
                 request.cancel()
             }
         }
+
+    // A free trial's introductory price is 0 — keep the base price then; Apple's
+    // payment sheet communicates the trial terms. SK1 reports the intro offer
+    // regardless of the user's eligibility, so the sheet is the source of truth.
+    private fun introOfferPricing(
+        skProduct: SKProduct,
+        basePrice: String,
+        basePriceMicros: Long,
+    ): Pair<String, Long> {
+        val intro = skProduct.introductoryPrice
+        if (intro == null || intro.price.doubleValue <= 0.0) return basePrice to basePriceMicros
+        val introFormatter =
+            NSNumberFormatter().apply {
+                numberStyle = NSNumberFormatterCurrencyStyle
+                locale = intro.priceLocale
+            }
+        val introPrice = introFormatter.stringFromNumber(intro.price) ?: basePrice
+        val introPriceMicros = (intro.price.doubleValue * PRICE_TO_MICROS_FACTOR).roundToLong()
+        return introPrice to introPriceMicros
+    }
 
     private fun logProductFetch(message: String) {
         val prefixedMessage = "$LOG_PREFIX $message"

--- a/shared/libs/iap/core/src/iosMain/kotlin/com/yral/shared/iap/core/providers/PurchaseManager.kt
+++ b/shared/libs/iap/core/src/iosMain/kotlin/com/yral/shared/iap/core/providers/PurchaseManager.kt
@@ -205,7 +205,14 @@ internal class PurchaseManager(
         transaction: SKPaymentTransaction,
         productId: String,
     ) {
-        val purchase = convertTransactionToPurchase(transaction, PurchaseState.PURCHASED)
+        // SK1 assigns restored transactions a fresh id; the billing server can only
+        // look up the original purchase/renewal id via the App Store Server API.
+        val originalTransactionId = transaction.originalTransaction?.transactionIdentifier
+        val purchase =
+            convertTransactionToPurchase(transaction, PurchaseState.PURCHASED)
+                .let { converted ->
+                    originalTransactionId?.let { converted.copy(purchaseToken = it) } ?: converted
+                }
         val receipt = getReceiptData()
         val purchaseWithReceipt = purchase.copy(receipt = receipt)
         restoreLock.withLock {

--- a/shared/libs/iap/main/src/androidMain/kotlin/com/yral/shared/iap/utils/ProSubscriptionSupport.android.kt
+++ b/shared/libs/iap/main/src/androidMain/kotlin/com/yral/shared/iap/utils/ProSubscriptionSupport.android.kt
@@ -1,0 +1,3 @@
+package com.yral.shared.iap.utils
+
+actual fun isProSubscriptionSupported(): Boolean = true

--- a/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/utils/ProSubscriptionSupport.kt
+++ b/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/utils/ProSubscriptionSupport.kt
@@ -1,0 +1,7 @@
+package com.yral.shared.iap.utils
+
+/**
+ * Whether the YRAL Pro subscription flow is available on this platform.
+ * iOS has no backend verification endpoint for it yet, so Pro stays off there.
+ */
+expect fun isProSubscriptionSupported(): Boolean

--- a/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/utils/PurchaseContext.kt
+++ b/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/utils/PurchaseContext.kt
@@ -3,6 +3,6 @@ package com.yral.shared.iap.utils
 /**
  * Platform-agnostic interface for purchase context.
  * - Android: Wraps [android.app.Activity] for billing flow
- * - iOS: Not used (returns null)
+ * - iOS: Marker object (StoreKit needs no host context)
  */
 interface PurchaseContext

--- a/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/utils/PurchaseContextHelpers.kt
+++ b/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/utils/PurchaseContextHelpers.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.Composable
 /**
  * Retrieves the platform-specific purchase context.
  * Android: Returns [PurchaseContext] wrapping current [android.app.Activity]
- * iOS: Returns null
+ * iOS: Returns a marker object (StoreKit needs no host context)
  */
 @Composable
 expect fun getPurchaseContext(): PurchaseContext?
@@ -13,6 +13,6 @@ expect fun getPurchaseContext(): PurchaseContext?
 /**
  * Extracts platform-specific context value for core IAP provider.
  * Android: Returns wrapped [android.app.Activity] or null
- * iOS: Returns null
+ * iOS: Returns null (IOSIAPProvider ignores the context)
  */
 expect fun PurchaseContext?.toPlatformContext(): Any?

--- a/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/verification/PurchaseVerificationService.kt
+++ b/shared/libs/iap/main/src/commonMain/kotlin/com/yral/shared/iap/verification/PurchaseVerificationService.kt
@@ -55,6 +55,13 @@ internal class PurchaseVerificationService(
             val purchaseToken =
                 purchase.purchaseToken
                     ?: throw IAPError.VerificationFailed(productId, Exception("Missing purchase token"))
+            val verifierEndpoint = getVerifierEndPoint()
+            if (verifierEndpoint.isBlank()) {
+                throw IAPError.VerificationFailed(
+                    productId,
+                    Exception("Purchase verification is not supported on this platform"),
+                )
+            }
             val request =
                 VerifyPurchaseRequest(
                     userId = userId,
@@ -68,7 +75,7 @@ internal class PurchaseVerificationService(
                     expectSuccess = false
                     url {
                         host = billingBaseUrl
-                        path(getVerifierEndPoint())
+                        path(verifierEndpoint)
                     }
                     setBody(request)
                 }

--- a/shared/libs/iap/main/src/iosMain/kotlin/com/yral/shared/iap/utils/ProSubscriptionSupport.ios.kt
+++ b/shared/libs/iap/main/src/iosMain/kotlin/com/yral/shared/iap/utils/ProSubscriptionSupport.ios.kt
@@ -1,0 +1,3 @@
+package com.yral.shared.iap.utils
+
+actual fun isProSubscriptionSupported(): Boolean = false

--- a/shared/libs/iap/main/src/iosMain/kotlin/com/yral/shared/iap/utils/PurchaseContextHelpers.ios.kt
+++ b/shared/libs/iap/main/src/iosMain/kotlin/com/yral/shared/iap/utils/PurchaseContextHelpers.ios.kt
@@ -2,7 +2,9 @@ package com.yral.shared.iap.utils
 
 import androidx.compose.runtime.Composable
 
+private object IosPurchaseContext : PurchaseContext
+
 @Composable
-actual fun getPurchaseContext(): PurchaseContext? = null
+actual fun getPurchaseContext(): PurchaseContext? = IosPurchaseContext
 
 actual fun PurchaseContext?.toPlatformContext(): Any? = null


### PR DESCRIPTION
- getPurchaseContext now returns a marker on iOS so subscribe taps launch StoreKit (IOSIAPProvider never needed a host context)
- Apple grant requests carry environment=sandbox/production, detected via the app-store receipt name, so sandbox/TestFlight lookups resolve
- ProductFetcher surfaces paid intro offers (free trials keep base price)
- restored SK1 transactions use the original transaction id so grant retries resolve on the App Store Server API
- YRAL Pro stays inert on iOS: verifier fails fast on blank endpoint and RootViewModel gates Pro entry behind isProSubscriptionSupported()


Fixes https://github.com/dolr-ai/yral/issues/1966
Fixes https://github.com/dolr-ai/yral/issues/1351