### PR TITLE
fix: request App Tracking Transparency permission before ad tracking

### DIFF
--- a/iosApp/Prod/Info.plist
+++ b/iosApp/Prod/Info.plist
@@ -65,6 +65,8 @@
 	<string>Yral needs permission to save downloaded videos and photos to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Yral needs access to your photo library so you can choose a profile picture.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Your permission lets Yral measure how well our ads perform and show you more relevant ads. Your data will not be sold.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/iosApp/Staging/Info-Staging.plist
+++ b/iosApp/Staging/Info-Staging.plist
@@ -61,6 +61,8 @@
 	<string>Yral needs access to your photo library so you can choose a profile picture.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>Yral needs permission to save downloaded videos and photos to your photo library.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Your permission lets Yral measure how well our ads perform and show you more relevant ads. Your data will not be sold.</string>
 	<key>ONESIGNAL_APP_ID</key>
 	<string>fe0ef73c-3eef-4c16-baa8-59dc8512895a</string>
 	<key>UIApplicationSceneManifest</key>

--- a/iosApp/iosApp/IosApp.swift
+++ b/iosApp/iosApp/IosApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppTrackingTransparency
 import FirebaseCore
 import FirebaseMessaging
 import FBSDKCoreKit
@@ -80,7 +81,33 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
       didFinishLaunchingWithOptions: launchOptions
     )
     UNUserNotificationCenter.current().delegate = self
+
+    NotificationCenter.default.addObserver(
+      forName: UIApplication.didBecomeActiveNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      self?.requestTrackingAuthorizationIfNeeded()
+    }
     return true
+  }
+
+  private func requestTrackingAuthorizationIfNeeded() {
+    let status = ATTrackingManager.trackingAuthorizationStatus
+    guard status == .notDetermined else {
+      applyTrackingAuthorization(granted: status == .authorized)
+      return
+    }
+    ATTrackingManager.requestTrackingAuthorization { [weak self] newStatus in
+      DispatchQueue.main.async {
+        self?.applyTrackingAuthorization(granted: newStatus == .authorized)
+      }
+    }
+  }
+
+  private func applyTrackingAuthorization(granted: Bool) {
+    Settings.shared.isAdvertiserTrackingEnabled = granted
+    Settings.shared.isAdvertiserIDCollectionEnabled = granted
   }
 
   func application(


### PR DESCRIPTION
App Review rejected 3.4.4 under guideline 5.1.2(i): the privacy label declares tracking but the app never requests permission via ATT.

- request ATTrackingManager authorization when the app becomes active
- gate Facebook SDK advertiser tracking and IDFA collection on the user's response (Branch reads the IDFA only when authorized)
- add NSUserTrackingUsageDescription to prod and staging Info.plists