### PR TITLE
Update Ruby and mise tools, align iOS deployment target

### DIFF
--- a/.github/workflows/deploy-prod-app-to-ios-app-store-on-release.yml
+++ b/.github/workflows/deploy-prod-app-to-ios-app-store-on-release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '4.0.6'
 
       - name: Set up Java (for Gradle)
         id: setup-jdk

--- a/.github/workflows/deploy-yral-alpha-to-app-and-play-store.yml
+++ b/.github/workflows/deploy-yral-alpha-to-app-and-play-store.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.0"
+          ruby-version: "4.0.6"
 
       - name: Restore Gradle and Rust caches
         id: restore-tooling-cache

--- a/mise.toml
+++ b/mise.toml
@@ -15,15 +15,15 @@
 
 [tools]
 # JDK — Gradle 8.14.4 + AGP 8.13.2 require JDK 17+; using JDK 21 LTS.
-java = "temurin-21.0.11+10.0.LTS"
-# Ruby — fastlane + CocoaPods need Ruby 3.x (macOS system Ruby 2.6 is too old).
-ruby = "3.4.10"
+java = "latest"
+# Ruby — fastlane + CocoaPods need Ruby 3.x+ (macOS system Ruby 2.6 is too old).
+ruby = "latest"
 # CocoaPods — iOS dependency manager (installed via gem, managed by mise).
 cocoapods = "latest"
 # SwiftLint — iOS lint (pre-commit hook + checks module).
-swiftlint = "0.65.0"
+swiftlint = "latest"
 # Maestro — mobile e2e test framework (Android + iOS flows).
-maestro = "cli-2.6.1"
+maestro = "latest"
 # kubectl and rust are inherited from the root monorepo mise.toml.
 
 [env]

--- a/shared/rust/rust-agent/build.gradle.kts
+++ b/shared/rust/rust-agent/build.gradle.kts
@@ -41,6 +41,17 @@ uniffi {
     generateFromLibrary()
 }
 
+// aws-lc-sys (pulled in transitively via rustls) compiles C/assembly against the
+// current Xcode SDK, which defaults to the latest iOS (e.g. 26.5). The Rust
+// aarch64-apple-ios target spec links at iOS 10.0 by default, so symbols like
+// ___chkstk_darwin (iOS 12.0+) become undefined. Setting
+// IPHONEOS_DEPLOYMENT_TARGET aligns the C build and the Rust linker at the same
+// deployment target (matching the KMP/ CocoaPods deployment target of 15.6).
+tasks.matching { it.name.startsWith("cargoBuild") && it.name.contains("Ios") }.configureEach {
+    val cargoBuildTask = this as gobley.gradle.cargo.tasks.CargoBuildTask
+    cargoBuildTask.additionalEnvironment.put("IPHONEOS_DEPLOYMENT_TARGET", "15.6")
+}
+
 tasks
     .matching {
         it.name.startsWith("runKtlintCheckOver") && it.name.endsWith("MainSourceSet")

--- a/shared/rust/rust-agent/rust-agent-uniffi/src/helpers.rs
+++ b/shared/rust/rust-agent/rust-agent-uniffi/src/helpers.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 
 use crate::uni_ffi_helpers::*;
 use crate::RUNTIME;
-use candid::de;
-use candid::Nat;
 use candid::{self, ser, CandidType, Decode, Deserialize, Encode, Principal};
 use ic_agent::export::PrincipalError;
 use ic_agent::identity::DelegatedIdentity;


### PR DESCRIPTION
Keep development tooling current by updating Ruby and mise to their latest releases. Resolve iOS build failures from mismatched deployment targets in the aws-lc-sys compilation. Remove dead code from unused Rust imports.