### PR TITLE
feat(routing): persona-chat deep link — ad links open a specific influencer's chat

### DIFF
--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/di/RoutingModule.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/di/RoutingModule.kt
@@ -8,6 +8,7 @@ import com.yral.shared.libs.routing.deeplink.engine.UrlBuilder
 import com.yral.shared.libs.routing.deeplink.engine.buildRoutingTable
 import com.yral.shared.libs.routing.routes.api.AddVideo
 import com.yral.shared.libs.routing.routes.api.Chat
+import com.yral.shared.libs.routing.routes.api.ConversationRoute
 import com.yral.shared.libs.routing.routes.api.GenerateAIVideo
 import com.yral.shared.libs.routing.routes.api.Home
 import com.yral.shared.libs.routing.routes.api.PostDetailsRoute
@@ -34,6 +35,7 @@ val routingModule =
                 route<GenerateAIVideo>(GenerateAIVideo.PATH)
                 route<Profile>(Profile.PATH)
                 route<Chat>(Chat.PATH)
+                route<ConversationRoute>(ConversationRoute.PATH)
                 route<UserProfileRoute>(UserProfileRoute.PATH)
 
                 route<VideoUploadSuccessful>(VideoUploadSuccessful.PATH)

--- a/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/DefaultRootComponent.kt
+++ b/shared/app/src/commonMain/kotlin/com/yral/shared/app/nav/DefaultRootComponent.kt
@@ -23,6 +23,7 @@ import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.instancekeeper.InstanceKeeper
 import com.arkivanov.essenty.instancekeeper.getOrCreate
+import com.yral.featureflag.ChatFeatureFlags
 import com.yral.featureflag.FeatureFlagManager
 import com.yral.shared.analytics.events.BotCreationSource
 import com.yral.shared.analytics.events.SubscriptionEntryPoint
@@ -33,6 +34,7 @@ import com.yral.shared.app.ui.screens.home.nav.HomeComponent
 import com.yral.shared.core.session.ProDetails
 import com.yral.shared.core.session.SessionManager
 import com.yral.shared.data.AlertsRequestType
+import com.yral.shared.data.domain.models.ConversationInfluencerSource
 import com.yral.shared.data.domain.models.OpenConversationParams
 import com.yral.shared.features.auth.ui.LoginCoordinator
 import com.yral.shared.features.auth.ui.LoginInfo
@@ -47,6 +49,7 @@ import com.yral.shared.features.subscriptions.nav.SubscriptionNudgeContent
 import com.yral.shared.koin.koinInstance
 import com.yral.shared.libs.phonevalidation.countries.Country
 import com.yral.shared.libs.routing.routes.api.AppRoute
+import com.yral.shared.libs.routing.routes.api.ConversationRoute
 import com.yral.shared.libs.routing.routes.api.Profile
 import com.yral.shared.libs.routing.routes.api.UserProfileRoute
 import com.yral.shared.rust.service.utils.CanisterData
@@ -370,6 +373,10 @@ class DefaultRootComponent(
                 handleUserProfileRoute(appRoute)
             }
 
+            is ConversationRoute -> {
+                handleConversationRoute(appRoute)
+            }
+
             else -> {
                 homeComponent?.onNavigationRequest(appRoute) ?: run {
                     pendingNavRoute = appRoute
@@ -377,6 +384,22 @@ class DefaultRootComponent(
                 }
             }
         }
+    }
+
+    // Paid-UA landing: an ad link opens one influencer's chat directly. When chat
+    // is off the deep link degrades to Home rather than opening a screen the rest
+    // of the app is hiding.
+    private fun handleConversationRoute(route: ConversationRoute) {
+        if (!featureFlagManager.isEnabled(ChatFeatureFlags.Chat.Enabled)) {
+            navigateToHome()
+            return
+        }
+        openConversation(
+            OpenConversationParams(
+                influencerId = route.influencerId,
+                influencerSource = ConversationInfluencerSource.DEEP_LINK,
+            ),
+        )
     }
 
     private fun handleUserProfileRoute(route: UserProfileRoute) {

--- a/shared/data/src/commonMain/kotlin/com/yral/shared/data/domain/models/OpenConversationParams.kt
+++ b/shared/data/src/commonMain/kotlin/com/yral/shared/data/domain/models/OpenConversationParams.kt
@@ -26,4 +26,5 @@ data class OpenConversationParams(
 enum class ConversationInfluencerSource {
     CARD,
     PROFILE,
+    DEEP_LINK,
 }

--- a/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/analytics/ChatTelemetry.kt
+++ b/shared/features/chat/src/commonMain/kotlin/com/yral/shared/features/chat/analytics/ChatTelemetry.kt
@@ -145,5 +145,6 @@ class ChatTelemetry(
         when (this) {
             ConversationInfluencerSource.CARD -> InfluencerSource.CARD
             ConversationInfluencerSource.PROFILE -> InfluencerSource.PROFILE
+            ConversationInfluencerSource.DEEP_LINK -> InfluencerSource.DEEP_LINK
         }
 }

--- a/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/events/YralEvents.kt
+++ b/shared/libs/analytics/src/commonMain/kotlin/com/yral/shared/analytics/events/YralEvents.kt
@@ -1925,6 +1925,9 @@ enum class InfluencerSource {
 
     @SerialName("profile")
     PROFILE,
+
+    @SerialName("deep_link")
+    DEEP_LINK,
 }
 
 @Serializable

--- a/shared/libs/routing/routes-api/src/commonMain/kotlin/com/yral/shared/libs/routing/routes/api/AppRoute.kt
+++ b/shared/libs/routing/routes-api/src/commonMain/kotlin/com/yral/shared/libs/routing/routes/api/AppRoute.kt
@@ -94,6 +94,16 @@ data class PostDetailsRoute(
 }
 
 @Serializable
+data class ConversationRoute(
+    val influencerId: String,
+) : AppRoute,
+    ExternallyExposedRoute {
+    companion object {
+        const val PATH = "chat/conversation/{influencerId}"
+    }
+}
+
+@Serializable
 data class RewardsReceived(
     val token: String,
     @SerialName("reward_on")


### PR DESCRIPTION
## ⚠️ Do not merge — Rishi is reviewing this himself.

## What this does

Adds one deep-link route so an external URL (a Branch link behind a Facebook ad) opens a **specific** AI influencer's chat, instead of dropping the user on the home feed.

`chat/conversation/{influencerId}` → that persona's conversation.

No SDK work. Branch, the Facebook SDK, Meta Install Referrer, and `openConversation()` all already existed — this wires a URL to them. The Branch link itself (`$deeplink_path=chat/conversation/<id>`) is dashboard-only config, not code.

## Why

Paid UA is gated on this. An ad for a specific character that lands on a generic home feed wastes the click — the user has to go find who they came for. The hypothesis being tested is that landing them directly in her chat lifts first-message rate and D1.

## The change — 6 files, +40 lines, 0 deletions

| File | Change |
|---|---|
| `AppRoute.kt` | `ConversationRoute(influencerId)`, `PATH = "chat/conversation/{influencerId}"` — modelled on `PostDetailsRoute` |
| `RoutingModule.kt` | Register the route |
| `DefaultRootComponent.kt` | `is ConversationRoute ->` branch in `handleAppRoute` → feature-flag gate → `openConversation(...)` |
| `OpenConversationParams.kt` | `ConversationInfluencerSource.DEEP_LINK` |
| `YralEvents.kt` | `InfluencerSource.DEEP_LINK` @ `@SerialName("deep_link")` |
| `ChatTelemetry.kt` | Map the new source (exhaustive `when`, so this is a compile requirement, not a choice) |

`openConversation` lives on `RootComponent` directly, so `DefaultHomeComponent` is untouched. Cold-start / deferred deep links already replay via the existing `pendingNavRoute` drain in `onStackChanged` — no new plumbing.

## Bug caught while building this

Without a gate, a deep link would have **opened chat even with `Chat.Enabled` off**. That flag only hides the bottom-nav tab; `openConversation` pushes onto the root stack and never consulted it. A deep link would have punched through a flag the rest of the app honours. `handleConversationRoute` now checks the flag and falls back to `navigateToHome()`.

## Device-tested on a physical Motorola g96 5G

Staging build, installed side-by-side, fired through the real `parseUrl` → `onNavigationRequest` path:

| Scenario | Result |
|---|---|
| App force-stopped → deep link (fresh-install / deferred path) | ✅ Lands in the target chat |
| App already running on home → deep link (`onNewIntent`) | ✅ Navigates into the target chat |
| Back from a deep-linked chat | ✅ Returns to home, does not exit the app |

Also green: ktlint + detekt on all 5 affected modules, `:androidApp:assembleProdDebug`, `:shared:app:compileKotlinIosSimulatorArm64`.

## Reviewer notes

- **`DEEP_LINK` is additive and backwards-compatible.** `ConversationInfluencerSource` is only serialized into Decompose saved-state (same binary reads it back). `InfluencerSource` goes on the wire as a new value on an existing `source` field.
- **Downstream caveat:** any analytics query filtering `source IN ('card','profile')` rather than grouping by it will silently drop all deep-link traffic. Needs a check before ad spend starts.
- **iOS is compiled but not device-tested.** The path is fully generic (`NotificationHandler.swift` → shared `parseUrl` → `onNavigationRequest`), no Swift changes needed, but it should be run on a real device before App Store submission.
- **No test committed** — it would have roughly doubled the diff. Behaviour was verified against the real parser and on-device instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGQVTD1zTwLETxaHaNQD8F
